### PR TITLE
Certifier-related email triggers

### DIFF
--- a/app/containers/Applications/ApplicationRecertificationContainer.tsx
+++ b/app/containers/Applications/ApplicationRecertificationContainer.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {Card} from 'react-bootstrap';
+import updateCertificationUrlMutation from 'mutations/form/updateCertificationUrlMutation';
+import {createFragmentContainer, graphql, RelayProp} from 'react-relay';
+import {ApplicationRecertificationContainer_certificationUrl} from 'ApplicationRecertificationContainer_certificationUrl.graphql';
+
+interface Props {
+  certificationUrl: ApplicationRecertificationContainer_certificationUrl;
+  relay: RelayProp;
+}
+
+export const ApplicationRecertification: React.FunctionComponent<Props> = ({
+  certificationUrl,
+  relay
+}) => {
+  const sendRecertificationRequest = async () => {
+    const {environment} = relay;
+    const variables = {
+      input: {
+        id: certificationUrl.id,
+        certificationUrlPatch: {
+          recertificationRequestSent: true
+        }
+      }
+    };
+    const response = await updateCertificationUrlMutation(
+      environment,
+      variables
+    );
+    console.log(response);
+  };
+
+  if (
+    !certificationUrl.hashMatches &&
+    !certificationUrl.recertificationRequestSent
+  )
+    sendRecertificationRequest();
+
+  return (
+    <Card className="text-center">
+      <Card.Header>Error</Card.Header>
+      <Card.Body>
+        <Card.Title>The data has changed</Card.Title>
+        <Card.Text>
+          The application data associated with this certification URL has been
+          modified after the URL was generated.
+        </Card.Text>
+        <Card.Text>
+          A notification has been automatically sent to the reporter requesting
+          the submission of a new URL with the updated application data.
+        </Card.Text>
+      </Card.Body>
+      <Card.Footer className="text-muted">
+        No action is required on your part
+      </Card.Footer>
+    </Card>
+  );
+};
+
+export default createFragmentContainer(ApplicationRecertification, {
+  certificationUrl: graphql`
+    fragment ApplicationRecertificationContainer_certificationUrl on CertificationUrl {
+      id
+      hashMatches
+      recertificationRequestSent
+    }
+  `
+});

--- a/app/containers/Applications/ApplicationWizardConfirmation.tsx
+++ b/app/containers/Applications/ApplicationWizardConfirmation.tsx
@@ -27,7 +27,6 @@ interface Target extends EventTarget {
 export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Props> = props => {
   const [copySuccess, setCopySuccess] = useState('');
   const [url, setUrl] = useState();
-  const [urlSent, setUrlSent] = useState(false);
   const copyArea = useRef(url);
   const revision = props.application.latestDraftRevision;
 
@@ -88,7 +87,6 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
         updateVariables
       );
       console.log(updateResponse);
-      setUrlSent(true);
     } catch (error) {
       throw new Error(error);
     }
@@ -147,7 +145,7 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
           Thank you for reviewing the application information. You may now send
           a generated Certification url to be signed prior to submission.
         </h5>
-        {url || urlSent ? copyUrl : generateCertification}
+        {url ? copyUrl : generateCertification}
       </>
     );
   } else if (

--- a/app/containers/Applications/ApplicationWizardConfirmation.tsx
+++ b/app/containers/Applications/ApplicationWizardConfirmation.tsx
@@ -27,6 +27,7 @@ interface Target extends EventTarget {
 export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Props> = props => {
   const [copySuccess, setCopySuccess] = useState('');
   const [url, setUrl] = useState();
+  const [urlSent, setUrlSent] = useState(false);
   const copyArea = useRef(url);
   const revision = props.application.latestDraftRevision;
 
@@ -87,6 +88,7 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
         updateVariables
       );
       console.log(updateResponse);
+      setUrlSent(true);
     } catch (error) {
       throw new Error(error);
     }
@@ -145,7 +147,7 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
           Thank you for reviewing the application information. You may now send
           a generated Certification url to be signed prior to submission.
         </h5>
-        {url ? copyUrl : generateCertification}
+        {url || urlSent ? copyUrl : generateCertification}
       </>
     );
   } else if (

--- a/app/containers/Applications/ApplicationWizardConfirmation.tsx
+++ b/app/containers/Applications/ApplicationWizardConfirmation.tsx
@@ -145,7 +145,13 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
           Thank you for reviewing the application information. You may now send
           a generated Certification url to be signed prior to submission.
         </h5>
-        {url ? copyUrl : generateCertification}
+        {url ? (
+          <>
+            <span style={{color: 'green'}}>{copySuccess}</span> {copyUrl}
+          </>
+        ) : (
+          generateCertification
+        )}
       </>
     );
   } else if (
@@ -178,7 +184,14 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
           </Card.Body>
           <Card.Footer />
         </Card>
-        {generateCertification}
+        {url ? (
+          <>
+            <span style={{color: 'green'}}>URL sent!</span>
+            {copyUrl}
+          </>
+        ) : (
+          generateCertification
+        )}
       </>
     );
   }

--- a/app/containers/Applications/ApplicationWizardConfirmation.tsx
+++ b/app/containers/Applications/ApplicationWizardConfirmation.tsx
@@ -5,6 +5,7 @@ import SubmitApplication from 'components/SubmitApplication';
 import {ApplicationWizardConfirmation_query} from 'ApplicationWizardConfirmation_query.graphql';
 import {ApplicationWizardConfirmation_application} from 'ApplicationWizardConfirmation_application.graphql';
 import createCertificationUrlMutation from 'mutations/form/createCertificationUrl';
+import updateCertificationUrlMutation from 'mutations/form/updateCertificationUrlMutation';
 import ApplicationDetailsContainer from './ApplicationDetailsContainer';
 /*
  * The ApplicationWizardConfirmation renders a summary of the data submitted in the application,
@@ -41,8 +42,7 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
                but the actual rowId is generated on the postgres level with a trigger, so a placeholder rowId is set here */
           rowId: 'placeholder',
           applicationId: props.application.rowId,
-          versionNumber: revision.versionNumber,
-          formResultsMd5: 'placeholder'
+          versionNumber: revision.versionNumber
         }
       }
     };
