### PR TITLE
Upgrade to typescript 3.7 and add example of optional chaining

### DIFF
--- a/app/.babelrc
+++ b/app/.babelrc
@@ -4,6 +4,8 @@
   ],
   "plugins": [
     ["relay", { "artifactDirectory": "./__generated__" }],
-    "macros"
+    "macros",
+    "@babel/plugin-proposal-optional-chaining",
+    "@babel/plugin-proposal-nullish-coalescing-operator"
   ]
 }

--- a/app/components/SearchTableLayout.tsx
+++ b/app/components/SearchTableLayout.tsx
@@ -9,9 +9,7 @@ interface Props {
   handleEvent: (...args: any[]) => void;
   dropdownSortItems: any[];
 }
-export const SearchTableLayoutComponent: React.FunctionComponent<
-  Props
-> = props => {
+export const SearchTableLayoutComponent: React.FunctionComponent<Props> = props => {
   const {
     orderByDisplay,
     searchDisplay,

--- a/app/containers/Admin/OrganisationRequestsTable.tsx
+++ b/app/containers/Admin/OrganisationRequestsTable.tsx
@@ -15,9 +15,7 @@ interface Props {
   handleEvent: (...args: any[]) => void;
   relay: RelayRefetchProp;
 }
-export const OrganisationRequestsTableComponent: React.FunctionComponent<
-  Props
-> = props => {
+export const OrganisationRequestsTableComponent: React.FunctionComponent<Props> = props => {
   const {
     orderByField,
     orderByDisplay,

--- a/app/containers/Admin/OrganisationRequestsTableRow.tsx
+++ b/app/containers/Admin/OrganisationRequestsTableRow.tsx
@@ -8,9 +8,7 @@ interface Props {
   userOrganisation: OrganisationRequestsTableRow_userOrganisation;
   key: string;
 }
-export const OrganisationRequestsTableRowComponent: React.FunctionComponent<
-  Props
-> = props => {
+export const OrganisationRequestsTableRowComponent: React.FunctionComponent<Props> = props => {
   const {userOrganisation} = props;
 
   const statusBadgeColor = {

--- a/app/containers/Forms/Form.tsx
+++ b/app/containers/Forms/Form.tsx
@@ -38,7 +38,6 @@ const CUSTOM_FIELDS = {
   )
 };
 
-// Note: https://github.com/graphile/postgraphile/issues/980
 export const FormComponent: React.FunctionComponent<Props> = ({
   query,
   onComplete,
@@ -69,31 +68,27 @@ export const FormComponent: React.FunctionComponent<Props> = ({
   };
 
   return (
-    <>
-      {/*
-      //@ts-ignore JsonSchemaForm typedef is missing customFormats prop */}
-      <JsonSchemaForm
-        omitExtraData
-        liveOmit
-        showErrorList={false}
-        ArrayFieldTemplate={FormArrayFieldTemplate}
-        FieldTemplate={FormFieldTemplate}
-        formContext={{query}}
-        formData={formResult}
-        fields={CUSTOM_FIELDS}
-        customFormats={customFormats}
-        schema={schema}
-        uiSchema={uiSchema}
-        ObjectFieldTemplate={FormObjectFieldTemplate}
-        transformErrors={transformErrors}
-        onSubmit={onComplete}
-        onChange={onValueChanged}
-      >
-        <div style={{textAlign: 'right'}}>
-          <Button type="submit">Submit</Button>
-        </div>
-      </JsonSchemaForm>
-    </>
+    <JsonSchemaForm
+      omitExtraData
+      liveOmit
+      showErrorList={false}
+      ArrayFieldTemplate={FormArrayFieldTemplate}
+      FieldTemplate={FormFieldTemplate}
+      formContext={{query}}
+      formData={formResult}
+      fields={CUSTOM_FIELDS}
+      customFormats={customFormats}
+      schema={schema}
+      uiSchema={uiSchema}
+      ObjectFieldTemplate={FormObjectFieldTemplate}
+      transformErrors={transformErrors}
+      onSubmit={onComplete}
+      onChange={onValueChanged}
+    >
+      <div style={{textAlign: 'right'}}>
+        <Button type="submit">Submit</Button>
+      </div>
+    </JsonSchemaForm>
   );
 };
 

--- a/app/containers/Forms/FormArrayFieldTemplate.tsx
+++ b/app/containers/Forms/FormArrayFieldTemplate.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 import {ArrayFieldTemplateProps} from 'react-jsonschema-form';
 import {Form, Button, Col} from 'react-bootstrap';
 
-const FormArrayFieldTemplate: React.FunctionComponent<
-  ArrayFieldTemplateProps
-> = ({items, canAdd, onAddClick, uiSchema}) => {
+const FormArrayFieldTemplate: React.FunctionComponent<ArrayFieldTemplateProps> = ({
+  items,
+  canAdd,
+  onAddClick,
+  uiSchema
+}) => {
   return (
     <>
       {items.map(element => {

--- a/app/containers/Organisations/Facility.tsx
+++ b/app/containers/Organisations/Facility.tsx
@@ -28,10 +28,8 @@ export const FacilityComponent = ({relay, facility}) => {
     });
   };
 
-  const {applicationsByFacilityId = {}} = facility;
-  const {edges = []} = applicationsByFacilityId;
-  const {node = {}} = edges[0] || {};
-  const {id: applicationId, applicationStatus} = node;
+  const {edges} = facility?.applicationsByFacilityId || {};
+  const {id: applicationId, applicationStatus} = edges?.[0] || {};
 
   // Conditionall render apply / resume button depending on existence and status of Facility's application
   const applyButton = () => {

--- a/app/containers/Organisations/Facility.tsx
+++ b/app/containers/Organisations/Facility.tsx
@@ -1,11 +1,20 @@
 import React from 'react';
-import {graphql, createFragmentContainer} from 'react-relay';
+import {graphql, createFragmentContainer, RelayProp} from 'react-relay';
 import {Button, Badge, Card, ListGroup, ListGroupItem} from 'react-bootstrap';
 import {useRouter} from 'next/router';
 import Link from 'next/link';
+import {Facility_facility} from 'Facility_facility.graphql';
 import createApplicationMutation from '../../mutations/application/createApplicationMutation';
 
-export const FacilityComponent = ({relay, facility}) => {
+interface Props {
+  relay: RelayProp;
+  facility: Facility_facility;
+}
+
+export const FacilityComponent: React.FunctionComponent<Props> = ({
+  relay,
+  facility
+}) => {
   const {environment} = relay;
   const router = useRouter();
 
@@ -29,7 +38,7 @@ export const FacilityComponent = ({relay, facility}) => {
   };
 
   const {edges} = facility?.applicationsByFacilityId || {};
-  const {id: applicationId, applicationStatus} = edges?.[0] || {};
+  const {id: applicationId, applicationStatus} = edges?.[0]?.node || {};
 
   // Conditionall render apply / resume button depending on existence and status of Facility's application
   const applyButton = () => {
@@ -83,7 +92,7 @@ export const FacilityComponent = ({relay, facility}) => {
           </ListGroupItem>
           <ListGroupItem>
             <strong>Application Status:</strong> &nbsp;{' '}
-            {edges.length > 0 ? (
+            {applicationStatus ? (
               <>
                 <Badge
                   pill

--- a/app/containers/User/UserForm.tsx
+++ b/app/containers/User/UserForm.tsx
@@ -79,7 +79,6 @@ const UserForm: React.FunctionComponent<Props> = ({
   });
 
   return (
-    // @ts-ignore JsonSchemaForm typedef is missing some props
     <JsonSchemaForm
       omitExtraData
       liveOmit

--- a/app/next-env.d.ts
+++ b/app/next-env.d.ts
@@ -2,6 +2,8 @@ import {NextComponentType, NextPageContext} from 'next';
 import {GraphQLTaggedNode} from 'relay-runtime';
 import {NextRouter} from 'next/router';
 import {ComponentClass} from 'react';
+import {FormProps as OriginalFromProps} from 'react-jsonschema-form';
+import {JSONSchema7} from 'json-schema';
 
 interface CiipPageInitialProps {
   pageProps: {
@@ -23,3 +25,15 @@ export type CiipPageComponent = NextComponentType<
   ComponentClass<CiipPageComponentProps> & {
     static query: GraphQLTaggedNode;
   };
+
+// This is overriding the form props defined in @types/react-jsonschema-form as they
+// are missing some props, and it usee JSONSchema6 instead of JSONSchema7
+// TODO: contribute to @types/react-jsonschema-form to fix these types so that we don't rely on this ugly override
+declare module 'react-jsonschema-form' {
+  export interface FormProps<T> extends OriginalFromProps<T> {
+    schema: JSONSchema7;
+    omitExtraData?: boolean;
+    liveOmit?: boolean;
+    customFormats?: Record<string, any>;
+  }
+}

--- a/app/package.json
+++ b/app/package.json
@@ -125,6 +125,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
+    "@babel/plugin-proposal-optional-chaining": "^7.6.0",
     "@storybook/addon-a11y": "^5.2.1",
     "@storybook/addon-storyshots": "^5.2.4",
     "@storybook/addons": "^5.2.1",

--- a/app/package.json
+++ b/app/package.json
@@ -168,13 +168,14 @@
     "relay-compiler-language-typescript": "^10.1.0",
     "relay-test-utils": "^7.0.0",
     "require-context.macro": "^1.2.2",
-    "typescript": "3.6.4",
+    "typescript": "3.7.2",
     "webpack": "^4.41.0",
     "xo": "^0.25.0"
   },
   "resolutions": {
     "@storybook/**/open": "^7.0.0",
     "xo/open-editor/open": "^7.0.0",
+    "xo/prettier": "^1.19.1",
     "jest/jest-cli/@jest/core/@jest/reporters/istanbul-reports/handlebars": "^4.5.2"
   },
   "jest": {

--- a/app/tests/containers/Forms/__snapshots__/Form.test.tsx.snap
+++ b/app/tests/containers/Forms/__snapshots__/Form.test.tsx.snap
@@ -1460,169 +1460,167 @@ exports[`Form should match the snapshot with the fuel form 1`] = `
 `;
 
 exports[`Form should match the snapshot with the production form 1`] = `
-<Fragment>
-  <Form
-    ArrayFieldTemplate={[Function]}
-    ErrorList={[Function]}
-    FieldTemplate={[Function]}
-    ObjectFieldTemplate={[Function]}
-    disabled={false}
-    fields={
-      Object {
-        "emissionGas": [Function],
-        "emissionSource": [Function],
-        "fuel": [Function],
-        "production": [Function],
-      }
+<Form
+  ArrayFieldTemplate={[Function]}
+  ErrorList={[Function]}
+  FieldTemplate={[Function]}
+  ObjectFieldTemplate={[Function]}
+  disabled={false}
+  fields={
+    Object {
+      "emissionGas": [Function],
+      "emissionSource": [Function],
+      "fuel": [Function],
+      "production": [Function],
     }
-    formContext={
-      Object {
-        "query": Object {
-          " $fragmentRefs": Object {
-            "FuelFields_query": true,
-            "ProductionFields_query": true,
-          },
-          " $refType": "Form_query",
-          "result": Object {
-            "formJsonByFormId": Object {
-              "formJson": Object {
-                "schema": Object {
-                  "definitions": Object {
-                    "production": Object {
-                      "properties": Object {
-                        "associatedEmissions": Object {
-                          "title": "Associated Emission (tCO2e)",
-                          "type": "number",
-                        },
-                        "comments": Object {
-                          "title": "comments",
-                          "type": "string",
-                        },
-                        "product": Object {
-                          "title": "Processing Unit Module",
-                          "type": "string",
-                        },
-                        "productUnits": Object {
-                          "title": "Units",
-                          "type": "string",
-                        },
-                        "quantity": Object {
-                          "title": "Quantity",
-                          "type": "number",
-                        },
+  }
+  formContext={
+    Object {
+      "query": Object {
+        " $fragmentRefs": Object {
+          "FuelFields_query": true,
+          "ProductionFields_query": true,
+        },
+        " $refType": "Form_query",
+        "result": Object {
+          "formJsonByFormId": Object {
+            "formJson": Object {
+              "schema": Object {
+                "definitions": Object {
+                  "production": Object {
+                    "properties": Object {
+                      "associatedEmissions": Object {
+                        "title": "Associated Emission (tCO2e)",
+                        "type": "number",
                       },
-                      "type": "object",
+                      "comments": Object {
+                        "title": "comments",
+                        "type": "string",
+                      },
+                      "product": Object {
+                        "title": "Processing Unit Module",
+                        "type": "string",
+                      },
+                      "productUnits": Object {
+                        "title": "Units",
+                        "type": "string",
+                      },
+                      "quantity": Object {
+                        "title": "Quantity",
+                        "type": "number",
+                      },
                     },
+                    "type": "object",
                   },
-                  "items": Object {
-                    "$ref": "#/definitions/production",
-                  },
-                  "title": "Production Information",
-                  "type": "array",
                 },
-                "uiSchema": Object {
-                  "items": Object {
-                    "ui:field": "production",
-                  },
-                  "ui:add-text": "Add a Product",
-                  "ui:remove-text": "Remove Product",
+                "items": Object {
+                  "$ref": "#/definitions/production",
                 },
+                "title": "Production Information",
+                "type": "array",
+              },
+              "uiSchema": Object {
+                "items": Object {
+                  "ui:field": "production",
+                },
+                "ui:add-text": "Add a Product",
+                "ui:remove-text": "Remove Product",
               },
             },
-            "formResult": Array [
-              Object {
-                "associatedEmissions": 42,
-                "comments": "Saepe quis aliquid e",
-                "product": "Dehydration",
-                "productUnits": "kl",
-                "quantity": 84,
-              },
-            ],
           },
-        },
-      }
-    }
-    formData={
-      Array [
-        Object {
-          "associatedEmissions": 42,
-          "comments": "Saepe quis aliquid e",
-          "product": "Dehydration",
-          "productUnits": "kl",
-          "quantity": 84,
-        },
-      ]
-    }
-    liveOmit={true}
-    liveValidate={false}
-    noHtml5Validate={false}
-    noValidate={false}
-    omitExtraData={true}
-    safeRenderCompletion={false}
-    schema={
-      Object {
-        "definitions": Object {
-          "production": Object {
-            "properties": Object {
-              "associatedEmissions": Object {
-                "title": "Associated Emission (tCO2e)",
-                "type": "number",
-              },
-              "comments": Object {
-                "title": "comments",
-                "type": "string",
-              },
-              "product": Object {
-                "title": "Processing Unit Module",
-                "type": "string",
-              },
-              "productUnits": Object {
-                "title": "Units",
-                "type": "string",
-              },
-              "quantity": Object {
-                "title": "Quantity",
-                "type": "number",
-              },
+          "formResult": Array [
+            Object {
+              "associatedEmissions": 42,
+              "comments": "Saepe quis aliquid e",
+              "product": "Dehydration",
+              "productUnits": "kl",
+              "quantity": 84,
             },
-            "type": "object",
-          },
+          ],
         },
-        "items": Object {
-          "$ref": "#/definitions/production",
-        },
-        "title": "Production Information",
-        "type": "array",
-      }
+      },
     }
-    showErrorList={false}
-    transformErrors={[Function]}
-    uiSchema={
+  }
+  formData={
+    Array [
       Object {
-        "items": Object {
-          "ui:field": "production",
+        "associatedEmissions": 42,
+        "comments": "Saepe quis aliquid e",
+        "product": "Dehydration",
+        "productUnits": "kl",
+        "quantity": 84,
+      },
+    ]
+  }
+  liveOmit={true}
+  liveValidate={false}
+  noHtml5Validate={false}
+  noValidate={false}
+  omitExtraData={true}
+  safeRenderCompletion={false}
+  schema={
+    Object {
+      "definitions": Object {
+        "production": Object {
+          "properties": Object {
+            "associatedEmissions": Object {
+              "title": "Associated Emission (tCO2e)",
+              "type": "number",
+            },
+            "comments": Object {
+              "title": "comments",
+              "type": "string",
+            },
+            "product": Object {
+              "title": "Processing Unit Module",
+              "type": "string",
+            },
+            "productUnits": Object {
+              "title": "Units",
+              "type": "string",
+            },
+            "quantity": Object {
+              "title": "Quantity",
+              "type": "number",
+            },
+          },
+          "type": "object",
         },
-        "ui:add-text": "Add a Product",
-        "ui:remove-text": "Remove Product",
+      },
+      "items": Object {
+        "$ref": "#/definitions/production",
+      },
+      "title": "Production Information",
+      "type": "array",
+    }
+  }
+  showErrorList={false}
+  transformErrors={[Function]}
+  uiSchema={
+    Object {
+      "items": Object {
+        "ui:field": "production",
+      },
+      "ui:add-text": "Add a Product",
+      "ui:remove-text": "Remove Product",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "textAlign": "right",
       }
     }
   >
-    <div
-      style={
-        Object {
-          "textAlign": "right",
-        }
-      }
+    <Button
+      active={false}
+      disabled={false}
+      type="submit"
+      variant="primary"
     >
-      <Button
-        active={false}
-        disabled={false}
-        type="submit"
-        variant="primary"
-      >
-        Submit
-      </Button>
-    </div>
-  </Form>
-</Fragment>
+      Submit
+    </Button>
+  </div>
+</Form>
 `;

--- a/app/tests/pages/application-details.test.tsx
+++ b/app/tests/pages/application-details.test.tsx
@@ -3,8 +3,7 @@ import {shallow} from 'enzyme';
 import {NextRouter} from 'next/router';
 import ApplicationDetails from '../../pages/application-details';
 
-// @ts-ignore
-const router: NextRouter = {
+const router: Partial<NextRouter> = {
   asPath:
     '/application-details?application_id=1&reportingyear=2018&bcghgid=100',
   route: '/application-details',

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -371,6 +371,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-json-strings" "^7.2.0"
 
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.4.4.tgz#41c360d59481d88e0ce3a3f837df10121a769b39"
+  integrity sha512-Amph7Epui1Dh/xxUxS2+K22/MUi6+6JVTvy3P58tja3B6yKTSjwwx0/d83rF7551D6PVSSoplQb8GCwqec7HRw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.2.0"
+
 "@babel/plugin-proposal-object-rest-spread@7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz#61939744f71ba76a3ae46b5eea18a54c16d22e58"
@@ -394,6 +402,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
+
+"@babel/plugin-proposal-optional-chaining@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.6.0.tgz#e9bf1f9b9ba10c77c033082da75f068389041af8"
+  integrity sha512-kj4gkZ6qUggkprRq3Uh5KP8XnE1MdIO0J7MhdDX8+rAbB6dJ2UrensGIS+0NPZAaaJ1Vr0PN6oLUgXMU1uMcSg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-optional-chaining" "^7.2.0"
 
 "@babel/plugin-proposal-unicode-property-regex@^7.4.4", "@babel/plugin-proposal-unicode-property-regex@^7.6.2", "@babel/plugin-proposal-unicode-property-regex@^7.7.0":
   version "7.7.0"
@@ -452,6 +468,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-syntax-nullish-coalescing-operator@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.2.0.tgz#f75083dfd5ade73e783db729bbd87e7b9efb7624"
+  integrity sha512-lRCEaKE+LTxDQtgbYajI04ddt6WW0WJq57xqkAZ+s11h4YgfRHhVA/Y2VhfPzzFD4qeLHWg32DMp9HooY4Kqlg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-syntax-object-rest-spread@^7.0.0", "@babel/plugin-syntax-object-rest-spread@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz#3b7a3e733510c57e820b9142a6579ac8b0dfad2e"
@@ -463,6 +486,13 @@
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz#a94013d6eda8908dfe6a477e7f9eda85656ecf5c"
   integrity sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-optional-chaining@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.2.0.tgz#a59d6ae8c167e7608eaa443fda9fa8fa6bf21dff"
+  integrity sha512-HtGCtvp5Uq/jH/WNUPkK6b7rufnCPLLlDAFN7cmACoIjaOOiXxUt3SswU5loHqrhtqTsa/WoLQ1OQ1AGuZqaWA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -10839,7 +10839,12 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.15.2, prettier@^1.16.0:
+prettier@^1.15.2, prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^1.16.0:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
@@ -13314,10 +13319,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.6.4:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
-  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
+typescript@3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"


### PR DESCRIPTION
For people using an IDE (@wenzowski nothing to see here), you may need to update the typescript version it uses. After running `yarn install` open the Facility component to see if your IDE complains about the [optional chaining](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#optional-chaining):

@hamzajaved Yours should update nicely, if not see https://www.jetbrains.com/help/webstorm/settings-languages-typescript.html

@dleard @blueQcloud @dimak1 If the root folder you have opened is `app`, you should be fine (maybe you still need the last step below). Otherwise, add the following line to your VScode workspace settings to use the Typescript in `app/node_module` instead of the one shipped with VScode (the version with Typescript 3.7 is still in beta: 
```
"typescript.tsdk": "app/node_modules/typescript/lib"
```
Then, when you have an editor opened on a `.tsx` file, click on the typescript version number (see [here](https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-newer-typescript-versions)) and select "Use Workspace version"