### PR TITLE
fix: enable rsjf's safeRenderCompletion hack to prevent cursor jumps

### DIFF
--- a/app/containers/Forms/Form.tsx
+++ b/app/containers/Forms/Form.tsx
@@ -75,6 +75,7 @@ export const FormComponent: React.FunctionComponent<Props> = ({
       <JsonSchemaForm
         omitExtraData
         liveOmit
+        safeRenderCompletion
         showErrorList={false}
         ArrayFieldTemplate={FormArrayFieldTemplate}
         FieldTemplate={FormFieldTemplate}

--- a/app/containers/User/UserForm.tsx
+++ b/app/containers/User/UserForm.tsx
@@ -94,6 +94,7 @@ const UserForm: React.FunctionComponent<Props> = ({
     <JsonSchemaForm
       omitExtraData
       liveOmit
+      safeRenderCompletion
       schema={userSchema}
       formData={user}
       showErrorList={false}

--- a/app/tests/containers/Forms/__snapshots__/Form.test.tsx.snap
+++ b/app/tests/containers/Forms/__snapshots__/Form.test.tsx.snap
@@ -1688,7 +1688,7 @@ exports[`Form should match the snapshot with the production form 1`] = `
     noHtml5Validate={false}
     noValidate={false}
     omitExtraData={true}
-    safeRenderCompletion={false}
+    safeRenderCompletion={true}
     schema={
       Object {
         "definitions": Object {


### PR DESCRIPTION
See: https://github.com/rjsf-team/react-jsonschema-form/issues/1197