### PR TITLE
Fix/1162 bypass legal checks

### DIFF
--- a/app/pages/reporter/ciip-application.tsx
+++ b/app/pages/reporter/ciip-application.tsx
@@ -55,8 +55,7 @@ class CiipApplication extends Component<Props> {
     const {application} = query || {};
 
     if (
-      application &&
-      application.latestDraftRevision?.legalDisclaimerAccepted === false
+      application?.latestDraftRevision?.legalDisclaimerAccepted === false
     ) {
       router.push({
         pathname: '/reporter/ciip-application-legal-disclaimer',

--- a/app/pages/reporter/ciip-application.tsx
+++ b/app/pages/reporter/ciip-application.tsx
@@ -5,11 +5,13 @@ import {CiipPageComponentProps} from 'next-env';
 import DefaultLayout from 'layouts/default-layout';
 import ApplicationWizard from 'containers/Applications/ApplicationWizard';
 import {USER} from 'data/group-constants';
+import {NextRouter} from 'next/router';
 
 const ALLOWED_GROUPS = [USER];
 
 interface Props extends CiipPageComponentProps {
   query: ciipApplicationQueryResponse['query'];
+  router: NextRouter;
 }
 class CiipApplication extends Component<Props> {
   static query = graphql`
@@ -19,6 +21,13 @@ class CiipApplication extends Component<Props> {
       $version: String!
     ) {
       query {
+        application(id: $applicationId) {
+          id
+          latestDraftRevision {
+            versionNumber
+            legalDisclaimerAccepted
+          }
+        }
         session {
           ...defaultLayout_session
         }
@@ -41,8 +50,20 @@ class CiipApplication extends Component<Props> {
   });
 
   render() {
-    const {query} = this.props;
+    const {query, router} = this.props;
     const {session} = query || {};
+    const {application} = query;
+    
+    if (application.latestDraftRevision.legalDisclaimerAccepted == false) {
+      router.push({
+        pathname: '/reporter/ciip-application-legal-disclaimer',
+        query: {
+          applicationId: application.id,
+          version: application.latestDraftRevision.versionNumber
+        }
+      });
+    }
+
     return (
       <DefaultLayout session={session} allowedGroups={ALLOWED_GROUPS}>
         <ApplicationWizard query={query} />

--- a/app/pages/reporter/ciip-application.tsx
+++ b/app/pages/reporter/ciip-application.tsx
@@ -52,9 +52,9 @@ class CiipApplication extends Component<Props> {
   render() {
     const {query, router} = this.props;
     const {session} = query || {};
-    const {application} = query;
+    const {application} = query || {};
     
-    if (application.latestDraftRevision.legalDisclaimerAccepted == false) {
+    if (application && application.latestDraftRevision.legalDisclaimerAccepted == false) {
       router.push({
         pathname: '/reporter/ciip-application-legal-disclaimer',
         query: {

--- a/app/pages/reporter/ciip-application.tsx
+++ b/app/pages/reporter/ciip-application.tsx
@@ -54,9 +54,7 @@ class CiipApplication extends Component<Props> {
     const {session} = query || {};
     const {application} = query || {};
 
-    if (
-      application?.latestDraftRevision?.legalDisclaimerAccepted === false
-    ) {
+    if (application?.latestDraftRevision?.legalDisclaimerAccepted === false) {
       router.push({
         pathname: '/reporter/ciip-application-legal-disclaimer',
         query: {

--- a/app/pages/reporter/ciip-application.tsx
+++ b/app/pages/reporter/ciip-application.tsx
@@ -53,8 +53,11 @@ class CiipApplication extends Component<Props> {
     const {query, router} = this.props;
     const {session} = query || {};
     const {application} = query || {};
-    
-    if (application && application.latestDraftRevision.legalDisclaimerAccepted == false) {
+
+    if (
+      application &&
+      application.latestDraftRevision.legalDisclaimerAccepted === false
+    ) {
       router.push({
         pathname: '/reporter/ciip-application-legal-disclaimer',
         query: {

--- a/app/pages/reporter/ciip-application.tsx
+++ b/app/pages/reporter/ciip-application.tsx
@@ -56,7 +56,7 @@ class CiipApplication extends Component<Props> {
 
     if (
       application &&
-      application.latestDraftRevision.legalDisclaimerAccepted === false
+      application.latestDraftRevision?.legalDisclaimerAccepted === false
     ) {
       router.push({
         pathname: '/reporter/ciip-application-legal-disclaimer',

--- a/app/tests/unit/pages/ciip-application.test.tsx
+++ b/app/tests/unit/pages/ciip-application.test.tsx
@@ -4,6 +4,13 @@ import CiipApplication from 'pages/reporter/ciip-application';
 
 const query = {
   session: null,
+  application: {
+    id: 1,
+    latestDraftRevision: {
+      versionNumber: 1,
+      legalDisclaimerAccepted: true
+    }
+  },
   allFormJsons: {
     edges: [{node: {id: 'form-1'}}]
   }

--- a/schema/data/fixtures/application-production-setup.sql
+++ b/schema/data/fixtures/application-production-setup.sql
@@ -3,5 +3,6 @@ begin;
 alter table ggircs_portal.ciip_user_organisation
   disable trigger _set_user_id;
 insert into ggircs_portal.ciip_user_organisation(user_id, organisation_id, status) values (6, 7, 'approved');
+update ggircs_portal.application_revision set legal_disclaimer_accepted=true where application_id=2 and version_number=1;
 
 commit;

--- a/schema/data/fixtures/application-production-teardown.sql
+++ b/schema/data/fixtures/application-production-teardown.sql
@@ -1,6 +1,7 @@
 begin;
 
 delete from ggircs_portal.ciip_user_organisation where user_id=6 and organisation_id=7;
+update ggircs_portal.application_revision set legal_disclaimer_accepted=false where application_id=2 and version_number=1;
 alter table ggircs_portal.ciip_user_organisation
   enable trigger _set_user_id;
 

--- a/schema/data/fixtures/form-validation-setup.sql
+++ b/schema/data/fixtures/form-validation-setup.sql
@@ -3,5 +3,6 @@ begin;
 alter table ggircs_portal.ciip_user_organisation
   disable trigger _set_user_id;
 insert into ggircs_portal.ciip_user_organisation(user_id, organisation_id, status) values (6, 7, 'approved');
+update ggircs_portal.application_revision set legal_disclaimer_accepted=true where application_id=2 and version_number=1;
 
 commit;

--- a/schema/data/fixtures/form-validation-teardown.sql
+++ b/schema/data/fixtures/form-validation-teardown.sql
@@ -1,6 +1,7 @@
 begin;
 
 delete from ggircs_portal.ciip_user_organisation where user_id=6 and organisation_id=7;
+update ggircs_portal.application_revision set legal_disclaimer_accepted=false where application_id=2 and version_number=1;
 alter table ggircs_portal.ciip_user_organisation
   enable trigger _set_user_id;
 


### PR DESCRIPTION
Currently, user can bypass legal checks by going directly (via full url) to next steps (app wizard).
This fix redirects user back to legal checks page if none were selected.