### PR TITLE
force graphql-cli to use a newer version of lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "surveyjs-widgets": "latest",
     "sync-exec": "^0.6.2"
   },
+  "resolutions": {
+    "graphql-cli/**/lodash": "^4.17.13"
+  },
   "devDependencies": {
     "@testing-library/react": "^9.1.2",
     "babel-plugin-relay": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6476,15 +6476,10 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@4.17.15, "lodash@>=4 <5", lodash@^4.15.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0:
+lodash@4.17.15, lodash@4.17.5, "lodash@>=4 <5", lodash@^4.15.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-lodash@4.17.5:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
-  integrity sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==
 
 log-symbols@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
resolves:
- [CVE-2019-1010266](https://nvd.nist.gov/vuln/detail/CVE-2019-1010266)
- [CVE-2019-10744](https://nvd.nist.gov/vuln/detail/CVE-2019-10744)
- [CVE-2018-16487](https://nvd.nist.gov/vuln/detail/CVE-2018-16487)