### PR TITLE
fix(security): patch arbitrary code execution exploit

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -178,7 +178,7 @@
     "@storybook/**/open": "^7.0.0",
     "xo/open-editor/open": "^7.0.0",
     "xo/prettier": "^1.19.1",
-    "jest/jest-cli/@jest/core/@jest/reporters/istanbul-reports/handlebars": "^4.5.2"
+    "jest/jest-cli/@jest/core/@jest/reporters/istanbul-reports/handlebars": "^4.5.3"
   },
   "jest": {
     "testMatch": [

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -6790,10 +6790,10 @@ gzip-size@5.1.1:
     duplexer "^0.1.1"
     pify "^4.0.1"
 
-handlebars@^4.1.2, handlebars@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.2.tgz#5a4eb92ab5962ca3415ac188c86dc7f784f76a0f"
-  integrity sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==
+handlebars@^4.1.2, handlebars@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
+  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION
Versions of handlebars prior to 4.5.3 are vulnerable to Arbitrary Code
Execution. The package's lookup helper fails to properly validate
templates, allowing attackers to submit templates that execute arbitrary
JavaScript in the system. It is due to an incomplete fix for a previous
issue. This vulnerability can be used to run arbitrary code in a server
processing Handlebars templates or on a victim's browser
(effectively serving as Cross-Site Scripting).

see https://www.npmjs.com/advisories/1324
see https://www.npmjs.com/advisories/1316