@@ -59,6 +59,23 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
           response.createCertificationUrl.certificationUrl.rowId
         )}&id=${encodeURIComponent(props.application.id)}`
       );
+      const updateVariables = {
+        input: {
+          id: response.createCertificationUrl.certificationUrl.id,
+          certificationUrlPatch: {
+            certifierUrl: `${
+              window.location.host
+            }/certifier/certification-redirect?rowId=${encodeURIComponent(
+              response.createCertificationUrl.certificationUrl.rowId
+            )}&id=${encodeURIComponent(props.application.id)}`
+          }
+        }
+      };
+      const updateResponse = await updateCertificationUrlMutation(
+        environment,
+        updateVariables
+      );
+      console.log(updateResponse);
     } catch (error) {
       throw new Error(error);
     }

--- a/app/containers/Applications/ApplicationWizardConfirmation.tsx
+++ b/app/containers/Applications/ApplicationWizardConfirmation.tsx
@@ -111,7 +111,7 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
           </Col>
           <Col md={2}>
             <Button variant="primary" type="submit">
-              Send
+              Send to Certifier
             </Button>
           </Col>
         </Form.Row>

--- a/app/cypress/integration/reporter-access-all-pages.spec.js
+++ b/app/cypress/integration/reporter-access-all-pages.spec.js
@@ -30,8 +30,9 @@ describe('When logged in as a reporter', () => {
     );
     cy.url().should('include', '/reporter/ciip-application');
     cy.get('.btn')
-      .contains('Generate')
+      .contains('Send to Certifier')
       .click();
+    cy.wait(500); // Wait for half second (otherwise cypress gets the input before the value has been set)
     cy.get('input')
       .invoke('val')
       .should('contain', 'localhost');

--- a/app/mutations/form/createCertificationUrl.ts
+++ b/app/mutations/form/createCertificationUrl.ts
@@ -12,6 +12,7 @@ const mutation = graphql`
   ) {
     createCertificationUrl(input: $input) {
       certificationUrl {
+        id
         rowId
       }
     }

--- a/app/package.json
+++ b/app/package.json
@@ -55,6 +55,7 @@
       }
     },
     "rules": {
+      "cypress/no-unnecessary-waiting": 0,
       "@typescript-eslint/indent": 0,
       "@typescript-eslint/semi": 0,
       "@typescript-eslint/no-var-requires": 0,

--- a/app/pages/certifier/certify.tsx
+++ b/app/pages/certifier/certify.tsx
@@ -3,6 +3,7 @@ import {graphql} from 'react-relay';
 import {Card} from 'react-bootstrap';
 import {certifyQueryResponse} from 'certifyQuery.graphql';
 import ApplicationDetailsContainer from 'containers/Applications/ApplicationDetailsContainer';
+import ApplicationRecertificationContainer from 'containers/Applications/ApplicationRecertificationContainer';
 import CertificationSignature from 'containers/Forms/CertificationSignature';
 import DefaultLayout from 'layouts/default-layout';
 import LegalDisclaimerChecklist from 'components/LegalDisclaimerChecklist';
@@ -38,6 +39,7 @@ class Certify extends Component<Props> {
             certificationUrl {
               certificationSignature
               hashMatches
+              ...ApplicationRecertificationContainer_certificationUrl
             }
           }
           ...CertificationSignature_application
@@ -124,24 +126,11 @@ class Certify extends Component<Props> {
               {Signature}
             </>
           ) : (
-            <Card className="text-center">
-              <Card.Header>Error</Card.Header>
-              <Card.Body>
-                <Card.Title>The data has changed</Card.Title>
-                <Card.Text>
-                  The application data associated with this certification URL
-                  has been modified after the URL was generated.
-                </Card.Text>
-                <Card.Text>
-                  A notification has been automatically sent to the reporter
-                  requesting the submission of a new URL with the updated
-                  application data.
-                </Card.Text>
-              </Card.Body>
-              <Card.Footer className="text-muted">
-                No action is required on your part
-              </Card.Footer>
-            </Card>
+            <ApplicationRecertificationContainer
+              certificationUrl={
+                query.application.latestDraftRevision.certificationUrl
+              }
+            />
           )}
         </DefaultLayout>
         <style jsx global>

