### PR TITLE
fix syntax error near EOF

### DIFF
--- a/app/cypress/support/commands.js
+++ b/app/cypress/support/commands.js
@@ -45,8 +45,8 @@ Cypress.Commands.add('sqlFixture', fixtureName => {
   // This is not a real promise
   // eslint-disable-next-line promise/prefer-await-to-then
   cy.fixture(`${fixtureName}.sql`).then(fixture =>
-    cy.exec(`psql -d ciip_portal_dev <<-EOF
-    ${fixture}
-    EOF`)
+    cy.exec(`psql -d ciip_portal_dev << EOF
+${fixture}
+EOF`)
   );
 });


### PR DESCRIPTION
The issue was generating text between the backticks (` `)  and added unexpected extra spaces in terms of code indentation.