### PR TITLE
fix: remove unused 'diff' dependency

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -109,7 +109,6 @@
     "bootstrap": "^3.4.1",
     "cors": "^2.8.5",
     "deep-diff": "^1.0.2",
-    "diff": "^4.0.1",
     "dotenv": "^8.2.0",
     "dotenv-webpack": "^1.7.0",
     "express": "^4.17.1",


### PR DESCRIPTION
 -yarn remove 'diff'