### PR TITLE
Paginate Facilities

### DIFF
--- a/app/pages/reporter/facilities-list.tsx
+++ b/app/pages/reporter/facilities-list.tsx
@@ -21,6 +21,7 @@ class FacilitiesList extends Component<Props> {
       $searchField: String
       $searchValue: String
       $organisationId: ID!
+      $offsetValue: Int
     ) {
       query {
         ...FacilitiesListContainer_query
@@ -30,6 +31,7 @@ class FacilitiesList extends Component<Props> {
             searchField: $searchField
             searchValue: $searchValue
             organisationId: $organisationId
+            offsetValue: $offsetValue
           )
         session {
           ...defaultLayout_session
@@ -42,7 +44,8 @@ class FacilitiesList extends Component<Props> {
     return {
       variables: {
         orderByField: 'facility_name',
-        direction: 'ASC'
+        direction: 'ASC',
+        offsetValue: 0
       }
     };
   }

--- a/app/server/schema.graphql
+++ b/app/server/schema.graphql
@@ -6798,6 +6798,7 @@ type FacilitySearchResult {
   organisationName: String
   reportingYear: Int
   rowId: Int
+  totalFacilityCount: Int
 }
 
 """A connection to a list of `FacilitySearchResult` values."""
@@ -11002,6 +11003,7 @@ type Query implements Node {
     based pagination. May not be used with `last`.
     """
     offset: Int
+    offsetValue: Int
     orderByField: String
     searchField: String
     searchValue: String

--- a/app/server/schema.json
+++ b/app/server/schema.json
@@ -3562,6 +3562,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "offsetValue",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "orderByField",
                   "description": null,
                   "type": {
@@ -26038,6 +26048,18 @@
             },
             {
               "name": "rowId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalFacilityCount",
               "description": null,
               "args": [],
               "type": {

--- a/app/tests/unit/containers/Facility/FacilitiesListContainer.test.tsx
+++ b/app/tests/unit/containers/Facility/FacilitiesListContainer.test.tsx
@@ -86,6 +86,69 @@ describe('FacilitiesListContainer', () => {
     expect(r.find('PageItem').exists()).toBe(true);
     expect(r).toMatchSnapshot();
   });
+  it('should create Math.ceil(totalFacilityCount / 10) pagination buttons (25 facilities = 3 index buttons)', async () => {
+    const query: FacilitiesListContainer_query = {
+      ' $fragmentRefs': {
+        FacilitiesRowItemContainer_query: true
+      },
+      ' $refType': 'FacilitiesListContainer_query',
+      searchAllFacilities: {
+        edges: [
+          {
+            node: {
+              rowId: 1,
+              totalFacilityCount: 25,
+              ' $fragmentRefs ': {
+                FacilitiesRowItemContainer_facilitySearchResult: true
+              }
+            }
+          }
+        ]
+      },
+      allFacilities: {totalCount: 20},
+      organisation: {id: 'abc', rowId: 1}
+    };
+    const useRouter = jest.spyOn(require('next/router'), 'useRouter');
+    useRouter.mockImplementationOnce(() => ({
+      query: {}
+    }));
+    const r = shallow(
+      <FacilitiesList
+        query={query}
+        relay={null}
+        direction="asc"
+        orderByField="id"
+        searchField={null}
+        searchValue={null}
+        offsetValue={1}
+        handleEvent={jest.fn()}
+      />
+    );
+    expect(
+      r
+        .find('PageItem')
+        .at(0)
+        .text()
+    ).toBe('1');
+    expect(
+      r
+        .find('PageItem')
+        .at(1)
+        .text()
+    ).toBe('2');
+    expect(
+      r
+        .find('PageItem')
+        .at(2)
+        .text()
+    ).toBe('3');
+    expect(
+      r
+        .find('PageItem')
+        .at(3)
+        .exists()
+    ).toBe(false);
+  });
   it('should not render the Pagination component if < 10 facilities (totalFacilityCount < 10)', async () => {
     const query: FacilitiesListContainer_query = {
       ' $fragmentRefs': {

--- a/app/tests/unit/containers/Facility/FacilitiesListContainer.test.tsx
+++ b/app/tests/unit/containers/Facility/FacilitiesListContainer.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {FacilitiesListContainer_query} from 'FacilitiesListContainer_query.graphql';
+import {FacilitiesList} from 'containers/Facilities/FacilitiesListContainer';
+import {First} from 'react-bootstrap/PageItem';
+
+describe('FacilitiesListContainer', () => {
+  it('should match the previous snapshot', async () => {
+    const query: FacilitiesListContainer_query = {
+      ' $fragmentRefs': {
+        FacilitiesRowItemContainer_query: true
+      },
+      ' $refType': 'FacilitiesListContainer_query',
+      searchAllFacilities: {
+        edges: [
+          {
+            node: {
+              rowId: 1,
+              totalFacilityCount: 1,
+              ' $fragmentRefs ': {
+                FacilitiesRowItemContainer_facilitySearchResult: true
+              }
+            }
+          }
+        ]
+      },
+      allFacilities: {totalCount: 20},
+      organisation: {id: 'abc', rowId: 1}
+    };
+    const useRouter = jest.spyOn(require('next/router'), 'useRouter');
+    useRouter.mockImplementationOnce(() => ({
+      query: {}
+    }));
+    const r = shallow(
+      <FacilitiesList
+        query={query}
+        relay={null}
+        direction="asc"
+        orderByField="id"
+        searchField={null}
+        searchValue={null}
+        offsetValue={1}
+        handleEvent={jest.fn()}
+      />
+    );
+    expect(r).toMatchSnapshot();
+  });
+  it('should render the Pagination component if > 10 facilities (totalFacilityCount > 10)', async () => {
+    const query: FacilitiesListContainer_query = {
+      ' $fragmentRefs': {
+        FacilitiesRowItemContainer_query: true
+      },
+      ' $refType': 'FacilitiesListContainer_query',
+      searchAllFacilities: {
+        edges: [
+          {
+            node: {
+              rowId: 1,
+              totalFacilityCount: 25,
+              ' $fragmentRefs ': {
+                FacilitiesRowItemContainer_facilitySearchResult: true
+              }
+            }
+          }
+        ]
+      },
+      allFacilities: {totalCount: 20},
+      organisation: {id: 'abc', rowId: 1}
+    };
+    const useRouter = jest.spyOn(require('next/router'), 'useRouter');
+    useRouter.mockImplementationOnce(() => ({
+      query: {}
+    }));
+    const r = shallow(
+      <FacilitiesList
+        query={query}
+        relay={null}
+        direction="asc"
+        orderByField="id"
+        searchField={null}
+        searchValue={null}
+        offsetValue={1}
+        handleEvent={jest.fn()}
+      />
+    );
+    expect(r.find('PageItem').exists()).toBe(true);
+    expect(r).toMatchSnapshot();
+  });
+  it('should not render the Pagination component if < 10 facilities (totalFacilityCount < 10)', async () => {
+    const query: FacilitiesListContainer_query = {
+      ' $fragmentRefs': {
+        FacilitiesRowItemContainer_query: true
+      },
+      ' $refType': 'FacilitiesListContainer_query',
+      searchAllFacilities: {
+        edges: [
+          {
+            node: {
+              rowId: 1,
+              totalFacilityCount: 5,
+              ' $fragmentRefs ': {
+                FacilitiesRowItemContainer_facilitySearchResult: true
+              }
+            }
+          }
+        ]
+      },
+      allFacilities: {totalCount: 20},
+      organisation: {id: 'abc', rowId: 1}
+    };
+    const useRouter = jest.spyOn(require('next/router'), 'useRouter');
+    useRouter.mockImplementationOnce(() => ({
+      query: {}
+    }));
+    const r = shallow(
+      <FacilitiesList
+        query={query}
+        relay={null}
+        direction="asc"
+        orderByField="id"
+        searchField={null}
+        searchValue={null}
+        offsetValue={1}
+        handleEvent={jest.fn()}
+      />
+    );
+    expect(r.find('PageItem').exists()).toBe(false);
+    expect(r).toMatchSnapshot();
+  });
+});

--- a/app/tests/unit/containers/Facility/__snapshots__/FacilitiesListContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Facility/__snapshots__/FacilitiesListContainer.test.tsx.snap
@@ -1,0 +1,227 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FacilitiesListContainer should match the previous snapshot 1`] = `
+<Fragment>
+  <SearchTableLayoutComponent
+    body={
+      <tbody>
+        <ForwardRef(Relay(FacilitiesRowItemComponent))
+          facilitySearchResult={
+            Object {
+              " $fragmentRefs ": Object {
+                "FacilitiesRowItemContainer_facilitySearchResult": true,
+              },
+              "rowId": 1,
+              "totalFacilityCount": 1,
+            }
+          }
+          query={
+            Object {
+              " $fragmentRefs": Object {
+                "FacilitiesRowItemContainer_query": true,
+              },
+              " $refType": "FacilitiesListContainer_query",
+              "allFacilities": Object {
+                "totalCount": 20,
+              },
+              "organisation": Object {
+                "id": "abc",
+                "rowId": 1,
+              },
+              "searchAllFacilities": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      " $fragmentRefs ": Object {
+                        "FacilitiesRowItemContainer_facilitySearchResult": true,
+                      },
+                      "rowId": 1,
+                      "totalFacilityCount": 1,
+                    },
+                  },
+                ],
+              },
+            }
+          }
+        />
+      </tbody>
+    }
+    displayNameToColumnNameMap={
+      Object {
+        "Address": "facility_mailing_address",
+        "City": "facility_city",
+        "Facility Name": "facility_name",
+        "Organisation Name": "organisation_name",
+        "Postal Code": "facility_postal_code",
+        "Status": "application_revision_status",
+      }
+    }
+    handleEvent={[MockFunction]}
+  />
+</Fragment>
+`;
+
+exports[`FacilitiesListContainer should not render the Pagination component if < 10 facilities (totalFacilityCount < 10) 1`] = `
+<Fragment>
+  <SearchTableLayoutComponent
+    body={
+      <tbody>
+        <ForwardRef(Relay(FacilitiesRowItemComponent))
+          facilitySearchResult={
+            Object {
+              " $fragmentRefs ": Object {
+                "FacilitiesRowItemContainer_facilitySearchResult": true,
+              },
+              "rowId": 1,
+              "totalFacilityCount": 5,
+            }
+          }
+          query={
+            Object {
+              " $fragmentRefs": Object {
+                "FacilitiesRowItemContainer_query": true,
+              },
+              " $refType": "FacilitiesListContainer_query",
+              "allFacilities": Object {
+                "totalCount": 20,
+              },
+              "organisation": Object {
+                "id": "abc",
+                "rowId": 1,
+              },
+              "searchAllFacilities": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      " $fragmentRefs ": Object {
+                        "FacilitiesRowItemContainer_facilitySearchResult": true,
+                      },
+                      "rowId": 1,
+                      "totalFacilityCount": 5,
+                    },
+                  },
+                ],
+              },
+            }
+          }
+        />
+      </tbody>
+    }
+    displayNameToColumnNameMap={
+      Object {
+        "Address": "facility_mailing_address",
+        "City": "facility_city",
+        "Facility Name": "facility_name",
+        "Organisation Name": "organisation_name",
+        "Postal Code": "facility_postal_code",
+        "Status": "application_revision_status",
+      }
+    }
+    handleEvent={[MockFunction]}
+  />
+</Fragment>
+`;
+
+exports[`FacilitiesListContainer should render the Pagination component if > 10 facilities (totalFacilityCount > 10) 1`] = `
+<Fragment>
+  <SearchTableLayoutComponent
+    body={
+      <tbody>
+        <ForwardRef(Relay(FacilitiesRowItemComponent))
+          facilitySearchResult={
+            Object {
+              " $fragmentRefs ": Object {
+                "FacilitiesRowItemContainer_facilitySearchResult": true,
+              },
+              "rowId": 1,
+              "totalFacilityCount": 25,
+            }
+          }
+          query={
+            Object {
+              " $fragmentRefs": Object {
+                "FacilitiesRowItemContainer_query": true,
+              },
+              " $refType": "FacilitiesListContainer_query",
+              "allFacilities": Object {
+                "totalCount": 20,
+              },
+              "organisation": Object {
+                "id": "abc",
+                "rowId": 1,
+              },
+              "searchAllFacilities": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      " $fragmentRefs ": Object {
+                        "FacilitiesRowItemContainer_facilitySearchResult": true,
+                      },
+                      "rowId": 1,
+                      "totalFacilityCount": 25,
+                    },
+                  },
+                ],
+              },
+            }
+          }
+        />
+      </tbody>
+    }
+    displayNameToColumnNameMap={
+      Object {
+        "Address": "facility_mailing_address",
+        "City": "facility_city",
+        "Facility Name": "facility_name",
+        "Organisation Name": "organisation_name",
+        "Postal Code": "facility_postal_code",
+        "Status": "application_revision_status",
+      }
+    }
+    handleEvent={[MockFunction]}
+  />
+  <ForwardRef>
+    <First
+      onClick={[Function]}
+    />
+    <Prev
+      onClick={[Function]}
+    />
+    <ForwardRef>
+      <PageItem
+        active={true}
+        activeLabel="(current)"
+        disabled={false}
+        key="1"
+        onClick={[Function]}
+      >
+        1
+      </PageItem>
+      <PageItem
+        active={false}
+        activeLabel="(current)"
+        disabled={false}
+        key="2"
+        onClick={[Function]}
+      >
+        2
+      </PageItem>
+      <PageItem
+        active={false}
+        activeLabel="(current)"
+        disabled={false}
+        key="3"
+        onClick={[Function]}
+      >
+        3
+      </PageItem>
+    </ForwardRef>
+    <Next
+      onClick={[Function]}
+    />
+    <Last
+      onClick={[Function]}
+    />
+  </ForwardRef>
+</Fragment>
+`;

--- a/schema/deploy/types/facility_search_result.sql
+++ b/schema/deploy/types/facility_search_result.sql
@@ -16,7 +16,8 @@ create type ggircs_portal.facility_search_result as (
     facility_postal_code varchar(1000),
     reporting_year integer,
     application_revision_status ggircs_portal.ciip_application_revision_status,
-    organisation_name varchar(1000)
+    organisation_name varchar(1000),
+    total_facility_count integer
 );
 
 comment on type ggircs_portal.facility_search_result is '@primaryKey (facility_id, application_id)


### PR DESCRIPTION
- Add an offset value to search_all_facilities.sql
- Add Pagination element to facilitiesListContainer & use to update offset value
- Return a 'totalFacilitiesCount' value along with search results to dynamically render pagination buttons

- I did some exploring of paginating the 'relay way' but it really does focus on the facebook infinite scroll style of pagination. The way the search function works also breaks the cursor-based pagination a bit, as we are not querying a table, but creating results on the fly, assigning id's by row_number() & returning them from the search function.