### PR TITLE
fix (eslint): delete includes in tsconfig to fix error on new files

### DIFF
--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -28,11 +28,5 @@
   },
   "exclude": [
     "node_modules"
-  ],
-  "include": [
-    "**/*.js",
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
   ]
 }


### PR DESCRIPTION
The includes wasn't really needed anyway as it was matching every tsx? and js files. However, I assume that typescript-eslint was listing the files/folders matching the globs when starting to watch the project, so new files were not in that list, causing it to complain about the file not being included in the project, and requiring us to restart the IDE. Now the app folder itself is included (except what is defined in the `excluded` array), so newly added files match that.