### PR TITLE
Fix a couple backend bugs

### DIFF
--- a/schema/deploy/database_functions/graphile_worker_job_definer.sql
+++ b/schema/deploy/database_functions/graphile_worker_job_definer.sql
@@ -8,6 +8,6 @@ returns void as $$
   begin
     perform graphile_worker.add_job(task, payload);
   end;
-$$ language plpgsql volatile;
+$$ language plpgsql volatile security definer;
 
 commit;

--- a/schema/deploy/trigger_functions/checksum_form_results.sql
+++ b/schema/deploy/trigger_functions/checksum_form_results.sql
@@ -29,9 +29,8 @@ begin
                                           and fr.version_number = new.version_number - 1)));
 
       if new_form_result_hash != old_form_result_hash then
-        update ggircs_portal.form_result_status frs set form_result_status = 'needs attention'
-        where frs.application_id = new.application_id
-        and frs.form_id = temp_row.form_id;
+        insert into ggircs_portal.form_result_status(application_id, form_id, form_result_status)
+        values (new.application_id, temp_row.form_id, 'needs attention');
       end if;
 
     end loop;

--- a/schema/deploy/trigger_functions/checksum_form_results.sql
+++ b/schema/deploy/trigger_functions/checksum_form_results.sql
@@ -38,7 +38,7 @@ begin
 
   return new;
 end;
-$$ language plpgsql;
+$$ language plpgsql volatile;
 
 grant execute on function ggircs_portal.checksum_form_results to ciip_administrator, ciip_analyst, ciip_industry_user;
 

--- a/schema/test/unit/trigger_functions/checksum_form_results_test.sql
+++ b/schema/test/unit/trigger_functions/checksum_form_results_test.sql
@@ -26,6 +26,8 @@ $$
   offset 2;
 $$ language sql;
 
+truncate ggircs_portal.application cascade;
+
 -- Call create application_mutation_chain to create a test application
 select ggircs_portal.create_application_mutation_chain((select id from ggircs_portal.facility where facility_name = 'test facility'));
 
@@ -74,14 +76,14 @@ values ((select max(id) from ggircs_portal.application), 2, 'signed');
 insert into ggircs_portal.application_revision_status(application_id, version_number, application_revision_status)
 values ((select max(id) from ggircs_portal.application), 2, 'submitted');
 
-
 -- Test trigger
 select results_eq(
   $$
     select form_result_status
       from ggircs_portal.form_result_status
       where application_id = (select max(id) from ggircs_portal.application)
-      and form_id = 1;
+      and form_id = 1
+      order by 1 desc limit 1;
   $$,
   ARRAY['needs attention'::ggircs_portal.ciip_form_result_status],
   'checksum_form_results trigger changes status to "needs attention" if form_result has changed'


### PR DESCRIPTION
- missing `security definer` declaration in graphile_worker_job_definer
- checksum_form_results() was updating form_result_status in place instead of inserting a new one.