### PR TITLE
Reload products page

### DIFF
--- a/app/containers/Products/ProductCreatorContainer.tsx
+++ b/app/containers/Products/ProductCreatorContainer.tsx
@@ -11,9 +11,13 @@ import productSchema from './product-schema.json';
 
 interface Props {
   relay: RelayProp;
+  updateProductCount: any;
 }
 
-export const ProductCreator: React.FunctionComponent<Props> = ({relay}) => {
+export const ProductCreator: React.FunctionComponent<Props> = ({
+  relay,
+  updateProductCount
+}) => {
   const saveProduct = async (e: IChangeEvent) => {
     const variables = {
       input: {
@@ -30,6 +34,7 @@ export const ProductCreator: React.FunctionComponent<Props> = ({relay}) => {
     console.log(variables);
     const {environment} = relay;
     const response = await createProductMutation(environment, variables);
+    updateProductCount(response.createProduct.query.allProducts.totalCount);
     console.log(response);
   };
 

--- a/app/containers/Products/ProductListContainer.tsx
+++ b/app/containers/Products/ProductListContainer.tsx
@@ -12,8 +12,8 @@ interface Props {
   searchField?: string;
   searchValue?: string;
   direction?: string;
-  totalProductCount: number;
-
+  productCount: number;
+  updateProductCount: any;
   handleEvent: (...args: any[]) => void;
   relay: any;
 }
@@ -26,16 +26,16 @@ export const ProductList: React.FunctionComponent<Props> = ({
   searchValue,
   direction,
   handleEvent,
-  totalProductCount
+  productCount,
+  updateProductCount
 }) => {
-  console.log(totalProductCount);
   useEffect(() => {
     const refetchVariables = {
       searchField,
       searchValue,
       orderByField,
       direction,
-      totalProductCount
+      productCount
     };
     relay.refetch(refetchVariables);
   });
@@ -54,7 +54,13 @@ export const ProductList: React.FunctionComponent<Props> = ({
     const body = (
       <tbody>
         {allProducts.map(({node}) => (
-          <ProductRowItemContainer key={node.id} product={node} query={query} />
+          <ProductRowItemContainer
+            key={node.id}
+            product={node}
+            query={query}
+            updateProductCount={updateProductCount}
+            productCount={query.allProducts.totalCount}
+          />
         ))}
       </tbody>
     );
@@ -115,7 +121,7 @@ export default createRefetchContainer(
       $searchValue: String
       $orderByField: String
       $direction: String
-      $totalProductCount: Int
+      $productCount: Int
     ) {
       query {
         ...ProductListContainer_query
@@ -124,7 +130,7 @@ export default createRefetchContainer(
             searchValue: $searchValue
             orderByField: $orderByField
             direction: $direction
-            productCount: $totalProductCount
+            productCount: $productCount
           )
       }
     }

--- a/app/containers/Products/ProductListContainer.tsx
+++ b/app/containers/Products/ProductListContainer.tsx
@@ -12,6 +12,7 @@ interface Props {
   searchField?: string;
   searchValue?: string;
   direction?: string;
+  totalProductCount: number;
 
   handleEvent: (...args: any[]) => void;
   relay: any;
@@ -24,14 +25,17 @@ export const ProductList: React.FunctionComponent<Props> = ({
   searchField,
   searchValue,
   direction,
-  handleEvent
+  handleEvent,
+  totalProductCount
 }) => {
+  console.log(totalProductCount);
   useEffect(() => {
     const refetchVariables = {
       searchField,
       searchValue,
       orderByField,
-      direction
+      direction,
+      totalProductCount
     };
     relay.refetch(refetchVariables);
   });
@@ -80,6 +84,7 @@ export default createRefetchContainer(
           searchValue: {type: "String"}
           orderByField: {type: "String"}
           direction: {type: "String"}
+          productCount: {type: "Int"}
         ) {
         ...ProductRowItemContainer_query
         searchProducts(
@@ -96,6 +101,11 @@ export default createRefetchContainer(
             }
           }
         }
+        # TODO: This is here to trigger a refactor as updating the edge / running the query in the mutation is not triggering a refresh
+        # Find a way to not pull the totalcount?
+        allProducts(first: $productCount) {
+          totalCount
+        }
       }
     `
   },
@@ -105,6 +115,7 @@ export default createRefetchContainer(
       $searchValue: String
       $orderByField: String
       $direction: String
+      $totalProductCount: Int
     ) {
       query {
         ...ProductListContainer_query
@@ -113,6 +124,7 @@ export default createRefetchContainer(
             searchValue: $searchValue
             orderByField: $orderByField
             direction: $direction
+            productCount: $totalProductCount
           )
       }
     }

--- a/app/containers/Products/ProductRowItemContainer.tsx
+++ b/app/containers/Products/ProductRowItemContainer.tsx
@@ -28,6 +28,8 @@ interface Props {
   relay: RelayProp;
   product: ProductRowItemContainer_product;
   query: ProductRowItemContainer_query;
+  updateProductCount: any;
+  productCount: number;
 }
 
 // Schema for ProductRowItemContainer
@@ -50,7 +52,9 @@ const benchmarkUISchema = {
 export const ProductRowItemComponent: React.FunctionComponent<Props> = ({
   relay,
   product,
-  query
+  query,
+  updateProductCount,
+  productCount
 }) => {
   const {reportingYear: nextReportingYear} = query.nextReportingYear;
 
@@ -253,7 +257,10 @@ export const ProductRowItemComponent: React.FunctionComponent<Props> = ({
       centered
       size="xl"
       show={modalShow}
-      onHide={() => setModalShow(false)}
+      onHide={() => {
+        setModalShow(false);
+        updateProductCount(productCount++);
+      }}
     >
       <Modal.Header closeButton>
         <Modal.Title>Edit Product</Modal.Title>

--- a/app/cypress/integration/product-benchmark.spec.js
+++ b/app/cypress/integration/product-benchmark.spec.js
@@ -20,6 +20,27 @@ describe('The products and benchmark page', () => {
       .should('be.gte', 2);
   });
 
+  it('Creates & displays a new product', () => {
+    cy.contains('New Product').click();
+    cy.get('#root_name')
+      .clear()
+      .type('newProduct');
+    cy.get('#root_description')
+      .clear()
+      .type('desc');
+    cy.get('#root_units')
+      .clear()
+      .type('units');
+    cy.get('#root_units')
+      .clear()
+      .type('units');
+    cy.get(':nth-child(1) > label > :nth-child(1) > input').click();
+    cy.contains('Add Product').click();
+    cy.get('tr')
+      .its('length')
+      .should('be.gte', 3);
+  });
+
   it('Opens a modal when clicking on the edit button', () => {
     cy.visit('/admin/products-benchmarks');
     cy.get('#page-content');

--- a/app/mutations/product/createProductMutation.ts
+++ b/app/mutations/product/createProductMutation.ts
@@ -17,6 +17,11 @@ const mutation = graphql`
         units
         requiresEmissionAllocation
       }
+      query {
+        allProducts {
+          totalCount
+        }
+      }
     }
   }
 `;

--- a/app/pages/admin/products-benchmarks.tsx
+++ b/app/pages/admin/products-benchmarks.tsx
@@ -21,6 +21,7 @@ class ProductsBenchmarks extends Component<Props> {
       $direction: String
       $searchField: String
       $searchValue: String
+      $productCount: Int
     ) {
       query {
         ...ProductListContainer_query
@@ -29,6 +30,7 @@ class ProductsBenchmarks extends Component<Props> {
             direction: $direction
             searchField: $searchField
             searchValue: $searchValue
+            productCount: $productCount
           )
         session {
           ...defaultLayout_session
@@ -41,7 +43,8 @@ class ProductsBenchmarks extends Component<Props> {
     formData: {formId: '', formJson: ''},
     mode: 'view',
     confirmationModalOpen: false,
-    expandCreateForm: false
+    expandCreateForm: false,
+    totalProductCount: 0
   };
 
   static async getInitialProps() {
@@ -52,6 +55,10 @@ class ProductsBenchmarks extends Component<Props> {
       }
     };
   }
+
+  updateProductCount = (count: number) => {
+    this.setState({totalProductCount: count});
+  };
 
   toggleShowCreateForm = () => {
     const expanded = this.state.expandCreateForm;
@@ -91,6 +98,7 @@ class ProductsBenchmarks extends Component<Props> {
 
   render() {
     const {query} = this.props;
+    const {totalProductCount} = this.state;
     return (
       <DefaultLayout
         session={query.session}
@@ -107,14 +115,23 @@ class ProductsBenchmarks extends Component<Props> {
         </div>
         <Row>
           <Col>
-            {this.state.expandCreateForm && <ProductCreatorContainer />}
+            {this.state.expandCreateForm && (
+              <ProductCreatorContainer
+                updateProductCount={this.updateProductCount}
+              />
+            )}
 
             <SearchTable
               query={query}
               defaultOrderByField="name"
               defaultOrderByDisplay="Product"
             >
-              {props => <ProductListContainer {...props} />}
+              {props => (
+                <ProductListContainer
+                  {...props}
+                  totalProductCount={totalProductCount}
+                />
+              )}
             </SearchTable>
           </Col>
         </Row>

--- a/app/pages/admin/products-benchmarks.tsx
+++ b/app/pages/admin/products-benchmarks.tsx
@@ -129,7 +129,8 @@ class ProductsBenchmarks extends Component<Props> {
               {props => (
                 <ProductListContainer
                   {...props}
-                  totalProductCount={totalProductCount}
+                  productCount={totalProductCount}
+                  updateProductCount={this.updateProductCount}
                 />
               )}
             </SearchTable>

--- a/app/tests/unit/containers/Products/__snapshots__/productListContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Products/__snapshots__/productListContainer.test.tsx.snap
@@ -10,9 +10,13 @@ exports[`ProductList should render the product list 1`] = `
             "id": "abc",
           }
         }
+        productCount={1}
         query={
           Object {
             " $refType": "ProductListContainer_query",
+            "allProducts": Object {
+              "totalCount": 1,
+            },
             "searchProducts": Object {
               "edges": Array [
                 Object {

--- a/app/tests/unit/containers/Products/productListContainer.test.tsx
+++ b/app/tests/unit/containers/Products/productListContainer.test.tsx
@@ -15,6 +15,9 @@ describe('ProductList', () => {
           }
         ]
       },
+      allProducts: {
+        totalCount: 1
+      },
       session: {
         ciipUserBySub: {
           rowId: 1


### PR DESCRIPTION
- refresh products on create new product
- refresh products on edit product/benchmark
- add cypress test

The allProducts -> totalCount update is a bit of a hack, It's triggering the refetch function with a new variable so that the whole refetch fires. It appears we are breaking the 'relay way' of doing things with the current way the search functions work. This is the way it has been done for facilitiesList as well.