### PR TITLE
pathfinder build should wait for next.js compilation 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,10 +364,11 @@ workflows:
             - tools
       - pathfinder_lint:
           requires:
-            - audit
             - lint
             - unit
+            - audit
             - schema
+            - compile
             - deploy-test-data
           context: cas-pipeline
           filters:


### PR DESCRIPTION
It's helpful to know that the production build will compile before we
start wasting pathfinder compute resources making a deployable container
image for the revision.