### PR TITLE
Throttle mutation calls

### DIFF
--- a/app/server/schema.graphql
+++ b/app/server/schema.graphql
@@ -3153,6 +3153,8 @@ type FormJson implements Node {
 
   """The JSON object that creates the form"""
   formJson: JSON!
+
+  """The name of the function that initializes the form_result with data"""
   formResultInitFunction: String
 
   """Reads and enables pagination through a set of `FormResult`."""
@@ -3258,6 +3260,8 @@ input FormJsonInput {
 
   """The JSON object that creates the form"""
   formJson: JSON!
+
+  """The name of the function that initializes the form_result with data"""
   formResultInitFunction: String
 
   """Name for the form"""
@@ -3292,6 +3296,8 @@ input FormJsonPatch {
 
   """The JSON object that creates the form"""
   formJson: JSON
+
+  """The name of the function that initializes the form_result with data"""
   formResultInitFunction: String
 
   """Name for the form"""

--- a/app/server/schema.json
+++ b/app/server/schema.json
@@ -7712,7 +7712,7 @@
             },
             {
               "name": "formResultInitFunction",
-              "description": null,
+              "description": "The name of the function that initializes the form_result with data",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -20401,7 +20401,7 @@
             },
             {
               "name": "formResultInitFunction",
-              "description": null,
+              "description": "The name of the function that initializes the form_result with data",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -25921,7 +25921,7 @@
             },
             {
               "name": "formResultInitFunction",
-              "description": null,
+              "description": "The name of the function that initializes the form_result with data",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",

--- a/app/tests/containers/Forms/FormEditUser.test.tsx
+++ b/app/tests/containers/Forms/FormEditUser.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import {shallow} from 'enzyme';
+import {createMockEnvironment} from 'relay-test-utils';
 import {FormEditUserComponent} from '../../../containers/Forms/FormEditUser';
+
+const environment = createMockEnvironment();
 
 describe('Form Edit User', () => {
   it('should render', () => {
@@ -10,8 +13,13 @@ describe('Form Edit User', () => {
       lastName: 'Test',
       emailAddress: 'Test@test.com'
     };
+    const relay = {
+      environment
+    };
 
-    const wrapper = shallow(<FormEditUserComponent user={user} />);
+    const wrapper = shallow(
+      <FormEditUserComponent relay={relay} user={user} />
+    );
 
     expect(wrapper).toMatchSnapshot();
 

--- a/schema/deploy/table_form_json.sql
+++ b/schema/deploy/table_form_json.sql
@@ -35,4 +35,5 @@ comment on column ggircs_portal.form_json.updated_at is 'The date the form was u
 comment on column ggircs_portal.form_json.updated_by is 'The person who updated the form';
 comment on column ggircs_portal.form_json.prepopulate_from_ciip is 'Whether the form is initialized with data submitted in the previous year''s application';
 comment on column ggircs_portal.form_json.prepopulate_from_swrs is 'Whether the form is initialized with data submitted in the previous year''s application';
+comment on column ggircs_portal.form_json.form_result_init_function is 'The name of the function that initializes the form_result with data';
 commit;


### PR DESCRIPTION
Adds throttle to the edit user (/registration) page:
  - updates the local store on every keystroke
  - sends a commitMutation call after 1 second of handleChange() inactivity