--- a/app/server/emailTemplates/certificationRequest.js
+++ b/app/server/emailTemplates/certificationRequest.js
@@ -1,4 +1,4 @@
-const createConfirmationMail = ({
+const createCertificationRequestMail = ({
   firstName,
   lastName,
   email,
@@ -36,4 +36,4 @@ const createConfirmationMail = ({
   `;
 };
 
-module.exports = createConfirmationMail;
+module.exports = createCertificationRequestMail;

--- a/app/server/emailTemplates/certificationRequest.js
+++ b/app/server/emailTemplates/certificationRequest.js
@@ -1,0 +1,39 @@
+const createConfirmationMail = ({
+  firstName,
+  lastName,
+  email,
+  facilityName,
+  operatorName,
+  reporterEmail,
+  certifierUrl
+}) => {
+  return `
+    <table align="center" border="1" cellpadding="0" cellspacing="0" width="600">
+      <tr>
+        <td style="padding: 40px 0 30px 0; " align="center">
+          <h2 style="text-decoration: underline">Province of British Columbia</h2>
+          <h3>Clean BC Industrial Incentive Program</h3>
+        </td>
+      </tr>
+      <tr style="border-top: 0px">
+        <td style="padding: 20px 10px 30px 10px;" >
+          <h3>Your certification is requested.</h3>
+          <p>
+            <strong>${firstName} ${lastName} (${reporterEmail})</strong>, on behalf of <strong>${operatorName}</strong> for facility <strong>${facilityName}</strong>
+            has requested that you review, verify and sign off on the data contained in this CIIP application. Follow the link below to view
+            a summary of the data.
+          </p>
+          <br/>
+          <a href=${certifierUrl}>CIIP Application</a>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding: 20px 10px 30px 10px;">
+        <p>Sent to: ${email}</p>
+        <p>On behalf of the Climate Action Secretariat &amp; the CleanBC Industrial Incentive Program</p></td>
+      </tr>
+    </table>
+  `;
+};
+
+module.exports = createConfirmationMail;

--- a/app/server/emailTemplates/recertificationRequest.js
+++ b/app/server/emailTemplates/recertificationRequest.js
@@ -3,10 +3,7 @@ const createSignedByCertifierMail = ({
   firstName,
   lastName,
   facilityName,
-  operatorName,
-  certifierEmail,
-  certifierFirstName,
-  certifierLastName
+  operatorName
 }) => {
   return `
     <table align="center" border="1" cellpadding="0" cellspacing="0" width="600">
@@ -19,7 +16,12 @@ const createSignedByCertifierMail = ({
       <tr style="border-top: 0px">
         <td style="padding: 20px 10px 30px 10px;" >
           <h3>Hello, <strong>${firstName} ${lastName}</strong>.</h3>
-          <h4>Your CIIP Application has been signed by your certifier, <strong>${certifierFirstName} ${certifierLastName}</strong> (${certifierEmail}).</h4>
+          <h4>Your CIIP Application requires a new certificaton URL.</h4>
+          <p>
+            Your certifier attempted to review your application, however the data has been
+            changed since the certification URL was generated. A new URl needs to be generated and sent to the certifier from
+            the Application Summary page
+          </p>
           <h4>Application Details:</h4>
           <p>Operator: ${operatorName}</p>
           <p>Facility: ${facilityName}</p>

--- a/app/server/emailTemplates/recertificationRequest.js
+++ b/app/server/emailTemplates/recertificationRequest.js
@@ -1,4 +1,4 @@
-const createSignedByCertifierMail = ({
+const createRecertificationRequestMail = ({
   email,
   firstName,
   lastName,
@@ -19,7 +19,7 @@ const createSignedByCertifierMail = ({
           <h4>Your CIIP Application requires a new certificaton URL.</h4>
           <p>
             Your certifier attempted to review your application, however the data has been
-            changed since the certification URL was generated. A new URl needs to be generated and sent to the certifier from
+            changed since the certification URL was generated. A new URL needs to be generated and sent to the certifier from
             the Application Summary page
           </p>
           <h4>Application Details:</h4>
@@ -38,4 +38,4 @@ const createSignedByCertifierMail = ({
   `;
 };
 
-module.exports = createSignedByCertifierMail;
+module.exports = createRecertificationRequestMail;

--- a/app/server/emailTemplates/signedByCertifier.js
+++ b/app/server/emailTemplates/signedByCertifier.js
@@ -1,0 +1,39 @@
+const createAmendmentMail = ({
+  email,
+  firstName,
+  lastName,
+  facilityName,
+  operatorName,
+  certifierEmail,
+  certifierFirstName,
+  certifierLastName
+}) => {
+  return `
+    <table align="center" border="1" cellpadding="0" cellspacing="0" width="600">
+      <tr>
+        <td style="padding: 40px 0 30px 0; " align="center">
+          <h2 style="text-decoration: underline">Province of British Columbia</h2>
+          <h3>Clean BC Industrial Incentive Program</h3>
+        </td>
+      </tr>
+      <tr style="border-top: 0px">
+        <td style="padding: 20px 10px 30px 10px;" >
+          <h3>Hello, <strong>${firstName} ${lastName}</strong>.</h3>
+          <h4>Your CIIP Application has been signed by your certifier, <strong>${certifierFirstName} ${certifierLastName}</strong> (${certifierEmail}).</h4>
+          <h4>Application Details:</h4>
+          <p>Operator: ${operatorName}</p>
+          <p>Facility: ${facilityName}</p>
+          <br/>
+          <a href="http://localhost:3004">CIIP Portal</a>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding: 20px 10px 30px 10px;">
+        <p>Sent to: ${email}</p>
+        <p>On behalf of the Climate Action Secretariat &amp; the CleanBC Industrial Incentive Program</p></td>
+      </tr>
+    </table>
+  `;
+};
+
+module.exports = createAmendmentMail;

--- a/app/server/schema.graphql
+++ b/app/server/schema.graphql
@@ -1318,6 +1318,8 @@ type CertificationUrl implements Node {
   Reads a single `ApplicationRevision` that is related to this `CertificationUrl`.
   """
   applicationRevisionByApplicationIdAndVersionNumber: ApplicationRevision
+  certificationRequestSentAt: Datetime
+  certificationRequestSentTo: String
 
   """The base64 representation of the certifier's signature"""
   certificationSignature: String
@@ -1327,6 +1329,7 @@ type CertificationUrl implements Node {
 
   """The user id of the certifier references ggircs_portal.ciip_user"""
   certifiedBy: Int
+  certifierUrl: String
 
   """Reads a single `CiipUser` that is related to this `CertificationUrl`."""
   ciipUserByCertifiedBy: CiipUser
@@ -1392,6 +1395,16 @@ input CertificationUrlCondition {
   """Checks for equality with the object’s `applicationId` field."""
   applicationId: Int
 
+  """
+  Checks for equality with the object’s `certificationRequestSentAt` field.
+  """
+  certificationRequestSentAt: Datetime
+
+  """
+  Checks for equality with the object’s `certificationRequestSentTo` field.
+  """
+  certificationRequestSentTo: String
+
   """Checks for equality with the object’s `certificationSignature` field."""
   certificationSignature: String
 
@@ -1400,6 +1413,9 @@ input CertificationUrlCondition {
 
   """Checks for equality with the object’s `certifiedBy` field."""
   certifiedBy: Int
+
+  """Checks for equality with the object’s `certifierUrl` field."""
+  certifierUrl: String
 
   """Checks for equality with the object’s `createdAt` field."""
   createdAt: Datetime
@@ -1436,6 +1452,8 @@ input CertificationUrlCondition {
 input CertificationUrlInput {
   """Foreign key to the application"""
   applicationId: Int!
+  certificationRequestSentAt: Datetime
+  certificationRequestSentTo: String
 
   """The base64 representation of the certifier's signature"""
   certificationSignature: String
@@ -1445,6 +1463,7 @@ input CertificationUrlInput {
 
   """The user id of the certifier references ggircs_portal.ciip_user"""
   certifiedBy: Int
+  certifierUrl: String
 
   """Creation date of row"""
   createdAt: Datetime
@@ -1485,6 +1504,8 @@ Represents an update to a `CertificationUrl`. Fields that are set will be update
 input CertificationUrlPatch {
   """Foreign key to the application"""
   applicationId: Int
+  certificationRequestSentAt: Datetime
+  certificationRequestSentTo: String
 
   """The base64 representation of the certifier's signature"""
   certificationSignature: String
@@ -1494,6 +1515,7 @@ input CertificationUrlPatch {
 
   """The user id of the certifier references ggircs_portal.ciip_user"""
   certifiedBy: Int
+  certifierUrl: String
 
   """Creation date of row"""
   createdAt: Datetime
@@ -1560,12 +1582,18 @@ type CertificationUrlsEdge {
 enum CertificationUrlsOrderBy {
   APPLICATION_ID_ASC
   APPLICATION_ID_DESC
+  CERTIFICATION_REQUEST_SENT_AT_ASC
+  CERTIFICATION_REQUEST_SENT_AT_DESC
+  CERTIFICATION_REQUEST_SENT_TO_ASC
+  CERTIFICATION_REQUEST_SENT_TO_DESC
   CERTIFICATION_SIGNATURE_ASC
   CERTIFICATION_SIGNATURE_DESC
   CERTIFIED_AT_ASC
   CERTIFIED_AT_DESC
   CERTIFIED_BY_ASC
   CERTIFIED_BY_DESC
+  CERTIFIER_URL_ASC
+  CERTIFIER_URL_DESC
   CREATED_AT_ASC
   CREATED_AT_DESC
   CREATED_BY_ASC

--- a/app/server/schema.graphql
+++ b/app/server/schema.graphql
@@ -1318,7 +1318,11 @@ type CertificationUrl implements Node {
   Reads a single `ApplicationRevision` that is related to this `CertificationUrl`.
   """
   applicationRevisionByApplicationIdAndVersionNumber: ApplicationRevision
+
+  """The time at which the certification request was sent"""
   certificationRequestSentAt: Datetime
+
+  """The email that the certification request was sent to"""
   certificationRequestSentTo: String
 
   """The base64 representation of the certifier's signature"""
@@ -1329,6 +1333,8 @@ type CertificationUrl implements Node {
 
   """The user id of the certifier references ggircs_portal.ciip_user"""
   certifiedBy: Int
+
+  """The URL sent to the certifier"""
   certifierUrl: String
 
   """Reads a single `CiipUser` that is related to this `CertificationUrl`."""
@@ -1452,7 +1458,11 @@ input CertificationUrlCondition {
 input CertificationUrlInput {
   """Foreign key to the application"""
   applicationId: Int!
+
+  """The time at which the certification request was sent"""
   certificationRequestSentAt: Datetime
+
+  """The email that the certification request was sent to"""
   certificationRequestSentTo: String
 
   """The base64 representation of the certifier's signature"""
@@ -1463,6 +1473,8 @@ input CertificationUrlInput {
 
   """The user id of the certifier references ggircs_portal.ciip_user"""
   certifiedBy: Int
+
+  """The URL sent to the certifier"""
   certifierUrl: String
 
   """Creation date of row"""
@@ -1504,7 +1516,11 @@ Represents an update to a `CertificationUrl`. Fields that are set will be update
 input CertificationUrlPatch {
   """Foreign key to the application"""
   applicationId: Int
+
+  """The time at which the certification request was sent"""
   certificationRequestSentAt: Datetime
+
+  """The email that the certification request was sent to"""
   certificationRequestSentTo: String
 
   """The base64 representation of the certifier's signature"""
@@ -1515,6 +1531,8 @@ input CertificationUrlPatch {
 
   """The user id of the certifier references ggircs_portal.ciip_user"""
   certifiedBy: Int
+
+  """The URL sent to the certifier"""
   certifierUrl: String
 
   """Creation date of row"""

--- a/app/server/schema.graphql
+++ b/app/server/schema.graphql
@@ -1377,6 +1377,10 @@ type CertificationUrl implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   id: ID!
+
+  """
+  Boolean for whether a recertification request has been sent to the reporter in the case of a data change
+  """
   recertificationRequestSent: Boolean
 
   """Unique ID for the certification_url"""
@@ -1500,6 +1504,10 @@ input CertificationUrlInput {
 
   """The hash of all form results at the time the signature was added"""
   formResultsMd5: String
+
+  """
+  Boolean for whether a recertification request has been sent to the reporter in the case of a data change
+  """
   recertificationRequestSent: Boolean
 
   """Unique ID for the certification_url"""
@@ -1559,6 +1567,10 @@ input CertificationUrlPatch {
 
   """The hash of all form results at the time the signature was added"""
   formResultsMd5: String
+
+  """
+  Boolean for whether a recertification request has been sent to the reporter in the case of a data change
+  """
   recertificationRequestSent: Boolean
 
   """Unique ID for the certification_url"""

--- a/app/server/schema.graphql
+++ b/app/server/schema.graphql
@@ -1377,6 +1377,7 @@ type CertificationUrl implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   id: ID!
+  recertificationRequestSent: Boolean
 
   """Unique ID for the certification_url"""
   rowId: String!
@@ -1441,6 +1442,11 @@ input CertificationUrlCondition {
   """Checks for equality with the object’s `formResultsMd5` field."""
   formResultsMd5: String
 
+  """
+  Checks for equality with the object’s `recertificationRequestSent` field.
+  """
+  recertificationRequestSent: Boolean
+
   """Checks for equality with the object’s `rowId` field."""
   rowId: String
 
@@ -1494,6 +1500,7 @@ input CertificationUrlInput {
 
   """The hash of all form results at the time the signature was added"""
   formResultsMd5: String
+  recertificationRequestSent: Boolean
 
   """Unique ID for the certification_url"""
   rowId: String!
@@ -1552,6 +1559,7 @@ input CertificationUrlPatch {
 
   """The hash of all form results at the time the signature was added"""
   formResultsMd5: String
+  recertificationRequestSent: Boolean
 
   """Unique ID for the certification_url"""
   rowId: String
@@ -1629,6 +1637,8 @@ enum CertificationUrlsOrderBy {
   NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
+  RECERTIFICATION_REQUEST_SENT_ASC
+  RECERTIFICATION_REQUEST_SENT_DESC
   UPDATED_AT_ASC
   UPDATED_AT_DESC
   UPDATED_BY_ASC

--- a/app/server/schema.json
+++ b/app/server/schema.json
@@ -14420,6 +14420,16 @@
               "defaultValue": null
             },
             {
+              "name": "recertificationRequestSent",
+              "description": "Checks for equality with the object’s `recertificationRequestSent` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
               "name": "rowId",
               "description": "Checks for equality with the object’s `rowId` field.",
               "type": {
@@ -14654,6 +14664,18 @@
             },
             {
               "name": "PRIMARY_KEY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RECERTIFICATION_REQUEST_SENT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RECERTIFICATION_REQUEST_SENT_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -15088,6 +15110,18 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "recertificationRequestSent",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -31621,6 +31655,16 @@
               "defaultValue": null
             },
             {
+              "name": "recertificationRequestSent",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
               "name": "rowId",
               "description": "Unique ID for the certification_url",
               "type": {
@@ -42019,6 +42063,16 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "recertificationRequestSent",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null

--- a/app/server/schema.json
+++ b/app/server/schema.json
@@ -14866,7 +14866,7 @@
             },
             {
               "name": "certificationRequestSentAt",
-              "description": null,
+              "description": "The time at which the certification request was sent",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -14878,7 +14878,7 @@
             },
             {
               "name": "certificationRequestSentTo",
-              "description": null,
+              "description": "The email that the certification request was sent to",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -14926,7 +14926,7 @@
             },
             {
               "name": "certifierUrl",
-              "description": null,
+              "description": "The URL sent to the certifier",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -31502,7 +31502,7 @@
             },
             {
               "name": "certificationRequestSentAt",
-              "description": null,
+              "description": "The time at which the certification request was sent",
               "type": {
                 "kind": "SCALAR",
                 "name": "Datetime",
@@ -31512,7 +31512,7 @@
             },
             {
               "name": "certificationRequestSentTo",
-              "description": null,
+              "description": "The email that the certification request was sent to",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -31552,7 +31552,7 @@
             },
             {
               "name": "certifierUrl",
-              "description": null,
+              "description": "The URL sent to the certifier",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -41905,7 +41905,7 @@
             },
             {
               "name": "certificationRequestSentAt",
-              "description": null,
+              "description": "The time at which the certification request was sent",
               "type": {
                 "kind": "SCALAR",
                 "name": "Datetime",
@@ -41915,7 +41915,7 @@
             },
             {
               "name": "certificationRequestSentTo",
-              "description": null,
+              "description": "The email that the certification request was sent to",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -41955,7 +41955,7 @@
             },
             {
               "name": "certifierUrl",
-              "description": null,
+              "description": "The URL sent to the certifier",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",

--- a/app/server/schema.json
+++ b/app/server/schema.json
@@ -14300,6 +14300,26 @@
               "defaultValue": null
             },
             {
+              "name": "certificationRequestSentAt",
+              "description": "Checks for equality with the object’s `certificationRequestSentAt` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "certificationRequestSentTo",
+              "description": "Checks for equality with the object’s `certificationRequestSentTo` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
               "name": "certificationSignature",
               "description": "Checks for equality with the object’s `certificationSignature` field.",
               "type": {
@@ -14325,6 +14345,16 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "certifierUrl",
+              "description": "Checks for equality with the object’s `certifierUrl` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "defaultValue": null
@@ -14455,6 +14485,30 @@
               "deprecationReason": null
             },
             {
+              "name": "CERTIFICATION_REQUEST_SENT_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CERTIFICATION_REQUEST_SENT_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CERTIFICATION_REQUEST_SENT_TO_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CERTIFICATION_REQUEST_SENT_TO_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "CERTIFICATION_SIGNATURE_ASC",
               "description": null,
               "isDeprecated": false,
@@ -14486,6 +14540,18 @@
             },
             {
               "name": "CERTIFIED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CERTIFIER_URL_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CERTIFIER_URL_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -14799,6 +14865,30 @@
               "deprecationReason": null
             },
             {
+              "name": "certificationRequestSentAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "certificationRequestSentTo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "certificationSignature",
               "description": "The base64 representation of the certifier's signature",
               "args": [],
@@ -14829,6 +14919,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "certifierUrl",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -31399,6 +31501,26 @@
               "defaultValue": null
             },
             {
+              "name": "certificationRequestSentAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "certificationRequestSentTo",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
               "name": "certificationSignature",
               "description": "The base64 representation of the certifier's signature",
               "type": {
@@ -31424,6 +31546,16 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "certifierUrl",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "defaultValue": null
@@ -41772,6 +41904,26 @@
               "defaultValue": null
             },
             {
+              "name": "certificationRequestSentAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "certificationRequestSentTo",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
               "name": "certificationSignature",
               "description": "The base64 representation of the certifier's signature",
               "type": {
@@ -41797,6 +41949,16 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "certifierUrl",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "defaultValue": null

--- a/app/server/schema.json
+++ b/app/server/schema.json
@@ -15116,7 +15116,7 @@
             },
             {
               "name": "recertificationRequestSent",
-              "description": null,
+              "description": "Boolean for whether a recertification request has been sent to the reporter in the case of a data change",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -31656,7 +31656,7 @@
             },
             {
               "name": "recertificationRequestSent",
-              "description": null,
+              "description": "Boolean for whether a recertification request has been sent to the reporter in the case of a data change",
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
@@ -42069,7 +42069,7 @@
             },
             {
               "name": "recertificationRequestSent",
-              "description": null,
+              "description": "Boolean for whether a recertification request has been sent to the reporter in the case of a data change",
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",

--- a/app/server/tasks/sendMail.js
+++ b/app/server/tasks/sendMail.js
@@ -3,6 +3,7 @@ const createWelcomeMail = require('../emailTemplates/welcome.js');
 const createConfirmationMail = require('../emailTemplates/confirmation.js');
 const createAmendmentMail = require('../emailTemplates/amendment.js');
 const createCertificationRequestMail = require('../emailTemplates/certificationRequest.js');
+const createSignedByCertifierMail = require('../emailTemplates/signedByCertifier.js');
 const dotenv = require('dotenv');
 dotenv.config();
 
@@ -15,8 +16,8 @@ module.exports = async ({
   operatorName,
   status,
   reporterEmail,
-  // CertifierFirstName,
-  // certifierLastName,
+  certifierFirstName,
+  certifierLastName,
   certifierUrl
 }) => {
   if (!process.env.SMTP_CONNECTION_STRING)
@@ -72,6 +73,20 @@ module.exports = async ({
         operatorName,
         reporterEmail,
         certifierUrl
+      });
+      break;
+    // Certifier signs application
+    case 'signed_by_certifier':
+      subject = 'CIIP application certified';
+      htmlContent = createSignedByCertifierMail({
+        reporterEmail,
+        firstName,
+        lastName,
+        facilityName,
+        operatorName,
+        email,
+        certifierFirstName,
+        certifierLastName
       });
       break;
     default:

--- a/app/server/tasks/sendMail.js
+++ b/app/server/tasks/sendMail.js
@@ -2,6 +2,7 @@ const nodemailer = require('nodemailer');
 const createWelcomeMail = require('../emailTemplates/welcome.js');
 const createConfirmationMail = require('../emailTemplates/confirmation.js');
 const createAmendmentMail = require('../emailTemplates/amendment.js');
+const createCertificationRequestMail = require('../emailTemplates/certificationRequest.js');
 const dotenv = require('dotenv');
 dotenv.config();
 
@@ -12,7 +13,11 @@ module.exports = async ({
   lastName,
   facilityName,
   operatorName,
-  status
+  status,
+  reporterEmail,
+  // CertifierFirstName,
+  // certifierLastName,
+  certifierUrl
 }) => {
   if (!process.env.SMTP_CONNECTION_STRING)
     throw new Error('SMTP connection string is undefined');
@@ -54,6 +59,19 @@ module.exports = async ({
         facilityName,
         operatorName,
         status
+      });
+      break;
+    // Request for certification
+    case 'certification_request':
+      subject = 'CIIP application certification request';
+      htmlContent = createCertificationRequestMail({
+        email,
+        firstName,
+        lastName,
+        facilityName,
+        operatorName,
+        reporterEmail,
+        certifierUrl
       });
       break;
     default:

--- a/app/server/tasks/sendMail.js
+++ b/app/server/tasks/sendMail.js
@@ -119,7 +119,7 @@ module.exports = async ({
     html: htmlContent
   };
 
-  transporter.sendMail(message, (error, info) => {
+  await transporter.sendMail(message, (error, info) => {
     if (error) return console.error(error);
     console.log('Message sent: %s', info.messageId);
   });

--- a/app/server/tasks/sendMail.js
+++ b/app/server/tasks/sendMail.js
@@ -4,6 +4,7 @@ const createConfirmationMail = require('../emailTemplates/confirmation.js');
 const createAmendmentMail = require('../emailTemplates/amendment.js');
 const createCertificationRequestMail = require('../emailTemplates/certificationRequest.js');
 const createSignedByCertifierMail = require('../emailTemplates/signedByCertifier.js');
+const createRecertificationRequestMail = require('../emailTemplates/recertificationRequest.js');
 const dotenv = require('dotenv');
 dotenv.config();
 
@@ -18,7 +19,8 @@ module.exports = async ({
   reporterEmail,
   certifierFirstName,
   certifierLastName,
-  certifierUrl
+  certifierUrl,
+  certifierEmail
 }) => {
   if (!process.env.SMTP_CONNECTION_STRING)
     throw new Error('SMTP connection string is undefined');
@@ -79,14 +81,25 @@ module.exports = async ({
     case 'signed_by_certifier':
       subject = 'CIIP application certified';
       htmlContent = createSignedByCertifierMail({
-        reporterEmail,
+        email,
         firstName,
         lastName,
         facilityName,
         operatorName,
-        email,
+        certifierEmail,
         certifierFirstName,
         certifierLastName
+      });
+      break;
+    // Request for recertification (data changed)
+    case 'recertification':
+      subject = 'CIIP Application recertification request';
+      htmlContent = createRecertificationRequestMail({
+        email,
+        firstName,
+        lastName,
+        facilityName,
+        operatorName
       });
       break;
     default:

--- a/app/tests/unit/containers/Applications/ApplicationWizardConfirmation.test.tsx
+++ b/app/tests/unit/containers/Applications/ApplicationWizardConfirmation.test.tsx
@@ -64,14 +64,14 @@ describe('The Confirmation Component', () => {
         .at(1)
         .text()
     ).toBe(
-      'Thank you for reviewing the application information. You may now generate a Certification page to be signed prior to submission.'
+      'Thank you for reviewing the application information. You may now send a generated Certification url to be signed prior to submission.'
     );
     expect(
       wrapper
         .find('Button')
         .at(0)
         .text()
-    ).toBe('Generate Certification Page');
+    ).toBe('Send to Certifier');
   });
 
   it('should show the Submit application dialog when certificationSignatureIsvalid is true', () => {

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationWizardConfirmation.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationWizardConfirmation.test.tsx.snap
@@ -38,61 +38,46 @@ exports[`The Confirmation Component match the snapshot 1`] = `
   />
   <br />
   <h5>
-    Thank you for reviewing the application information. You may now generate a Certification page to be signed prior to submission.
+    Thank you for reviewing the application information. You may now send a generated Certification url to be signed prior to submission.
   </h5>
   <br />
-  <ForwardRef
-    noGutters={false}
+  <Form
+    inline={false}
+    onSubmit={[Function]}
   >
-    <Col>
-      <Button
-        active={false}
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-        variant="primary"
+    <FormRow>
+      <Col
+        md={6}
       >
-        Generate Certification Page
-      </Button>
-    </Col>
-  </ForwardRef>
-  <br />
-  <ForwardRef
-    noGutters={false}
-  >
-    <Col
-      md={6}
-    >
-      <input
-        readOnly={true}
-        style={
-          Object {
-            "width": "100%",
-          }
-        }
-      />
-    </Col>
-    <Col
-      md={2}
-    >
-      <Button
-        active={false}
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-        variant="primary"
+        <FormGroup
+          controlId="certifierEmail"
+        >
+          <FormControl
+            name="email"
+            placeholder="Enter email"
+            type="email"
+          />
+          <FormText
+            className="text-muted"
+          >
+            Send URL to certifier
+          </FormText>
+        </FormGroup>
+      </Col>
+      <Col
+        md={2}
       >
-        Copy Link
-      </Button>
-      <span
-        style={
-          Object {
-            "color": "green",
-          }
-        }
-      />
-    </Col>
-  </ForwardRef>
+        <Button
+          active={false}
+          disabled={false}
+          type="submit"
+          variant="primary"
+        >
+          Send to Certifier
+        </Button>
+      </Col>
+    </FormRow>
+  </Form>
 </Fragment>
 `;
 
@@ -139,5 +124,41 @@ exports[`The Confirmation Component should show a certifier has not yet signed m
   <h5>
     Your application has been sent to a certifier. Submission will be possible once they have verified the data in the application.
   </h5>
+  <ForwardRef
+    noGutters={false}
+  >
+    <Col
+      md={6}
+    >
+      <input
+        readOnly={true}
+        style={
+          Object {
+            "width": "100%",
+          }
+        }
+      />
+    </Col>
+    <Col
+      md={2}
+    >
+      <Button
+        active={false}
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+        variant="primary"
+      >
+        Copy Link
+      </Button>
+      <span
+        style={
+          Object {
+            "color": "green",
+          }
+        }
+      />
+    </Col>
+  </ForwardRef>
 </Fragment>
 `;

--- a/app/tests/unit/pages/__snapshots__/certify.test.tsx.snap
+++ b/app/tests/unit/pages/__snapshots__/certify.test.tsx.snap
@@ -31,6 +31,9 @@ exports[`It matches the last accepted Snapshot 1`] = `
           },
           "latestDraftRevision": Object {
             "certificationUrl": Object {
+              " $fragmentRefs": Object {
+                "ApplicationRecertificationContainer_certificationUrl": true,
+              },
               "certificationSignature": "test",
               "hashMatches": true,
             },
@@ -49,6 +52,9 @@ exports[`It matches the last accepted Snapshot 1`] = `
             },
             "latestDraftRevision": Object {
               "certificationUrl": Object {
+                " $fragmentRefs": Object {
+                  "ApplicationRecertificationContainer_certificationUrl": true,
+                },
                 "certificationSignature": "test",
                 "hashMatches": true,
               },
@@ -77,7 +83,7 @@ exports[`It matches the last accepted Snapshot 1`] = `
 </Fragment>
 `;
 
-exports[`It shows a "data has changed" error if hashMatches is false 1`] = `
+exports[`It renders ApplicationRecertificationContainer if hashMatches is false 1`] = `
 <Fragment>
   <Relay(DefaultLayout)
     allowedGroups={
@@ -99,30 +105,17 @@ exports[`It shows a "data has changed" error if hashMatches is false 1`] = `
     }
     title="Submission Certification"
   >
-    <Card
-      body={false}
-      className="text-center"
-    >
-      <CardHeader>
-        Error
-      </CardHeader>
-      <CardBody>
-        <CardTitle>
-          The data has changed
-        </CardTitle>
-        <CardText>
-          The application data associated with this certification URL has been modified after the URL was generated.
-        </CardText>
-        <CardText>
-          A notification has been automatically sent to the reporter requesting the submission of a new URL with the updated application data.
-        </CardText>
-      </CardBody>
-      <CardFooter
-        className="text-muted"
-      >
-        No action is required on your part
-      </CardFooter>
-    </Card>
+    <Relay(ApplicationRecertification)
+      certificationUrl={
+        Object {
+          " $fragmentRefs": Object {
+            "ApplicationRecertificationContainer_certificationUrl": true,
+          },
+          "certificationSignature": "test",
+          "hashMatches": false,
+        }
+      }
+    />
   </Relay(DefaultLayout)>
   <JSXStyle
     id="1964638049"

--- a/app/tests/unit/pages/certify.test.tsx
+++ b/app/tests/unit/pages/certify.test.tsx
@@ -20,7 +20,10 @@ const query = {
     latestDraftRevision: {
       certificationUrl: {
         certificationSignature: 'test',
-        hashMatches: true
+        hashMatches: true,
+        ' $fragmentRefs': {
+          ApplicationRecertificationContainer_certificationUrl: true
+        }
       }
     },
     ' $fragmentRefs': {
@@ -43,9 +46,11 @@ it('It loads the summary component & passes it the application prop if hashMatch
   ).toBe(query.application);
 });
 
-it('It shows a "data has changed" error if hashMatches is false', () => {
+it('It renders ApplicationRecertificationContainer if hashMatches is false', () => {
   query.application.latestDraftRevision.certificationUrl.hashMatches = false;
   const wrapper = shallow(<Certify query={query} />);
   expect(wrapper).toMatchSnapshot();
-  expect(wrapper.find('CardHeader').text()).toBe('Error');
+  expect(
+    wrapper.find('Relay(ApplicationRecertification)').prop('certificationUrl')
+  ).toBe(query.application.latestDraftRevision.certificationUrl);
 });

--- a/schema/data/dev/certification_url.sql
+++ b/schema/data/dev/certification_url.sql
@@ -5,6 +5,9 @@
 
 begin;
 
+alter table ggircs_portal.certification_url disable trigger _certification_request_email;
+alter table ggircs_portal.certification_url disable trigger _signed_by_certifier_email;
+
 with rows as (
 insert into ggircs_portal.certification_url(id, application_id, version_number)
 overriding system value
@@ -25,6 +28,8 @@ alter table ggircs_portal.application_revision_status disable trigger _status_ch
   insert into ggircs_portal.application_revision_status(application_id, version_number, application_revision_status)
   values (1,2,'submitted');
 
+alter table ggircs_portal.certification_url enable trigger _certification_request_email;
+alter table ggircs_portal.certification_url enable trigger _signed_by_certifier_email;
 alter table ggircs_portal.application_revision_status enable trigger _status_change_email;
 
 commit;

--- a/schema/data/fixtures/reporter-all-access-setup.sql
+++ b/schema/data/fixtures/reporter-all-access-setup.sql
@@ -5,6 +5,10 @@ alter table ggircs_portal.ciip_user_organisation
   disable trigger _set_user_id;
 alter table ggircs_portal.application_revision_status
   disable trigger _status_change_email;
+alter table ggircs_portal.certification_url
+  disable trigger _certification_request_email;
+alter table ggircs_portal.certification_url
+  disable trigger _signed_by_certifier_email;
 insert into ggircs_portal.ciip_user_organisation(user_id, organisation_id, status) values (6, 7, 'approved');
 update ggircs_portal.application_revision_status set application_revision_status = 'draft' where application_id=2 and version_number=1;
 update ggircs_portal.application_revision set legal_disclaimer_accepted = false where application_id=2 and version_number=1;

--- a/schema/data/fixtures/reporter-all-access-teardown.sql
+++ b/schema/data/fixtures/reporter-all-access-teardown.sql
@@ -9,5 +9,9 @@ alter table ggircs_portal.ciip_user_organisation
   enable trigger _set_user_id;
 alter table ggircs_portal.application_revision_status
   enable trigger _status_change_email;
+alter table ggircs_portal.certification_url
+  enable trigger _certification_request_email;
+alter table ggircs_portal.certification_url
+  enable trigger _signed_by_certifier_email;
 
 commit;

--- a/schema/deploy/tables/certification_url.sql
+++ b/schema/deploy/tables/certification_url.sql
@@ -5,6 +5,7 @@ begin;
 
 create table ggircs_portal.certification_url (
   id varchar(1000) primary key,
+  certifier_url varchar(1000),
   application_id int not null references ggircs_portal.application(id),
   version_number int not null,
   certification_signature bytea,
@@ -17,6 +18,8 @@ create table ggircs_portal.certification_url (
   updated_by int references ggircs_portal.ciip_user,
   deleted_at timestamp with time zone,
   deleted_by int references ggircs_portal.ciip_user,
+  certification_request_sent_to varchar(1000),
+  certification_request_sent_at timestamp with time zone,
   -- TODO(Dylan): revisit expiry / deprecation of generated URLs in the context of Authorization
   -- Should we allow creation of multiple URLs, should the previous ones be deprecated in that case?...etc
   expires_at timestamp with time zone not null default now(),
@@ -54,6 +57,17 @@ create trigger _set_user_id
   for each row
   execute procedure ggircs_portal.set_user_id('certification_url');
 
+create trigger _certification_request_email
+  before update of certification_request_sent_to on ggircs_portal.certification_url
+  for each row
+  execute procedure ggircs_portal_private.run_graphile_worker_job('certification_request');
+
+create trigger _signed_by_certifier_email
+  before update of certification_signature on ggircs_portal.certification_url
+  for each row
+  execute procedure ggircs_portal_private.run_graphile_worker_job('signed_by_certifier');
+
+
 do
 $grant$
 begin
@@ -67,7 +81,7 @@ perform ggircs_portal_private.grant_permissions('select', 'certification_url', '
 -- Grant ciip_industry_user permissions
 perform ggircs_portal_private.grant_permissions('select', 'certification_url', 'ciip_industry_user');
 perform ggircs_portal_private.grant_permissions('insert', 'certification_url', 'ciip_industry_user');
-perform ggircs_portal_private.grant_permissions('update', 'certification_url', 'ciip_industry_user', ARRAY['certification_signature']);
+perform ggircs_portal_private.grant_permissions('update', 'certification_url', 'ciip_industry_user', ARRAY['certification_signature', 'certifier_url']);
 
 -- Grant ciip_guest permissions
 -- ?
@@ -116,6 +130,7 @@ $policy$;
 
 comment on table ggircs_portal.certification_url is 'Table containing the certification_url for an application';
 comment on column ggircs_portal.certification_url.id is 'Unique ID for the certification_url';
+comment on column ggircs_portal.certification_url.certifier_url is 'The URL sent to the certifier';
 comment on column ggircs_portal.certification_url.application_id is 'Foreign key to the application';
 comment on column ggircs_portal.certification_url.version_number is 'The version number of the application (foreign key to application_revision along with application_id)';
 comment on column ggircs_portal.certification_url.certification_signature is 'The base64 representation of the certifier''s signature';
@@ -127,6 +142,8 @@ comment on column ggircs_portal.certification_url.created_by is 'Creator of row'
 comment on column ggircs_portal.certification_url.updated_at is 'Last update date of row';
 comment on column ggircs_portal.certification_url.updated_by is 'The user who last updated the row';
 comment on column ggircs_portal.certification_url.deleted_at is 'Deletion date of row';
+comment on column ggircs_portal.certification_url.certification_request_sent_to is 'The email that the certification request was sent to';
+comment on column ggircs_portal.certification_url.certification_request_sent_at is 'The time at which the certification request was sent';
 comment on column ggircs_portal.certification_url.deleted_by is 'The user who deleted the row';
 comment on column ggircs_portal.certification_url.expires_at is 'The expiry date for the row';
 

--- a/schema/deploy/tables/certification_url.sql
+++ b/schema/deploy/tables/certification_url.sql
@@ -20,6 +20,7 @@ create table ggircs_portal.certification_url (
   deleted_by int references ggircs_portal.ciip_user,
   certification_request_sent_to varchar(1000),
   certification_request_sent_at timestamp with time zone,
+  recertification_request_sent boolean default false,
   -- TODO(Dylan): revisit expiry / deprecation of generated URLs in the context of Authorization
   -- Should we allow creation of multiple URLs, should the previous ones be deprecated in that case?...etc
   expires_at timestamp with time zone not null default now(),
@@ -67,6 +68,11 @@ create trigger _signed_by_certifier_email
   for each row
   execute procedure ggircs_portal_private.run_graphile_worker_job('signed_by_certifier');
 
+create trigger _recertification_request
+  before update of recertification_request_sent on ggircs_portal.certification_url
+  for each row
+  execute procedure ggircs_portal_private.run_graphile_worker_job('recertification');
+
 
 do
 $grant$
@@ -81,7 +87,7 @@ perform ggircs_portal_private.grant_permissions('select', 'certification_url', '
 -- Grant ciip_industry_user permissions
 perform ggircs_portal_private.grant_permissions('select', 'certification_url', 'ciip_industry_user');
 perform ggircs_portal_private.grant_permissions('insert', 'certification_url', 'ciip_industry_user');
-perform ggircs_portal_private.grant_permissions('update', 'certification_url', 'ciip_industry_user', ARRAY['certification_signature', 'certifier_url']);
+perform ggircs_portal_private.grant_permissions('update', 'certification_url', 'ciip_industry_user', ARRAY['certification_signature', 'certifier_url', 'recertification_request_sent']);
 
 -- Grant ciip_guest permissions
 -- ?

--- a/schema/deploy/tables/certification_url.sql
+++ b/schema/deploy/tables/certification_url.sql
@@ -150,6 +150,7 @@ comment on column ggircs_portal.certification_url.updated_by is 'The user who la
 comment on column ggircs_portal.certification_url.deleted_at is 'Deletion date of row';
 comment on column ggircs_portal.certification_url.certification_request_sent_to is 'The email that the certification request was sent to';
 comment on column ggircs_portal.certification_url.certification_request_sent_at is 'The time at which the certification request was sent';
+comment on column ggircs_portal.certification_url.recertification_request_sent is 'Boolean for whether a recertification request has been sent to the reporter in the case of a data change';
 comment on column ggircs_portal.certification_url.deleted_by is 'The user who deleted the row';
 comment on column ggircs_portal.certification_url.expires_at is 'The expiry date for the row';
 

--- a/schema/deploy/tables/certification_url.sql
+++ b/schema/deploy/tables/certification_url.sql
@@ -87,7 +87,7 @@ perform ggircs_portal_private.grant_permissions('select', 'certification_url', '
 -- Grant ciip_industry_user permissions
 perform ggircs_portal_private.grant_permissions('select', 'certification_url', 'ciip_industry_user');
 perform ggircs_portal_private.grant_permissions('insert', 'certification_url', 'ciip_industry_user');
-perform ggircs_portal_private.grant_permissions('update', 'certification_url', 'ciip_industry_user', ARRAY['certification_signature', 'certifier_url', 'recertification_request_sent']);
+perform ggircs_portal_private.grant_permissions('update', 'certification_url', 'ciip_industry_user', ARRAY['certification_signature', 'certifier_url', 'recertification_request_sent', 'certification_request_sent_to']);
 
 -- Grant ciip_guest permissions
 -- ?

--- a/schema/deploy/trigger_functions/run_graphile_worker_job.sql
+++ b/schema/deploy/trigger_functions/run_graphile_worker_job.sql
@@ -124,10 +124,10 @@ begin
         perform ggircs_portal_private.graphile_worker_job_definer('sendMail',
               json_build_object(
                 'type', 'signed_by_certifier',
-                'reporterEmail', application_details.email_address,
+                'email', application_details.email_address,
                 'firstName', application_details.first_name,
                 'lastName', application_details.last_name,
-                'email', new.certification_request_sent_to,
+                'certifierEmail', new.certification_request_sent_to,
                 'facilityName', application_details.facility_name,
                 'operatorName', application_details.operator_name,
                 'certifierFirstName', certifier_details.first_name,

--- a/schema/deploy/trigger_functions/run_graphile_worker_job.sql
+++ b/schema/deploy/trigger_functions/run_graphile_worker_job.sql
@@ -6,6 +6,7 @@ begin;
 create or replace function ggircs_portal_private.run_graphile_worker_job() returns trigger as $$
 declare
   application_details record;
+  certifier_details record;
   status_change_type text;
 begin
   case
@@ -64,6 +65,73 @@ begin
               'facilityName', application_details.facility_name,
               'operatorName', application_details.operator_name,
               'status', new.application_revision_status));
+      return new;
+
+    -- **ON REQUEST FOR CERTIFICATION**
+    when tg_argv[0] = 'certification_request' then
+
+      with ad as (select o.operator_name, f.facility_name, u.first_name, u.last_name, u.email_address
+            from ggircs_portal.application_revision ar
+            join ggircs_portal.application a
+            on ar.application_id = a.id
+            and new.application_id = ar.application_id
+            and new.version_number = ar.version_number
+            join ggircs_portal.facility f
+            on a.facility_id = f.id
+            join ggircs_portal.organisation o
+            on f.organisation_id = o.id
+            join ggircs_portal.ciip_user u
+            on u.id = new.created_by
+            )
+      select operator_name, facility_name, first_name, last_name, email_address from ad into application_details;
+
+      perform ggircs_portal_private.graphile_worker_job_definer('sendMail',
+            json_build_object(
+              'type', 'certification_request',
+              'certifierUrl', new.certifier_url,
+              'reporterEmail', application_details.email_address,
+              'firstName', application_details.first_name,
+              'lastName', application_details.last_name,
+              'email', new.certification_request_sent_to,
+              'facilityName', application_details.facility_name,
+              'operatorName', application_details.operator_name));
+
+      -- timestamp when the email was sent
+      new.certification_request_sent_at = now();
+      return new;
+
+      -- **ON SIGNED BY CERTIFIER**
+      when tg_argv[0] = 'signed_by_certifier' then
+
+        with ad as (select o.operator_name, f.facility_name, u.first_name, u.last_name, u.email_address
+              from ggircs_portal.application_revision ar
+              join ggircs_portal.application a
+              on ar.application_id = a.id
+              and new.application_id = ar.application_id
+              and new.version_number = ar.version_number
+              join ggircs_portal.facility f
+              on a.facility_id = f.id
+              join ggircs_portal.organisation o
+              on f.organisation_id = o.id
+              join ggircs_portal.ciip_user u
+              on u.id = new.created_by
+              )
+        select operator_name, facility_name, first_name, last_name, email_address from ad into application_details;
+
+        with certifier as (select u.first_name, u.last_name from ggircs_portal.ciip_user u where u.id = new.certified_by)
+        select first_name, last_name from certifier into certifier_details;
+
+        perform ggircs_portal_private.graphile_worker_job_definer('sendMail',
+              json_build_object(
+                'type', 'signed_by_certifier',
+                'reporterEmail', application_details.email_address,
+                'firstName', application_details.first_name,
+                'lastName', application_details.last_name,
+                'email', new.certification_request_sent_to,
+                'facilityName', application_details.facility_name,
+                'operatorName', application_details.operator_name,
+                'certifierFirstName', certifier_details.first_name,
+                'certifierLastName', certifier_details.last_name));
       return new;
   end case;
 end;

--- a/schema/deploy/trigger_functions/run_graphile_worker_job.sql
+++ b/schema/deploy/trigger_functions/run_graphile_worker_job.sql
@@ -101,37 +101,69 @@ begin
       return new;
 
       -- **ON SIGNED BY CERTIFIER**
-      when tg_argv[0] = 'signed_by_certifier' then
+    when tg_argv[0] = 'signed_by_certifier' then
 
-        with ad as (select o.operator_name, f.facility_name, u.first_name, u.last_name, u.email_address
-              from ggircs_portal.application_revision ar
-              join ggircs_portal.application a
-              on ar.application_id = a.id
-              and new.application_id = ar.application_id
-              and new.version_number = ar.version_number
-              join ggircs_portal.facility f
-              on a.facility_id = f.id
-              join ggircs_portal.organisation o
-              on f.organisation_id = o.id
-              join ggircs_portal.ciip_user u
-              on u.id = new.created_by
-              )
-        select operator_name, facility_name, first_name, last_name, email_address from ad into application_details;
+      with ad as (select o.operator_name, f.facility_name, u.first_name, u.last_name, u.email_address
+            from ggircs_portal.application_revision ar
+            join ggircs_portal.application a
+            on ar.application_id = a.id
+            and new.application_id = ar.application_id
+            and new.version_number = ar.version_number
+            join ggircs_portal.facility f
+            on a.facility_id = f.id
+            join ggircs_portal.organisation o
+            on f.organisation_id = o.id
+            join ggircs_portal.ciip_user u
+            on u.id = new.created_by
+            )
+      select operator_name, facility_name, first_name, last_name, email_address from ad into application_details;
 
-        with certifier as (select u.first_name, u.last_name from ggircs_portal.ciip_user u where u.id = new.certified_by)
-        select first_name, last_name from certifier into certifier_details;
+      with certifier as (select u.first_name, u.last_name from ggircs_portal.ciip_user u where u.id = new.certified_by)
+      select first_name, last_name from certifier into certifier_details;
 
-        perform ggircs_portal_private.graphile_worker_job_definer('sendMail',
-              json_build_object(
-                'type', 'signed_by_certifier',
-                'email', application_details.email_address,
-                'firstName', application_details.first_name,
-                'lastName', application_details.last_name,
-                'certifierEmail', new.certification_request_sent_to,
-                'facilityName', application_details.facility_name,
-                'operatorName', application_details.operator_name,
-                'certifierFirstName', certifier_details.first_name,
-                'certifierLastName', certifier_details.last_name));
+      perform ggircs_portal_private.graphile_worker_job_definer('sendMail',
+            json_build_object(
+              'type', 'signed_by_certifier',
+              'email', application_details.email_address,
+              'firstName', application_details.first_name,
+              'lastName', application_details.last_name,
+              'certifierEmail', new.certification_request_sent_to,
+              'facilityName', application_details.facility_name,
+              'operatorName', application_details.operator_name,
+              'certifierFirstName', certifier_details.first_name,
+              'certifierLastName', certifier_details.last_name));
+      return new;
+
+    -- **ON SIGNED BY CERTIFIER**
+    when tg_argv[0] = 'recertification' then
+
+      with ad as (select o.operator_name, f.facility_name, u.first_name, u.last_name, u.email_address
+            from ggircs_portal.application_revision ar
+            join ggircs_portal.application a
+            on ar.application_id = a.id
+            and new.application_id = ar.application_id
+            and new.version_number = ar.version_number
+            join ggircs_portal.facility f
+            on a.facility_id = f.id
+            join ggircs_portal.organisation o
+            on f.organisation_id = o.id
+            join ggircs_portal.ciip_user u
+            on u.id = new.created_by
+            )
+      select operator_name, facility_name, first_name, last_name, email_address from ad into application_details;
+
+      with certifier as (select u.first_name, u.last_name from ggircs_portal.ciip_user u where u.id = new.certified_by)
+      select first_name, last_name from certifier into certifier_details;
+
+      perform ggircs_portal_private.graphile_worker_job_definer('sendMail',
+            json_build_object(
+              'type', 'recertification',
+              'email', application_details.email_address,
+              'firstName', application_details.first_name,
+              'lastName', application_details.last_name,
+              'facilityName', application_details.facility_name,
+              'operatorName', application_details.operator_name));
+      new.recertification_request_sent=true;
       return new;
   end case;
 end;

--- a/schema/test/unit/computed_columns/application_revision_certification_signature_is_valid_test.sql
+++ b/schema/test/unit/computed_columns/application_revision_certification_signature_is_valid_test.sql
@@ -13,6 +13,7 @@ select has_function(
 truncate ggircs_portal.application restart identity cascade;
 truncate ggircs_portal.certification_url cascade;
 alter table ggircs_portal.application_revision_status disable trigger _status_change_email;
+alter table ggircs_portal.certification_url disable trigger _signed_by_certifier_email;
 
 -- Call create application_mutation_chain to create a test application
 select ggircs_portal.create_application_mutation_chain(1);

--- a/schema/test/unit/trigger_functions/signature_md5_test.sql
+++ b/schema/test/unit/trigger_functions/signature_md5_test.sql
@@ -11,6 +11,7 @@ select has_function(
 );
 
 alter table ggircs_portal.application_revision_status disable trigger _status_change_email;
+alter table ggircs_portal.certification_url disable trigger _signed_by_certifier_email;
 
 -- Insert organisation & facility test data
 insert into ggircs_portal.organisation(operator_name) values ('test org');
@@ -35,11 +36,6 @@ insert into ggircs_portal.certification_url(application_id, version_number)
 values
 ((select max(id) from ggircs_portal.application), 1);
 
--- update ggircs_portal.application_revision_status
---   set application_revision_status = 'submitted'
---   where application_id = (select max(id) from ggircs_portal.application)
---   and version_number = 1;
-
 select isnt_empty(
   $$
     select form_results_md5 from ggircs_portal.certification_url where id = (select max(id) from ggircs_portal.certification_url);
@@ -55,7 +51,6 @@ select lives_ok(
   'trigger should not throw an exception if the form_result_md5 matches the current form result hash'
 );
 
-select certification_signature from ggircs_portal.certification_url where id = (select max(id) from ggircs_portal.certification_url);
 
 -- Trigger doesn't throw when it shouldn't (user can submit if form_results_md5 = current hash and signature exists)
 select lives_ok(

--- a/schema/verify/tables/certification_url.sql
+++ b/schema/verify/tables/certification_url.sql
@@ -16,7 +16,7 @@ select ggircs_portal_private.verify_grant('select', 'certification_url', 'ciip_a
 select ggircs_portal_private.verify_grant('select', 'certification_url', 'ciip_industry_user');
 select ggircs_portal_private.verify_grant('insert', 'certification_url', 'ciip_industry_user');
 select ggircs_portal_private.verify_grant('update', 'certification_url', 'ciip_industry_user',
-  ARRAY['certification_signature']);
+  ARRAY['certification_signature', 'certifier_url']);
 
 -- ciip_guest Grants
 

--- a/schema/verify/tables/certification_url.sql
+++ b/schema/verify/tables/certification_url.sql
@@ -16,7 +16,7 @@ select ggircs_portal_private.verify_grant('select', 'certification_url', 'ciip_a
 select ggircs_portal_private.verify_grant('select', 'certification_url', 'ciip_industry_user');
 select ggircs_portal_private.verify_grant('insert', 'certification_url', 'ciip_industry_user');
 select ggircs_portal_private.verify_grant('update', 'certification_url', 'ciip_industry_user',
-  ARRAY['certification_signature', 'certifier_url']);
+  ARRAY['certification_signature', 'certifier_url', 'recertification_request_sent']);
 
 -- ciip_guest Grants
 

--- a/schema/verify/tables/certification_url.sql
+++ b/schema/verify/tables/certification_url.sql
@@ -16,7 +16,7 @@ select ggircs_portal_private.verify_grant('select', 'certification_url', 'ciip_a
 select ggircs_portal_private.verify_grant('select', 'certification_url', 'ciip_industry_user');
 select ggircs_portal_private.verify_grant('insert', 'certification_url', 'ciip_industry_user');
 select ggircs_portal_private.verify_grant('update', 'certification_url', 'ciip_industry_user',
-  ARRAY['certification_signature', 'certifier_url', 'recertification_request_sent']);
+  ARRAY['certification_signature', 'certifier_url', 'recertification_request_sent', 'certification_request_sent_to']);
 
 -- ciip_guest Grants
 


### PR DESCRIPTION
- Adds triggers & email templates for:
   - request for certification (upon email input by reporter)
   - request for re-certification (data has changed between url generation & signing)
   - certifier has signed (upon certifier signing)
- Refactors URL generation in summary component -> send url to certifier email instead. (can still copy link afterwards)