### PR TITLE
sketch of a session implementation

### DIFF
--- a/app/components/Layout/Header.js
+++ b/app/components/Layout/Header.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import {ButtonToolbar, Row, Col, Button} from 'react-bootstrap';
+import {Row, Col, Form, Button} from 'react-bootstrap';
+import {createFragmentContainer, graphql} from 'react-relay';
 import Link from 'next/link';
 
-const Header = props => (
+const HeaderLayout = props => (
   <header>
     <div className="container">
       <div className="banner">
@@ -15,62 +16,52 @@ const Header = props => (
           </Link>
           <h1>CleanBC Industrial Incentive Program</h1>
         </div>
-        {!props.isLoggedIn && (
-          <div className="login-btns header-right">
-            <Row>
-              <Col>
-                <Link
-                  href={{
-                    pathname: '/dummy-login'
-                  }}
-                >
-                  <Button style={{marginRight: '10px'}} variant="outline-light">
-                    Register
-                  </Button>
-                </Link>
-                <Link
-                  href={{
-                    pathname: '/dummy-login'
-                  }}
-                >
-                  <Button variant="outline-light">Login</Button>
-                </Link>
-              </Col>
-            </Row>
-          </div>
-        )}
+        <div className="login-btns header-right">
+          <Row>
+            <Col>
+              {props.session ? (
+                <Form.Row>
+                  <Col>
+                    <Form action="/user-profile" method="get">
+                      <Button type="submit" variant="outline-light">
+                        Profile
+                      </Button>
+                    </Form>
+                  </Col>
+                  <Col>
+                    <Form action="/logout" method="post">
+                      <Button type="submit" variant="outline-light">
+                        Logout
+                      </Button>
+                    </Form>
+                  </Col>
+                </Form.Row>
+              ) : (
+                <Form.Row>
+                  <Col>
+                    <Form
+                      target="_blank"
+                      action="https://www.bceid.ca/register/"
+                      method="get"
+                    >
+                      <Button type="submit" variant="outline-light">
+                        Register
+                      </Button>
+                    </Form>
+                  </Col>
+                  <Col>
+                    <Form action="/login" method="post">
+                      <Button type="submit" variant="outline-light">
+                        Login
+                      </Button>
+                    </Form>
+                  </Col>
+                </Form.Row>
+              )}
+            </Col>
+          </Row>
+        </div>
       </div>
-      {props.isLoggedIn && (
-        <>
-          <div className="buttons">
-            <Row>
-              <Col md={{span: 8}}>
-                <a className="link" href="/user-profile">
-                  <p style={{fontWeight: 'bolder', marginTop: '13px'}}>
-                    {props.userName} <br />
-                    {props.occupation}
-                  </p>
-                </a>
-              </Col>
-              <Col md={{span: 4}}>
-                <ButtonToolbar>
-                  <a
-                    style={{
-                      backgroundColor: '#EDA500',
-                      color: 'white',
-                      marginTop: '18px'
-                    }}
-                    href="/logout"
-                    className="btn"
-                  >
-                    Logout
-                  </a>
-                </ButtonToolbar>
-              </Col>
-            </Row>
-          </div>
-        </>
-      )}
     </div>
     <style jsx>
       {`
@@ -156,4 +147,11 @@ const Header = props => (
   </header>
 );
 
-export default Header;
+export {HeaderLayout};
+export default createFragmentContainer(HeaderLayout, {
+  session: graphql`
+    fragment Header_session on JwtToken {
+      sub
+    }
+  `
+});

--- a/app/containers/Applications/ApplicationListContainer.js
+++ b/app/containers/Applications/ApplicationListContainer.js
@@ -12,7 +12,7 @@ import {
 import DropdownMenuItemComponent from '../../components/DropdownMenuItemComponent';
 import ApplicationRowItemContainer from './ApplicationRowItemContainer';
 
-export const ApplicationListContainer = props => {
+export const ApplicationList = props => {
   const {
     orderByDisplay,
     searchDisplay,
@@ -163,7 +163,7 @@ export const ApplicationListContainer = props => {
 // @see https://facebook.github.io/relay/graphql/objectidentification.htm#sec-Node-Interface
 // TODO: Several entitites do not have graphql ID's because they are views
 export default createRefetchContainer(
-  ApplicationListContainer,
+  ApplicationList,
   {
     query: graphql`
       fragment ApplicationListContainer_query on Query

--- a/app/containers/Applications/ApplicationRowItemContainer.js
+++ b/app/containers/Applications/ApplicationRowItemContainer.js
@@ -3,7 +3,7 @@ import {Button, Badge} from 'react-bootstrap';
 import {graphql, createFragmentContainer} from 'react-relay';
 import Link from 'next/link';
 
-export const ApplicationRowItemContainer = props => {
+export const ApplicationRowItem = props => {
   const {ciipApplication = {}} = props;
   const statusBadgeColor = {
     attention: 'warning',
@@ -45,7 +45,7 @@ export const ApplicationRowItemContainer = props => {
   );
 };
 
-export default createFragmentContainer(ApplicationRowItemContainer, {
+export default createFragmentContainer(ApplicationRowItem, {
   ciipApplication: graphql`
     fragment ApplicationRowItemContainer_ciipApplication on CiipApplication {
       rowId

--- a/app/containers/Applications/ApplicationStatusContainer.js
+++ b/app/containers/Applications/ApplicationStatusContainer.js
@@ -15,7 +15,7 @@ const setStatus = graphql`
   }
 `;
 
-export const ApplicationStatusContainer = props => {
+export const ApplicationStatus = props => {
   const {allApplicationStatuses} = props.query;
   useEffect(() => {
     const refetchVariables = {
@@ -67,7 +67,7 @@ export const ApplicationStatusContainer = props => {
 };
 
 export default createRefetchContainer(
-  ApplicationStatusContainer,
+  ApplicationStatus,
   {
     query: graphql`
       fragment ApplicationStatusContainer_query on Query

--- a/app/containers/Applications/ApplicationStatusItemContainer.js
+++ b/app/containers/Applications/ApplicationStatusItemContainer.js
@@ -3,7 +3,7 @@ import {Container, Row, Col, Dropdown} from 'react-bootstrap';
 import {graphql, createFragmentContainer} from 'react-relay';
 import DropdownMenuItemComponent from '../../components/DropdownMenuItemComponent';
 
-export const ApplicationStatusItemContainer = props => {
+export const ApplicationStatusItem = props => {
   const statusBadgeColor = {
     pending: 'info',
     attention: 'warning',
@@ -45,7 +45,7 @@ export const ApplicationStatusItemContainer = props => {
   );
 };
 
-export default createFragmentContainer(ApplicationStatusItemContainer, {
+export default createFragmentContainer(ApplicationStatusItem, {
   applicationStatus: graphql`
     fragment ApplicationStatusItemContainer_applicationStatus on ApplicationStatus {
       applicationId

--- a/app/containers/Incentives/IncentiveCalculatorContainer.js
+++ b/app/containers/Incentives/IncentiveCalculatorContainer.js
@@ -5,7 +5,7 @@ import IncentiveSegmentFormula from '../../components/Incentives/IncentiveSegmen
 import LoadingSpinner from '../../components/LoadingSpinner';
 import IncentiveSegmentContainer from './IncentiveSegmentContainer';
 
-export const IncentiveCalculatorContainer = props => {
+export const IncentiveCalculator = props => {
   useEffect(() => {
     const refetchVariables = {
       bcghgidInput: Number(props.bcghgid),
@@ -70,7 +70,7 @@ export const IncentiveCalculatorContainer = props => {
 };
 
 export default createRefetchContainer(
-  IncentiveCalculatorContainer,
+  IncentiveCalculator,
   {
     query: graphql`
       fragment IncentiveCalculatorContainer_query on Query

--- a/app/containers/Industry/UserDetailContainer.js
+++ b/app/containers/Industry/UserDetailContainer.js
@@ -156,7 +156,7 @@ export const UserDetail = props => {
 
 export default createFragmentContainer(UserDetail, {
   user: graphql`
-    fragment UserDetail_user on User {
+    fragment UserDetailContainer_user on User {
       rowId
       firstName
       lastName

--- a/app/containers/Products/ProductCreatorContainer.js
+++ b/app/containers/Products/ProductCreatorContainer.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {graphql, createFragmentContainer, commitMutation} from 'react-relay';
 import {Form, Button, Col} from 'react-bootstrap';
 
-export const ProductCreatorContainer = props => {
+export const ProductCreator = props => {
   const createProductFromRef = React.createRef();
   const createProduct = graphql`
     mutation ProductCreatorContainerMutation($input: CreateProductInput!) {
@@ -68,4 +68,4 @@ export const ProductCreatorContainer = props => {
   );
 };
 
-export default createFragmentContainer(ProductCreatorContainer, {});
+export default createFragmentContainer(ProductCreator, {});

--- a/app/containers/Products/ProductListContainer.js
+++ b/app/containers/Products/ProductListContainer.js
@@ -3,7 +3,7 @@ import {graphql, createFragmentContainer} from 'react-relay';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import ProductRowItemContainer from './ProductRowItemContainer';
 
-export const ProductListContainer = props => {
+export const ProductList = props => {
   const {query} = props;
   if (
     query &&
@@ -29,7 +29,7 @@ export const ProductListContainer = props => {
 // we need the first two billion edges to force graphql to return the right type
 // @see https://relay.dev/docs/en/pagination-container#connection
 // https://www.prisma.io/blog/relay-moderns-connection-directive-1ecd8322f5c8
-export default createFragmentContainer(ProductListContainer, {
+export default createFragmentContainer(ProductList, {
   query: graphql`
     fragment ProductListContainer_query on Query {
       active: allProducts(first: 2147483647, condition: {state: "active"})

--- a/app/containers/pageContainers/Admin.js
+++ b/app/containers/pageContainers/Admin.js
@@ -52,6 +52,9 @@ class Admin extends Component {
   static query = graphql`
     query AdminQuery {
       query {
+        session {
+          ...Header_session
+        }
         ...ProductListContainer_query
       }
     }
@@ -61,7 +64,7 @@ class Admin extends Component {
     const {query} = this.props;
     return (
       <>
-        <DefaultLayout title="Products and Benchmarks">
+        <DefaultLayout title="Products and Benchmarks" session={query.session}>
           <Row>
             <Col>
               <br />

--- a/app/containers/pageContainers/ApplicationDetails.js
+++ b/app/containers/pageContainers/ApplicationDetails.js
@@ -17,6 +17,9 @@ class ApplicationDetails extends Component {
       $reportingYear: String
     ) {
       query {
+        session {
+          ...Header_session
+        }
         ...ApplicationStatusContainer_query
           @arguments(condition: $applicationStatusCondition)
         ...IncentiveCalculatorContainer_query
@@ -41,8 +44,9 @@ class ApplicationDetails extends Component {
 
   render() {
     const {query} = this.props;
+    const {session} = query || {};
     return (
-      <DefaultLayout>
+      <DefaultLayout session={session}>
         <ApplicationStatusContainer
           query={query}
           applicationId={this.props.router.query.applicationId}

--- a/app/containers/pageContainers/Applications.js
+++ b/app/containers/pageContainers/Applications.js
@@ -24,6 +24,9 @@ class Applications extends Component {
       $searchValue: String
     ) {
       query {
+        session {
+          ...Header_session
+        }
         ...ApplicationListContainer_query
           @arguments(
             orderByField: $orderByField
@@ -92,7 +95,7 @@ class Applications extends Component {
     const {query} = this.props;
     return (
       <>
-        <DefaultLayout title="Applications">
+        <DefaultLayout title="Applications" session={query.session}>
           <ApplicationListContainer
             query={query}
             orderByDisplay={this.state.orderByDisplay}

--- a/app/containers/pageContainers/CiipApplication.js
+++ b/app/containers/pageContainers/CiipApplication.js
@@ -14,6 +14,9 @@ class CiipApplication extends Component {
   static query = graphql`
     query CiipApplicationQuery($formResultId: ID!, $applicationId: ID!) {
       query {
+        session {
+          ...Header_session
+        }
         ...ApplicationWizard_query
           @arguments(formResultId: $formResultId, applicationId: $applicationId)
       }
@@ -22,8 +25,9 @@ class CiipApplication extends Component {
 
   render() {
     const {query} = this.props;
+    const {session} = query || {};
     return (
-      <DefaultLayout>
+      <DefaultLayout session={session}>
         <ApplicationWizard query={query} />
       </DefaultLayout>
     );

--- a/app/containers/pageContainers/Index.js
+++ b/app/containers/pageContainers/Index.js
@@ -1,12 +1,25 @@
 import React, {Component} from 'react';
 import {Button, Row, Col, Card, Jumbotron, Table} from 'react-bootstrap';
 import Link from 'next/link';
+import {graphql} from 'react-relay';
 import DefaultLayout from '../../layouts/default-layout';
 
 export default class Index extends Component {
+  static query = graphql`
+    query IndexQuery {
+      query {
+        session {
+          ...Header_session
+        }
+      }
+    }
+  `;
+
   render() {
+    const {query} = this.props;
+    const {session} = query || {};
     return (
-      <DefaultLayout showSubheader={false} isLoggedIn={false}>
+      <DefaultLayout showSubheader={false} session={session}>
         <Row style={{marginTop: '60px'}}>
           <Col md={6}>
             <h3 className="blue">

--- a/app/containers/pageContainers/UserDashboard.js
+++ b/app/containers/pageContainers/UserDashboard.js
@@ -10,6 +10,9 @@ export default class UserDashBoard extends Component {
     query UserDashboardQuery($id: ID!) {
       query {
         ...Organisations_query @arguments(id: $id)
+        session {
+          ...Header_session
+        }
       }
     }
   `;
@@ -52,12 +55,14 @@ export default class UserDashBoard extends Component {
   };
 
   render() {
+    const {query} = this.props;
+    const {session} = query || {};
     return (
-      <DefaultLayout showSubheader title="My Operators">
+      <DefaultLayout showSubheader session={session} title="My Operators">
         <Row>
           <Col md={{span: 8}}>
             <Organisations
-              query={this.props.query}
+              query={query}
               userId={this.props.router.query.id}
               orgInput={this.state.orgInput}
               selectedOrg={this.state.selectedOrg}

--- a/app/containers/pageContainers/UserOrganisationFacilities.js
+++ b/app/containers/pageContainers/UserOrganisationFacilities.js
@@ -8,6 +8,9 @@ export default class UserOrganisationFacilities extends Component {
     query UserOrganisationFacilitiesQuery($organisationId: ID!) {
       query {
         ...OrganisationFacilities_query @arguments(id: $organisationId)
+        session {
+          ...Header_session
+        }
         organisation(id: $organisationId) {
           operatorName
         }
@@ -16,10 +19,10 @@ export default class UserOrganisationFacilities extends Component {
   `;
 
   render() {
-    const {organisation} = this.props.query;
+    const {organisation, session} = this.props.query;
     const orgTitle = `Facilities for ${organisation.operatorName} `;
     return (
-      <DefaultLayout showSubheader title={orgTitle}>
+      <DefaultLayout showSubheader session={session} title={orgTitle}>
         <OrganisationFacilities query={this.props.query} />
       </DefaultLayout>
     );

--- a/app/containers/pageContainers/UserProfile.js
+++ b/app/containers/pageContainers/UserProfile.js
@@ -1,25 +1,30 @@
 import React, {Component} from 'react';
 import {graphql} from 'react-relay';
 import DefaultLayout from '../../layouts/default-layout';
-import UserDetail from '../Industry/UserDetail';
+import UserDetailContainer from '../Industry/UserDetailContainer';
 
 class UserProfile extends Component {
   static query = graphql`
     query UserProfileQuery {
       query {
-        user(id: "WyJ1c2VycyIsMV0=") {
-          ...UserDetail_user
+        session {
+          ...Header_session
+          userBySub {
+            ...UserDetailContainer_user
+          }
         }
       }
     }
   `;
 
   render() {
-    const {user} = this.props.query;
+    const {session} = this.props.query;
+    if (!session) return 'No session exists, the user should go sign in.';
+    if (!session.userBySub) return 'A session exists but not a user!';
     return (
       <>
-        <DefaultLayout>
-          <UserDetail user={user} />
+        <DefaultLayout session={session}>
+          <UserDetailContainer user={session.userBySub} />
         </DefaultLayout>
       </>
     );

--- a/app/layouts/default-layout.js
+++ b/app/layouts/default-layout.js
@@ -6,10 +6,10 @@ import Subheader from '../components/Layout/Subheader';
 
 class DefaultLayout extends Component {
   render() {
-    const {children, title, showSubheader, isLoggedIn} = this.props;
+    const {children, title, showSubheader, session} = this.props;
     return (
       <div className="page-wrap">
-        <Header isLoggedOut={isLoggedIn} />
+        <Header session={session} />
         {showSubheader && <Subheader />}
         {title ? (
           <div className="page-title">

--- a/app/package.json
+++ b/app/package.json
@@ -12,11 +12,15 @@
     "build:relay": "relay-compiler --src ./ --exclude '**/.next/**' '**/node_modules/**' '**/test/**'  '**/__generated__/**' '**/server/**' --schema ./server/schema.graphql --verbose",
     "build:next": "next build",
     "start": "NODE_ENV=production node server",
-    "format": "xo --fix --ignore './static/survey-creator.css' './static/bootstrap.min.css'",
+    "format": "xo --fix",
     "lint": "xo",
     "storybook": "start-storybook"
   },
   "xo": {
+    "ignores": [
+      "./static/survey-creator.css",
+      "./static/bootstrap.min.css"
+    ],
     "extends": [
       "xo-react",
       "plugin:jest/recommended",

--- a/app/server/index.js
+++ b/app/server/index.js
@@ -64,20 +64,23 @@ app.prepare().then(() => {
       classicIds: true,
       pgSettings(req) {
         const claims = {};
-        if ((((req.kauth || {}).grant || {}).id_token || {}).content) {
-          // TODO: actually map jwt realms to postgres roles
-          // @see https://www.postgresql.org/docs/current/default-roles.html
-          // claims['role'] = 'pg_monitor';
-          const token = req.kauth.grant.id_token.content;
-          for (const property in token) {
-            claims[`jwt.claims.${property}`] = token[property];
-          }
+        if (
+          !req.kauth ||
+          !req.kauth.grant ||
+          !req.kauth.grant.id_token ||
+          !req.kauth.grant.id_token.content
+        )
+          return claims;
+
+        // TODO: actually map jwt realms to postgres roles
+        // @see https://www.postgresql.org/docs/current/default-roles.html
+        // claims['role'] = 'pg_monitor';
+        const token = req.kauth.grant.id_token.content;
+        for (const property in token) {
+          claims[`jwt.claims.${property}`] = token[property];
         }
 
-        console.dir(claims);
-        return {
-          ...claims
-        };
+        return claims;
       }
     })
   );

--- a/app/server/index.js
+++ b/app/server/index.js
@@ -1,4 +1,4 @@
-const path = require('path');
+// Const path = require('path');
 const express = require('express');
 const {postgraphile} = require('postgraphile');
 const next = require('next');
@@ -8,7 +8,7 @@ const port = parseInt(process.env.PORT, 10) || 3004;
 const dev = process.env.NODE_ENV !== 'production';
 const app = next({dev});
 const handle = app.getRequestHandler();
-const schemaPath = path.join(__dirname, '/schema.graphql');
+// Const schemaPath = path.join(__dirname, '/schema.graphql');
 const session = require('express-session');
 const bodyParser = require('body-parser');
 const Keycloak = require('keycloak-connect');
@@ -76,16 +76,40 @@ app.prepare().then(() => {
         // @see https://www.postgresql.org/docs/current/default-roles.html
         // claims['role'] = 'pg_monitor';
         const token = req.kauth.grant.id_token.content;
-        for (const property in token) {
+        const properties = [
+          'jti',
+          'exp',
+          'nbf',
+          'iat',
+          'iss',
+          'aud',
+          'sub',
+          'typ',
+          'azp',
+          'auth_time',
+          'session_state',
+          'acr',
+          'email_verified',
+          'name',
+          'preferred_username',
+          'given_name',
+          'family_name',
+          'email'
+        ];
+        properties.forEach(property => {
           claims[`jwt.claims.${property}`] = token[property];
-        }
+        });
 
         return claims;
       }
     })
   );
 
-  server.get('/form-builder', keycloak.protect());
+  server.post('/login', keycloak.protect(), (req, res) =>
+    res.redirect(302, '/user-dashboard')
+  );
+  // Keycloak callbak; do not keycloak.protect() to avoid users being authenticated against their will via XSS attack
+  server.get('/login', (req, res) => res.redirect(302, '/user-dashboard'));
 
   server.get('*', (req, res) => {
     return handle(req, res);

--- a/app/server/schema.graphql
+++ b/app/server/schema.graphql
@@ -3838,6 +3838,30 @@ A JavaScript object encoded in the JSON format as specified by [ECMA-404](http:/
 """
 scalar JSON
 
+type JwtToken {
+  acr: String
+  aud: String
+  authTime: Int
+  azp: String
+  email: String
+  emailVerified: Boolean
+  exp: Int
+  familyName: String
+  givenName: String
+  iat: Int
+  iss: String
+  jti: UUID
+  name: String
+  nbf: Int
+  preferredUsername: String
+  sessionState: UUID
+  sub: UUID
+  typ: String
+
+  """Reads a single `User` that is related to this `JwtToken`."""
+  userBySub: User
+}
+
 """
 The root mutation type which contains root level fields which mutate data.
 """
@@ -5885,6 +5909,7 @@ type Query implements Node {
     searchField: String
     searchValue: String
   ): CiipApplicationsConnection!
+  session: JwtToken
 
   """Reads a single `User` using its globally unique `ID`."""
   user(

--- a/app/server/schema.json
+++ b/app/server/schema.json
@@ -3578,6 +3578,18 @@
               "deprecationReason": null
             },
             {
+              "name": "session",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "JwtToken",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "user",
               "description": "Reads a single `User` using its globally unique `ID`.",
               "args": [
@@ -17182,6 +17194,245 @@
             {
               "name": "node",
               "description": "The `User` at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "JwtToken",
+          "description": "",
+          "fields": [
+            {
+              "name": "acr",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "aud",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "authTime",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "azp",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "email",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "emailVerified",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "exp",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "familyName",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "givenName",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iat",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iss",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jti",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "UUID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nbf",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "preferredUsername",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sessionState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "UUID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sub",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "UUID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "typ",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userBySub",
+              "description": "Reads a single `User` that is related to this `JwtToken`.",
               "args": [],
               "type": {
                 "kind": "OBJECT",

--- a/app/tests/components/Layout/Header.test.js
+++ b/app/tests/components/Layout/Header.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import {render} from 'enzyme';
-import Header from '../../../components/Layout/Header';
+import {shallow} from 'enzyme';
+import {HeaderLayout} from '../../../components/Layout/Header';
 
 // It renders the Header
 
 it('It matches the last accepted Snapshot', () => {
-  const wrapper = render(<Header />);
+  const wrapper = shallow(<HeaderLayout />);
   expect(wrapper).toMatchSnapshot();
 });

--- a/app/tests/components/Layout/__snapshots__/Header.test.js.snap
+++ b/app/tests/components/Layout/__snapshots__/Header.test.js.snap
@@ -2,54 +2,83 @@
 
 exports[`It matches the last accepted Snapshot 1`] = `
 <header
-  class="jsx-2807878339"
+  className="jsx-2807878339"
 >
   <div
-    class="jsx-2807878339 container"
+    className="jsx-2807878339 container"
   >
     <div
-      class="jsx-2807878339 banner"
+      className="jsx-2807878339 banner"
     >
       <div
-        class="jsx-2807878339 header-left"
+        className="jsx-2807878339 header-left"
       >
-        <img
-          alt="Go to the Government of British Columbia website"
-          class="jsx-2807878339"
-          src="/static/logo-banner.png"
-        />
+        <Link
+          href="/"
+        >
+          <img
+            alt="Go to the Government of British Columbia website"
+            className="jsx-2807878339"
+            src="/static/logo-banner.png"
+          />
+        </Link>
         <h1
-          class="jsx-2807878339"
+          className="jsx-2807878339"
         >
           CleanBC Industrial Incentive Program
         </h1>
       </div>
       <div
-        class="jsx-2807878339 login-btns header-right"
+        className="jsx-2807878339 login-btns header-right"
       >
-        <div
-          class="row"
+        <ForwardRef
+          noGutters={false}
         >
-          <div
-            class="col"
-          >
-            <button
-              class="btn btn-outline-light"
-              style="margin-right:10px"
-              type="button"
-            >
-              Register
-            </button>
-            <button
-              class="btn btn-outline-light"
-              type="button"
-            >
-              Login
-            </button>
-          </div>
-        </div>
+          <Col>
+            <FormRow>
+              <Col>
+                <Form
+                  action="https://www.bceid.ca/register/"
+                  inline={false}
+                  method="get"
+                  target="_blank"
+                >
+                  <Button
+                    active={false}
+                    disabled={false}
+                    type="submit"
+                    variant="outline-light"
+                  >
+                    Register
+                  </Button>
+                </Form>
+              </Col>
+              <Col>
+                <Form
+                  action="/login"
+                  inline={false}
+                  method="post"
+                >
+                  <Button
+                    active={false}
+                    disabled={false}
+                    type="submit"
+                    variant="outline-light"
+                  >
+                    Login
+                  </Button>
+                </Form>
+              </Col>
+            </FormRow>
+          </Col>
+        </ForwardRef>
       </div>
     </div>
   </div>
+  <JSXStyle
+    id="2807878339"
+  >
+    header.jsx-2807878339{background-color:#036;border-bottom:2px solid #fcba19;padding:10px 65px;color:#fff;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;height:65px;top:0px;width:100%;}header.jsx-2807878339 h1.jsx-2807878339{font-weight:normal;margin:8px 5px 5px 18px;visibility:hidden;}.header-left.jsx-2807878339{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}.header-right.jsx-2807878339{margin-right:-25px;}header.jsx-2807878339 .banner.jsx-2807878339{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-pack:justify;-webkit-justify-content:space-between;-ms-flex-pack:justify;justify-content:space-between;-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;margin:0 10px 0 0;}header.jsx-2807878339 .other.jsx-2807878339{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-flex:1;-webkit-flex-grow:1;-ms-flex-positive:1;flex-grow:1;}.buttons.jsx-2807878339{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-flex:1;-webkit-flex-grow:1;-ms-flex-positive:1;flex-grow:1;-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;-webkit-box-pack:end;-webkit-justify-content:flex-end;-ms-flex-pack:end;justify-content:flex-end;}.btn.jsx-2807878339{font-weight:bolder;}.link.jsx-2807878339{color:white;-webkit-text-decoration:none;text-decoration:none;}a.jsx-2807878339:link,a.jsx-2807878339:visited{color:white;}a.jsx-2807878339:hover,a.jsx-2807878339:active{color:white;}@media screen and (min-width:600px) and (max-width:899px){header.jsx-2807878339 h1.jsx-2807878339{font-size:calc(7px + 2.2vw);visibility:visible;}}@media screen and (min-width:900px){header.jsx-2807878339 h1.jsx-2807878339{font-size:1.4em;visibility:visible;}}
+  </JSXStyle>
 </header>
 `;

--- a/app/tests/containers/Applications/__snapshots__/applicationListContainer.test.js.snap
+++ b/app/tests/containers/Applications/__snapshots__/applicationListContainer.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ApplicationListContainer should render the application list 1`] = `
+exports[`ApplicationList should render the application list 1`] = `
 <Fragment>
   <Container
     fluid={false}
@@ -281,7 +281,7 @@ exports[`ApplicationListContainer should render the application list 1`] = `
         </tr>
       </thead>
       <tbody>
-        <Relay(ApplicationRowItemContainer)
+        <Relay(ApplicationRowItem)
           ciipApplication={
             Object {
               "id": "ciip-application-1",

--- a/app/tests/containers/Applications/__snapshots__/applicationRowItemContainer.test.js.snap
+++ b/app/tests/containers/Applications/__snapshots__/applicationRowItemContainer.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ApplicationRowItemContainer should render the application 1`] = `
+exports[`ApplicationRowItem should render the application 1`] = `
 <tr>
   <td />
   <td>

--- a/app/tests/containers/Applications/__snapshots__/applicationStatusContainer.test.js.snap
+++ b/app/tests/containers/Applications/__snapshots__/applicationStatusContainer.test.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ApplicationStatusContainer should render empty edges as empty 1`] = `""`;
+exports[`ApplicationStatus should render empty edges as empty 1`] = `""`;
 
-exports[`ApplicationStatusContainer should render extra edges as empty 1`] = `""`;
+exports[`ApplicationStatus should render extra edges as empty 1`] = `""`;
 
-exports[`ApplicationStatusContainer should render the application status 1`] = `
-<Relay(ApplicationStatusItemContainer)
+exports[`ApplicationStatus should render the application status 1`] = `
+<Relay(ApplicationStatusItem)
   applicationStatus={
     Object {
       "id": "1",

--- a/app/tests/containers/Applications/__snapshots__/applicationStatusItemContainer.test.js.snap
+++ b/app/tests/containers/Applications/__snapshots__/applicationStatusItemContainer.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ApplicationStatusItemContainer should render the application status 1`] = `
+exports[`ApplicationStatusItem should render the application status 1`] = `
 <Fragment>
   <Container
     fluid={false}

--- a/app/tests/containers/Applications/applicationListContainer.test.js
+++ b/app/tests/containers/Applications/applicationListContainer.test.js
@@ -1,18 +1,18 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {ApplicationListContainer} from '../../../containers/Applications/ApplicationListContainer';
+import {ApplicationList} from '../../../containers/Applications/ApplicationListContainer';
 
-describe('ApplicationListContainer', () => {
+describe('ApplicationList', () => {
   it('should render the application list', async () => {
     const query = {
       searchApplicationList: {
         edges: [{node: {id: 'ciip-application-1'}}]
       }
     };
-    const r = shallow(<ApplicationListContainer query={query} />);
+    const r = shallow(<ApplicationList query={query} />);
     expect(r).toMatchSnapshot();
-    expect(
-      r.find('Relay(ApplicationRowItemContainer)').prop('ciipApplication')
-    ).toBe(query.searchApplicationList.edges[0].node);
+    expect(r.find('Relay(ApplicationRowItem)').prop('ciipApplication')).toBe(
+      query.searchApplicationList.edges[0].node
+    );
   });
 });

--- a/app/tests/containers/Applications/applicationRowItemContainer.test.js
+++ b/app/tests/containers/Applications/applicationRowItemContainer.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {ApplicationRowItemContainer} from '../../../containers/Applications/ApplicationRowItemContainer';
+import {ApplicationRowItem} from '../../../containers/Applications/ApplicationRowItemContainer';
 
-describe('ApplicationRowItemContainer', () => {
+describe('ApplicationRowItem', () => {
   it('should render the application', () => {
     const ciipApplication = {
       applicationId: '9',
@@ -12,7 +12,7 @@ describe('ApplicationRowItemContainer', () => {
       submissionDate: 'Sun, 17 Dec 1995 03:24:00 GMT'
     };
     const render = shallow(
-      <ApplicationRowItemContainer ciipApplication={ciipApplication} />
+      <ApplicationRowItem ciipApplication={ciipApplication} />
     );
     expect(render).toMatchSnapshot();
   });

--- a/app/tests/containers/Applications/applicationStatusContainer.test.js
+++ b/app/tests/containers/Applications/applicationStatusContainer.test.js
@@ -1,18 +1,18 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {ApplicationStatusContainer} from '../../../containers/Applications/ApplicationStatusContainer';
+import {ApplicationStatus} from '../../../containers/Applications/ApplicationStatusContainer';
 
-describe('ApplicationStatusContainer', () => {
+describe('ApplicationStatus', () => {
   it('should render the application status', async () => {
     const query = {
       allApplicationStatuses: {
         edges: [{node: {id: '1'}}]
       }
     };
-    const r = shallow(<ApplicationStatusContainer query={query} />);
+    const r = shallow(<ApplicationStatus query={query} />);
     expect(r).toMatchSnapshot();
     expect(
-      r.find('Relay(ApplicationStatusItemContainer)').prop('applicationStatus')
+      r.find('Relay(ApplicationStatusItem)').prop('applicationStatus')
     ).toBe(query.allApplicationStatuses.edges[0].node);
   });
 
@@ -22,7 +22,7 @@ describe('ApplicationStatusContainer', () => {
         edges: []
       }
     };
-    const r = shallow(<ApplicationStatusContainer query={query} />);
+    const r = shallow(<ApplicationStatus query={query} />);
     expect(r).toMatchSnapshot();
     expect(r.isEmptyRender()).toBe(true);
   });
@@ -33,7 +33,7 @@ describe('ApplicationStatusContainer', () => {
         edges: [{node: {id: '1'}}, {node: {id: '1'}}]
       }
     };
-    const r = shallow(<ApplicationStatusContainer query={query} />);
+    const r = shallow(<ApplicationStatus query={query} />);
     expect(r).toMatchSnapshot();
     expect(r.isEmptyRender()).toBe(true);
   });

--- a/app/tests/containers/Applications/applicationStatusItemContainer.test.js
+++ b/app/tests/containers/Applications/applicationStatusItemContainer.test.js
@@ -1,15 +1,15 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {ApplicationStatusItemContainer} from '../../../containers/Applications/ApplicationStatusItemContainer';
+import {ApplicationStatusItem} from '../../../containers/Applications/ApplicationStatusItemContainer';
 
-describe('ApplicationStatusItemContainer', () => {
+describe('ApplicationStatusItem', () => {
   it('should render the application status', async () => {
     const applicationStatus = {
       applicationId: '123',
       applicationStatus: 'pending'
     };
     const r = shallow(
-      <ApplicationStatusItemContainer
+      <ApplicationStatusItem
         applicationStatus={applicationStatus}
         setApplicationStatus={jest.fn()}
       />

--- a/app/tests/containers/Incentives/IncentiveCalculatorContainer.test.js
+++ b/app/tests/containers/Incentives/IncentiveCalculatorContainer.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {IncentiveCalculatorContainer} from '../../../containers/Incentives/IncentiveCalculatorContainer';
+import {IncentiveCalculator} from '../../../containers/Incentives/IncentiveCalculatorContainer';
 
-describe('IncentiveCalculatorContainer', () => {
+describe('IncentiveCalculator', () => {
   it('should render the page', async () => {
     const r = shallow(
-      <IncentiveCalculatorContainer
+      <IncentiveCalculator
         query={{
           allProducts: {edges: []},
           bcghgidProducts: {edges: []},
@@ -24,7 +24,7 @@ describe('IncentiveCalculatorContainer', () => {
       },
       carbonTax: []
     };
-    const r = shallow(<IncentiveCalculatorContainer query={query} />);
+    const r = shallow(<IncentiveCalculator query={query} />);
     expect(
       r
         .find('Relay(IncentiveSegmentContainer)')

--- a/app/tests/containers/Incentives/__snapshots__/IncentiveCalculatorContainer.test.js.snap
+++ b/app/tests/containers/Incentives/__snapshots__/IncentiveCalculatorContainer.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IncentiveCalculatorContainer should render the page 1`] = `
+exports[`IncentiveCalculator should render the page 1`] = `
 <Fragment>
   <Jumbotron
     fluid={false}

--- a/app/tests/containers/Industry/UserDetail.test.js
+++ b/app/tests/containers/Industry/UserDetail.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {UserDetail} from '../../../containers/Industry/UserDetail';
+import {UserDetail} from '../../../containers/Industry/UserDetailContainer';
 const user = {
   id: 'WyJ1c2VycyIsMV0=',
   rowId: 1,

--- a/app/tests/containers/Products/__snapshots__/productCreator.test.js.snap
+++ b/app/tests/containers/Products/__snapshots__/productCreator.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ProductCreatorContainer render() should match the last usable snapshot 1`] = `
+exports[`ProductCreator render() should match the last usable snapshot 1`] = `
 <Fragment>
   <div>
     <Form

--- a/app/tests/containers/Products/__snapshots__/productListContainer.test.js.snap
+++ b/app/tests/containers/Products/__snapshots__/productListContainer.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ProductListContainer should render the product list 1`] = `
+exports[`ProductList should render the product list 1`] = `
 Array [
   <Relay(ProductRowItemComponent)
     key="product-1"

--- a/app/tests/containers/Products/__snapshots__/productRowItemContainer.test.js.snap
+++ b/app/tests/containers/Products/__snapshots__/productRowItemContainer.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ProductRowItemContainer with active product should render the product row item 1`] = `
+exports[`ProductRowItem with active product should render the product row item 1`] = `
 <Fragment>
   <div
     className="jsx-3284210077 "
@@ -565,7 +565,7 @@ exports[`ProductRowItemContainer with active product should render the product r
 </Fragment>
 `;
 
-exports[`ProductRowItemContainer with archived product should render the product row item 1`] = `
+exports[`ProductRowItem with archived product should render the product row item 1`] = `
 <Fragment>
   <div
     className="jsx-3284210077 "
@@ -1200,7 +1200,7 @@ exports[`ProductRowItemContainer with archived product should render the product
 </Fragment>
 `;
 
-exports[`ProductRowItemContainer with mode set to benchmark should render the product row item with the benchmark class 1`] = `
+exports[`ProductRowItem with mode set to benchmark should render the product row item with the benchmark class 1`] = `
 <Fragment>
   <div
     className="jsx-3284210077 benchmark"
@@ -1835,7 +1835,7 @@ exports[`ProductRowItemContainer with mode set to benchmark should render the pr
 </Fragment>
 `;
 
-exports[`ProductRowItemContainer with mode set to product should render the product row item with the product class 1`] = `
+exports[`ProductRowItem with mode set to product should render the product row item with the product class 1`] = `
 <Fragment>
   <div
     className="jsx-3284210077 product"
@@ -2470,7 +2470,7 @@ exports[`ProductRowItemContainer with mode set to product should render the prod
 </Fragment>
 `;
 
-exports[`ProductRowItemContainer with mode set to view should render the product row item with the view class 1`] = `
+exports[`ProductRowItem with mode set to view should render the product row item with the view class 1`] = `
 <Fragment>
   <div
     className="jsx-3284210077 view"

--- a/app/tests/containers/Products/productCreator.test.js
+++ b/app/tests/containers/Products/productCreator.test.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {ProductCreatorContainer} from '../../../containers/Products/ProductCreatorContainer';
+import {ProductCreator} from '../../../containers/Products/ProductCreatorContainer';
 
-describe('ProductCreatorContainer', () => {
+describe('ProductCreator', () => {
   describe('render()', () => {
     let render;
 
     beforeAll(() => {
-      render = shallow(<ProductCreatorContainer />);
+      render = shallow(<ProductCreator />);
     });
 
     it('should match the last usable snapshot', async () => {

--- a/app/tests/containers/Products/productListContainer.test.js
+++ b/app/tests/containers/Products/productListContainer.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {ProductListContainer} from '../../../containers/Products/ProductListContainer';
+import {ProductList} from '../../../containers/Products/ProductListContainer';
 
-describe('ProductListContainer', () => {
+describe('ProductList', () => {
   it('should render the product list', async () => {
     const query = {
       active: {
@@ -12,7 +12,7 @@ describe('ProductListContainer', () => {
         edges: [{node: {id: 'product-2'}}]
       }
     };
-    const r = shallow(<ProductListContainer query={query} />);
+    const r = shallow(<ProductList query={query} />);
     expect(r).toMatchSnapshot();
     expect(
       r

--- a/app/tests/containers/Products/productRowItemContainer.test.js
+++ b/app/tests/containers/Products/productRowItemContainer.test.js
@@ -37,7 +37,7 @@ const productRowActions = {
 };
 
 let render;
-describe('ProductRowItemContainer', () => {
+describe('ProductRowItem', () => {
   describe('with active product', () => {
     beforeAll(() => {
       render = shallow(

--- a/app/tests/layout/Default-layout.test.js
+++ b/app/tests/layout/Default-layout.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import {render} from 'enzyme';
+import {shallow} from 'enzyme';
 import DefaultLayout from '../../layouts/default-layout';
 
 // It renders the Default Layout
 
 it('It matches the last accepted Snapshot', () => {
-  const wrapper = render(<DefaultLayout />);
+  const wrapper = shallow(<DefaultLayout />);
   expect(wrapper).toMatchSnapshot();
 });

--- a/app/tests/layout/__snapshots__/Default-layout.test.js.snap
+++ b/app/tests/layout/__snapshots__/Default-layout.test.js.snap
@@ -2,93 +2,18 @@
 
 exports[`It matches the last accepted Snapshot 1`] = `
 <div
-  class="jsx-1958721952 page-wrap"
+  className="jsx-1958721952 page-wrap"
 >
-  <header
-    class="jsx-2807878339"
-  >
-    <div
-      class="jsx-2807878339 container"
-    >
-      <div
-        class="jsx-2807878339 banner"
-      >
-        <div
-          class="jsx-2807878339 header-left"
-        >
-          <img
-            alt="Go to the Government of British Columbia website"
-            class="jsx-2807878339"
-            src="/static/logo-banner.png"
-          />
-          <h1
-            class="jsx-2807878339"
-          >
-            CleanBC Industrial Incentive Program
-          </h1>
-        </div>
-        <div
-          class="jsx-2807878339 login-btns header-right"
-        >
-          <div
-            class="row"
-          >
-            <div
-              class="col"
-            >
-              <button
-                class="btn btn-outline-light"
-                style="margin-right:10px"
-                type="button"
-              >
-                Register
-              </button>
-              <button
-                class="btn btn-outline-light"
-                type="button"
-              >
-                Login
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </header>
-  <div
-    class="content container"
+  <Relay(HeaderLayout) />
+  <Container
+    className="content"
+    fluid={false}
   />
-  <footer
-    class="jsx-2746091499 footer"
+  <Footer />
+  <JSXStyle
+    id="1958721952"
   >
-    <div
-      class="jsx-2746091499 container"
-    >
-      <ul
-        class="jsx-2746091499"
-      >
-        <li
-          class="jsx-2746091499"
-        >
-          <a
-            class="jsx-2746091499"
-            href="."
-          >
-            Home
-          </a>
-        </li>
-        <li
-          class="jsx-2746091499"
-        >
-          <a
-            class="jsx-2746091499"
-            href="."
-          >
-            Contact Us
-          </a>
-        </li>
-      </ul>
-    </div>
-  </footer>
+    html,body,#__next,.page-wrap{height:100%;}.page-wrap{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;}.content{padding-top:50px;-webkit-flex:1 0 auto;-ms-flex:1 0 auto;flex:1 0 auto;}.footer{-webkit-flex-shrink:0;-ms-flex-negative:0;flex-shrink:0;}h1{font-size:30px;}.page-title{background:#f5f5f5;border-bottom:1px solid #ccc;padding:40px 0 20px;}.page-title h1{font-size:25px;font-weight:400;}h3{margin-bottom:20px;font-weight:500;}.blue{color:#036;}p{line-height:25px;}.ciip-card{border:1px solid #036;padding:15px;border-radius:0;box-shadow:1px 8px 13px -5px #00336694;}button.full-width{width:100%;}.btn-primary{background:#036;border-color:#036;}.with-shadow{box-shadow:1px 8px 13px -5px #00336694;}.accordion button{text-align:left;padding-left:0;color:#1a5a96;}.accordion .card-body{font-size:15px;}
+  </JSXStyle>
 </div>
 `;

--- a/app/tests/pages/__snapshots__/application-details.test.js.snap
+++ b/app/tests/pages/__snapshots__/application-details.test.js.snap
@@ -2,11 +2,11 @@
 
 exports[`It matches the last accepted Snapshot 1`] = `
 <DefaultLayout>
-  <Relay(ApplicationStatusContainer)
+  <Relay(ApplicationStatus)
     applicationId="1"
   />
   <hr />
-  <Relay(IncentiveCalculatorContainer)
+  <Relay(IncentiveCalculator)
     bcghgid="100"
     reportingYear="2018"
   />

--- a/app/tests/pages/__snapshots__/index.test.js.snap
+++ b/app/tests/pages/__snapshots__/index.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`landing It matches the last accepted Snapshot 1`] = `
 <DefaultLayout
-  isLoggedIn={false}
   showSubheader={false}
 >
   <ForwardRef

--- a/app/tests/pages/__snapshots__/user-profile.test.js.snap
+++ b/app/tests/pages/__snapshots__/user-profile.test.js.snap
@@ -1,15 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`user profile matches snapshot 1`] = `
-<Fragment>
-  <DefaultLayout>
-    <Relay(UserDetail)
-      user={
-        Object {
-          "id": "WyJ1c2VycyIsMV0=",
-        }
-      }
-    />
-  </DefaultLayout>
-</Fragment>
-`;
+exports[`user profile matches snapshot 1`] = `"No session exists, the user should go sign in."`;

--- a/app/tests/pages/application-details.test.js
+++ b/app/tests/pages/application-details.test.js
@@ -19,19 +19,19 @@ it('It receives the props for app_id, bcghgid and reporting year', () => {
   const wrapper = shallow(<ApplicationDetails router={router} />);
   expect(
     wrapper
-      .find('Relay(ApplicationStatusContainer)')
+      .find('Relay(ApplicationStatus)')
       .first()
       .prop('applicationId')
   ).toBe(router.query.applicationId);
   expect(
     wrapper
-      .find('Relay(IncentiveCalculatorContainer)')
+      .find('Relay(IncentiveCalculator)')
       .first()
       .prop('reportingYear')
   ).toBe(router.query.reportingYear);
   expect(
     wrapper
-      .find('Relay(IncentiveCalculatorContainer)')
+      .find('Relay(IncentiveCalculator)')
       .first()
       .prop('bcghgid')
   ).toBe(router.query.bcghgid);

--- a/app/tests/pages/ciip-application.test.js
+++ b/app/tests/pages/ciip-application.test.js
@@ -3,6 +3,7 @@ import {shallow} from 'enzyme';
 import CiipApplication from '../../containers/pageContainers/CiipApplication';
 
 const query = {
+  session: null,
   allFormJsons: {
     edges: [{node: {id: 'form-1'}}]
   }

--- a/app/tests/storyShots/__snapshots__/Admin.stories.storyshot
+++ b/app/tests/storyShots/__snapshots__/Admin.stories.storyshot
@@ -47,123 +47,151 @@ exports[`Storyshots containers/pageContainers/Admin Render Admin page 1`] = `
       <div
         className="jsx-1958721952 page-wrap"
       >
-        <Header>
-          <header
-            className="jsx-2807878339"
+        <Relay(HeaderLayout)>
+          <Relay(HeaderLayout)
+            __relayContext={
+              Object {
+                "environment": "RelayModernEnvironment(RelayModernMockEnvironment)",
+              }
+            }
+            componentRef={null}
           >
-            <div
-              className="jsx-2807878339 container"
+            <HeaderLayout
+              relay={
+                Object {
+                  "environment": "RelayModernEnvironment(RelayModernMockEnvironment)",
+                }
+              }
+              session={null}
             >
-              <div
-                className="jsx-2807878339 banner"
+              <header
+                className="jsx-2807878339"
               >
                 <div
-                  className="jsx-2807878339 header-left"
+                  className="jsx-2807878339 container"
                 >
-                  <Link
-                    href="/"
-                  >
-                    <img
-                      alt="Go to the Government of British Columbia website"
-                      className="jsx-2807878339"
-                      onClick={[Function]}
-                      onMouseEnter={[Function]}
-                      src="/static/logo-banner.png"
-                    />
-                  </Link>
-                  <h1
-                    className="jsx-2807878339"
-                  >
-                    CleanBC Industrial Incentive Program
-                  </h1>
-                </div>
-                <div
-                  className="jsx-2807878339 login-btns header-right"
-                >
-                  <ForwardRef
-                    noGutters={false}
+                  <div
+                    className="jsx-2807878339 banner"
                   >
                     <div
-                      className="row"
+                      className="jsx-2807878339 header-left"
                     >
-                      <Col>
-                        <div
-                          className="col"
-                        >
-                          <Link
-                            href={
-                              Object {
-                                "pathname": "/dummy-login",
-                              }
-                            }
-                          >
-                            <Button
-                              active={false}
-                              disabled={false}
-                              onClick={[Function]}
-                              onMouseEnter={[Function]}
-                              style={
-                                Object {
-                                  "marginRight": "10px",
-                                }
-                              }
-                              type="button"
-                              variant="outline-light"
-                            >
-                              <button
-                                className="btn btn-outline-light"
-                                disabled={false}
-                                onClick={[Function]}
-                                onMouseEnter={[Function]}
-                                style={
-                                  Object {
-                                    "marginRight": "10px",
-                                  }
-                                }
-                                type="button"
-                              >
-                                Register
-                              </button>
-                            </Button>
-                          </Link>
-                          <Link
-                            href={
-                              Object {
-                                "pathname": "/dummy-login",
-                              }
-                            }
-                          >
-                            <Button
-                              active={false}
-                              disabled={false}
-                              onClick={[Function]}
-                              onMouseEnter={[Function]}
-                              type="button"
-                              variant="outline-light"
-                            >
-                              <button
-                                className="btn btn-outline-light"
-                                disabled={false}
-                                onClick={[Function]}
-                                onMouseEnter={[Function]}
-                                type="button"
-                              >
-                                Login
-                              </button>
-                            </Button>
-                          </Link>
-                        </div>
-                      </Col>
+                      <Link
+                        href="/"
+                      >
+                        <img
+                          alt="Go to the Government of British Columbia website"
+                          className="jsx-2807878339"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          src="/static/logo-banner.png"
+                        />
+                      </Link>
+                      <h1
+                        className="jsx-2807878339"
+                      >
+                        CleanBC Industrial Incentive Program
+                      </h1>
                     </div>
-                  </ForwardRef>
+                    <div
+                      className="jsx-2807878339 login-btns header-right"
+                    >
+                      <ForwardRef
+                        noGutters={false}
+                      >
+                        <div
+                          className="row"
+                        >
+                          <Col>
+                            <div
+                              className="col"
+                            >
+                              <FormRow>
+                                <div
+                                  className="form-row"
+                                >
+                                  <Col>
+                                    <div
+                                      className="col"
+                                    >
+                                      <Form
+                                        action="https://www.bceid.ca/register/"
+                                        inline={false}
+                                        method="get"
+                                        target="_blank"
+                                      >
+                                        <form
+                                          action="https://www.bceid.ca/register/"
+                                          className=""
+                                          method="get"
+                                          target="_blank"
+                                        >
+                                          <Button
+                                            active={false}
+                                            disabled={false}
+                                            type="submit"
+                                            variant="outline-light"
+                                          >
+                                            <button
+                                              className="btn btn-outline-light"
+                                              disabled={false}
+                                              type="submit"
+                                            >
+                                              Register
+                                            </button>
+                                          </Button>
+                                        </form>
+                                      </Form>
+                                    </div>
+                                  </Col>
+                                  <Col>
+                                    <div
+                                      className="col"
+                                    >
+                                      <Form
+                                        action="/login"
+                                        inline={false}
+                                        method="post"
+                                      >
+                                        <form
+                                          action="/login"
+                                          className=""
+                                          method="post"
+                                        >
+                                          <Button
+                                            active={false}
+                                            disabled={false}
+                                            type="submit"
+                                            variant="outline-light"
+                                          >
+                                            <button
+                                              className="btn btn-outline-light"
+                                              disabled={false}
+                                              type="submit"
+                                            >
+                                              Login
+                                            </button>
+                                          </Button>
+                                        </form>
+                                      </Form>
+                                    </div>
+                                  </Col>
+                                </div>
+                              </FormRow>
+                            </div>
+                          </Col>
+                        </div>
+                      </ForwardRef>
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </div>
-            <JSXStyle
-              id="2807878339"
-            />
-          </header>
-        </Header>
+                <JSXStyle
+                  id="2807878339"
+                />
+              </header>
+            </HeaderLayout>
+          </Relay(HeaderLayout)>
+        </Relay(HeaderLayout)>
         <div
           className="jsx-1958721952 page-title"
         >
@@ -209,8 +237,8 @@ exports[`Storyshots containers/pageContainers/Admin Render Admin page 1`] = `
                           Create a Product
                         </h4>
                         <br />
-                        <Relay(ProductCreatorContainer)>
-                          <Relay(ProductCreatorContainer)
+                        <Relay(ProductCreator)>
+                          <Relay(ProductCreator)
                             __relayContext={
                               Object {
                                 "environment": "RelayModernEnvironment(RelayModernMockEnvironment)",
@@ -218,7 +246,7 @@ exports[`Storyshots containers/pageContainers/Admin Render Admin page 1`] = `
                             }
                             componentRef={null}
                           >
-                            <ProductCreatorContainer
+                            <ProductCreator
                               relay={
                                 Object {
                                   "environment": "RelayModernEnvironment(RelayModernMockEnvironment)",
@@ -347,15 +375,15 @@ exports[`Storyshots containers/pageContainers/Admin Render Admin page 1`] = `
                                   </form>
                                 </Form>
                               </div>
-                            </ProductCreatorContainer>
-                          </Relay(ProductCreatorContainer)>
-                        </Relay(ProductCreatorContainer)>
+                            </ProductCreator>
+                          </Relay(ProductCreator)>
+                        </Relay(ProductCreator)>
                       </div>
                     </Jumbotron>
                     <br />
                     <br />
                     <br />
-                    <Relay(ProductListContainer)
+                    <Relay(ProductList)
                       confirmationModalOpen={false}
                       mode="view"
                       productRowActions={
@@ -399,7 +427,7 @@ exports[`Storyshots containers/pageContainers/Admin Render Admin page 1`] = `
                         }
                       }
                     >
-                      <Relay(ProductListContainer)
+                      <Relay(ProductList)
                         __relayContext={
                           Object {
                             "environment": "RelayModernEnvironment(RelayModernMockEnvironment)",
@@ -449,7 +477,7 @@ exports[`Storyshots containers/pageContainers/Admin Render Admin page 1`] = `
                           }
                         }
                       >
-                        <ProductListContainer
+                        <ProductList
                           confirmationModalOpen={false}
                           mode="view"
                           productRowActions={
@@ -2560,9 +2588,9 @@ exports[`Storyshots containers/pageContainers/Admin Render Admin page 1`] = `
                               </ProductRowItemComponent>
                             </Relay(ProductRowItemComponent)>
                           </Relay(ProductRowItemComponent)>
-                        </ProductListContainer>
-                      </Relay(ProductListContainer)>
-                    </Relay(ProductListContainer)>
+                        </ProductList>
+                      </Relay(ProductList)>
+                    </Relay(ProductList)>
                   </div>
                 </Col>
               </div>

--- a/schema/deploy/function_session.sql
+++ b/schema/deploy/function_session.sql
@@ -1,0 +1,32 @@
+-- Deploy ggircs-portal:function_session to pg
+-- requires: schema_ggircs_portal
+-- requires: type_jwt_token
+
+begin;
+
+create or replace function ggircs_portal.session()
+  returns ggircs_portal.jwt_token as $function$
+    select (
+      current_setting('jwt.claims.jti', true),
+      current_setting('jwt.claims.exp', true),
+      current_setting('jwt.claims.nbf', true),
+      current_setting('jwt.claims.iat', true),
+      current_setting('jwt.claims.iss', true),
+      current_setting('jwt.claims.aud', true),
+      current_setting('jwt.claims.sub', true),
+      current_setting('jwt.claims.typ', true),
+      current_setting('jwt.claims.azp', true),
+      current_setting('jwt.claims.auth_time', true),
+      current_setting('jwt.claims.session_state', true),
+      current_setting('jwt.claims.acr', true),
+      current_setting('jwt.claims.email_verified', true),
+      current_setting('jwt.claims.name', true),
+      current_setting('jwt.claims.preferred_username', true),
+      current_setting('jwt.claims.given_name', true),
+      current_setting('jwt.claims.family_name', true),
+      current_setting('jwt.claims.email', true)
+    )::ggircs_portal.jwt_token;
+  $function$ language sql stable strict;
+
+
+commit;

--- a/schema/deploy/function_session.sql
+++ b/schema/deploy/function_session.sql
@@ -5,28 +5,35 @@
 begin;
 
 create or replace function ggircs_portal.session()
-  returns ggircs_portal.jwt_token as $function$
-    select (
-      current_setting('jwt.claims.jti', true),
-      current_setting('jwt.claims.exp', true),
-      current_setting('jwt.claims.nbf', true),
-      current_setting('jwt.claims.iat', true),
-      current_setting('jwt.claims.iss', true),
-      current_setting('jwt.claims.aud', true),
-      current_setting('jwt.claims.sub', true),
-      current_setting('jwt.claims.typ', true),
-      current_setting('jwt.claims.azp', true),
-      current_setting('jwt.claims.auth_time', true),
-      current_setting('jwt.claims.session_state', true),
-      current_setting('jwt.claims.acr', true),
-      current_setting('jwt.claims.email_verified', true),
-      current_setting('jwt.claims.name', true),
-      current_setting('jwt.claims.preferred_username', true),
-      current_setting('jwt.claims.given_name', true),
-      current_setting('jwt.claims.family_name', true),
-      current_setting('jwt.claims.email', true)
-    )::ggircs_portal.jwt_token;
-  $function$ language sql stable strict;
-
+    returns ggircs_portal.jwt_token as
+$function$
+begin
+    if (current_setting('jwt.claims.sub', true) is null) then
+        return null;
+    end if;
+    return (
+        select row (
+                   current_setting('jwt.claims.jti', true),
+                   current_setting('jwt.claims.exp', true),
+                   current_setting('jwt.claims.nbf', true),
+                   current_setting('jwt.claims.iat', true),
+                   current_setting('jwt.claims.iss', true),
+                   current_setting('jwt.claims.aud', true),
+                   current_setting('jwt.claims.sub'), -- subject can never be null
+                   current_setting('jwt.claims.typ', true),
+                   current_setting('jwt.claims.azp', true),
+                   current_setting('jwt.claims.auth_time', true),
+                   current_setting('jwt.claims.session_state', true),
+                   current_setting('jwt.claims.acr', true),
+                   current_setting('jwt.claims.email_verified', true),
+                   current_setting('jwt.claims.name', true),
+                   current_setting('jwt.claims.preferred_username', true),
+                   current_setting('jwt.claims.given_name', true),
+                   current_setting('jwt.claims.family_name', true),
+                   current_setting('jwt.claims.email', true)
+                   )::ggircs_portal.jwt_token
+    );
+end
+$function$ language 'plpgsql' stable;
 
 commit;

--- a/schema/deploy/type_jwt_token.sql
+++ b/schema/deploy/type_jwt_token.sql
@@ -1,0 +1,50 @@
+-- Deploy ggircs-portal:type_jwt_token to pg
+-- requires: schema_ggircs_portal
+
+begin;
+
+create type ggircs_portal.jwt_token as (
+  jti uuid,
+  exp integer,
+  nbf integer,
+  iat integer,
+  iss text,
+  aud text,
+  sub uuid,
+  typ text,
+  azp text,
+  auth_time integer,
+  session_state uuid,
+  acr text,
+  email_verified boolean,
+  name text,
+  preferred_username text,
+  given_name text,
+  family_name text,
+  email text
+);
+
+comment on type ggircs_portal.jwt_token is E'@primaryKey sub\n@foreignKey (sub) references user (uuid)';
+
+-- TODO: should be conformant with https://tools.ietf.org/html/rfc7519
+-- Sample payload from Keycloak via IDIR provider
+--  { jti: 'a090bc6c-dccd-4e55-857c-eb1a7bda2034',
+--    exp: 1571273650,
+--    nbf: 0,
+--    iat: 1571273350,
+--    iss: 'https://sso-dev.pathfinder.gov.bc.ca/auth/realms/pisrwwhx',
+--    aud: 'cas-ciip-portal',
+--    sub: '46d2dafb-f48f-4782-838c-37d6a3e2d34a',
+--    typ: 'ID',
+--    azp: 'cas-ciip-portal',
+--    auth_time: 1571272904,
+--    session_state: 'e0444b80-0ce0-4ea6-a3e6-5a227122af3c',
+--    acr: '0',
+--    email_verified: false,
+--    name: 'Alec Wenzowski',
+--    preferred_username: 'awenzows@idir',
+--    given_name: 'Alec',
+--    family_name: 'Wenzowski',
+--    email: 'alec.wenzowski@gov.bc.ca' }
+
+commit;

--- a/schema/revert/function_session.sql
+++ b/schema/revert/function_session.sql
@@ -1,0 +1,7 @@
+-- Revert ggircs-portal:function_session from pg
+
+begin;
+
+drop function if exists ggircs_portal.session;
+
+commit;

--- a/schema/revert/type_jwt_token.sql
+++ b/schema/revert/type_jwt_token.sql
@@ -1,0 +1,7 @@
+-- Revert ggircs-portal:type_jwt_token from pg
+
+begin;
+
+drop type ggircs_portal.jwt_token;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -44,3 +44,5 @@ table_fuel [schema_ggircs_portal] 2019-10-16T18:17:17Z Matthieu Foucault <matthi
 function_create_application_mutation_chain [table_application table_application_status] 2019-10-25T18:24:34Z Dylan Leard <dylan@button.is> # Mutation chain to create an application and create a pending application status
 function_application_application_status [table_application_status table_application] 2019-10-30T23:57:31Z Helen Liu <helen@button.is> # Added new column application status to application
 function_application_ordered_form_results [table_application table_form_result table_ciip_application_wizard] 2019-10-30T22:29:53Z Dylan Leard <dleard@dleard-Aspire-V5-591G> # Function to order form results on an application
+type_jwt_token [schema_ggircs_portal] 2019-10-17T00:28:40Z Alec Wenzowski <alec@button.is> # Add a schema for Keycloak JWT Tokens
+function_session [schema_ggircs_portal type_jwt_token] 2019-10-17T01:02:35Z Alec Wenzowski <alec@button.is> # Something

--- a/schema/verify/function_session.sql
+++ b/schema/verify/function_session.sql
@@ -1,0 +1,7 @@
+-- Verify ggircs-portal:function_session on pg
+
+begin;
+
+select pg_get_functiondef('ggircs_portal.session()'::regprocedure);
+
+rollback;

--- a/schema/verify/type_jwt_token.sql
+++ b/schema/verify/type_jwt_token.sql
@@ -1,0 +1,13 @@
+-- Verify ggircs-portal:type_jwt_token on pg
+
+begin;
+
+do $$
+  begin
+    assert (
+      select true from pg_catalog.pg_type where typname = 'jwt_token'
+    ), 'type "jwt_token" is not defined';
+  end;
+$$;
+
+rollback;


### PR DESCRIPTION
The `session` field will only be available when authenticated via
keycloak. In order to use the `userBySub` relation, a `User` must
already exist with the `user.uuid` column set to the `session.sub`.

example usage:
```graphql
{
  session {
    jti
    exp
    nbf
    iat
    iss
    aud
    sub
    typ
    azp
    authTime
    sessionState
    acr
    emailVerified
    name
    preferredUsername
    givenName
    familyName
    email
    userBySub {
      id
      rowId
      uuid
      firstName
      lastName
      emailAddress
      createdAt
      updatedAt
      createdBy
      updatedBy
      userOrganisationsByUserId {
        edges {
          node {
            id
          }
        }
      }
    }
  }
}
```

Comments describing the `JwtToken` type conformance to [RFC 7519] are
still needed, and the nullability of those fields should be correctly
set in the type to conform to the RFC.

[RFC 7519]: https://tools.ietf.org/html/rfc7519