### PR TITLE
Truncate facilities pagination bar

### DIFF
--- a/app/containers/Facilities/FacilitiesListContainer.tsx
+++ b/app/containers/Facilities/FacilitiesListContainer.tsx
@@ -100,7 +100,23 @@ export const FacilitiesList: React.FunctionComponent<Props> = ({
     setActivePage(pageNumber);
   };
 
-  for (let pageNumber = 1; pageNumber <= maxPages; pageNumber++) {
+  let startPage;
+  let endPage;
+  if (maxPages <= 9) {
+    startPage = 1;
+    endPage = maxPages;
+  } else if (maxPages - activePage <= 4) {
+    startPage = maxPages - 8;
+    endPage = maxPages;
+  } else if (activePage <= 5) {
+    startPage = 1;
+    endPage = 9;
+  } else {
+    startPage = activePage - 4;
+    endPage = activePage + 4;
+  }
+
+  for (let pageNumber = startPage; pageNumber <= endPage; pageNumber++) {
     items.push(
       <Pagination.Item
         key={pageNumber}
@@ -123,7 +139,9 @@ export const FacilitiesList: React.FunctionComponent<Props> = ({
         <Pagination>
           <Pagination.First onClick={() => handlePaginationByPageNumber(1)} />
           <Pagination.Prev onClick={previousTenPagination} />
+          {startPage !== 1 && <Pagination.Ellipsis />}
           <Pagination>{items}</Pagination>
+          {endPage !== maxPages && <Pagination.Ellipsis />}
           <Pagination.Next onClick={nextTenPagination} />
           <Pagination.Last
             onClick={() => handlePaginationByPageNumber(maxPages)}

--- a/app/containers/Products/product-schema.json
+++ b/app/containers/Products/product-schema.json
@@ -147,7 +147,7 @@
     },
     "requiresProductAmount": {
       "ui:widget": "radio",
-      "ui:help": "Should the reporting the product amount for this Non-CIIP product be required?"
+      "ui:help": "Should reporting the product amount for this Non-CIIP product be required?"
     },
     "addPurchasedElectricityEmissions": {
       "ui:widget": "radio",

--- a/app/tests/unit/containers/Facility/FacilitiesListContainer.test.tsx
+++ b/app/tests/unit/containers/Facility/FacilitiesListContainer.test.tsx
@@ -190,4 +190,57 @@ describe('FacilitiesListContainer', () => {
     expect(r.find('PageItem').exists()).toBe(false);
     expect(r).toMatchSnapshot();
   });
+  it('should render a maximum of 9 pagination pages if there are > 9 possible pages ( totalFacilityCount > 90)', async () => {
+    const query: FacilitiesListContainer_query = {
+      ' $fragmentRefs': {
+        FacilitiesRowItemContainer_query: true
+      },
+      ' $refType': 'FacilitiesListContainer_query',
+      searchAllFacilities: {
+        edges: [
+          {
+            node: {
+              rowId: 1,
+              totalFacilityCount: 200,
+              ' $fragmentRefs ': {
+                FacilitiesRowItemContainer_facilitySearchResult: true
+              }
+            }
+          }
+        ]
+      },
+      allFacilities: {totalCount: 20},
+      organisation: {id: 'abc', rowId: 1}
+    };
+    const useRouter = jest.spyOn(require('next/router'), 'useRouter');
+    useRouter.mockImplementationOnce(() => ({
+      query: {}
+    }));
+    const r = shallow(
+      <FacilitiesList
+        query={query}
+        relay={null}
+        direction="asc"
+        orderByField="id"
+        searchField={null}
+        searchValue={null}
+        offsetValue={1}
+        handleEvent={jest.fn()}
+      />
+    );
+    expect(
+      r
+        .find('PageItem')
+        .at(8)
+        .text()
+    ).toBe('9');
+    expect(
+      r
+        .find('PageItem')
+        .at(9)
+        .exists()
+    ).toBe(false);
+    expect(r.find('Ellipsis').exists()).toBe(true);
+    expect(r).toMatchSnapshot();
+  });
 });

--- a/app/tests/unit/containers/Facility/__snapshots__/FacilitiesListContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Facility/__snapshots__/FacilitiesListContainer.test.tsx.snap
@@ -122,6 +122,165 @@ exports[`FacilitiesListContainer should not render the Pagination component if <
 </Fragment>
 `;
 
+exports[`FacilitiesListContainer should render a maximum of 9 pagination pages if there are > 9 possible pages ( totalFacilityCount > 90) 1`] = `
+<Fragment>
+  <SearchTableLayoutComponent
+    body={
+      <tbody>
+        <ForwardRef(Relay(FacilitiesRowItemComponent))
+          facilitySearchResult={
+            Object {
+              " $fragmentRefs ": Object {
+                "FacilitiesRowItemContainer_facilitySearchResult": true,
+              },
+              "rowId": 1,
+              "totalFacilityCount": 200,
+            }
+          }
+          query={
+            Object {
+              " $fragmentRefs": Object {
+                "FacilitiesRowItemContainer_query": true,
+              },
+              " $refType": "FacilitiesListContainer_query",
+              "allFacilities": Object {
+                "totalCount": 20,
+              },
+              "organisation": Object {
+                "id": "abc",
+                "rowId": 1,
+              },
+              "searchAllFacilities": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      " $fragmentRefs ": Object {
+                        "FacilitiesRowItemContainer_facilitySearchResult": true,
+                      },
+                      "rowId": 1,
+                      "totalFacilityCount": 200,
+                    },
+                  },
+                ],
+              },
+            }
+          }
+        />
+      </tbody>
+    }
+    displayNameToColumnNameMap={
+      Object {
+        "Address": "facility_mailing_address",
+        "City": "facility_city",
+        "Facility Name": "facility_name",
+        "Organisation Name": "organisation_name",
+        "Postal Code": "facility_postal_code",
+        "Status": "application_revision_status",
+      }
+    }
+    handleEvent={[MockFunction]}
+  />
+  <ForwardRef>
+    <First
+      onClick={[Function]}
+    />
+    <Prev
+      onClick={[Function]}
+    />
+    <ForwardRef>
+      <PageItem
+        active={true}
+        activeLabel="(current)"
+        disabled={false}
+        key="1"
+        onClick={[Function]}
+      >
+        1
+      </PageItem>
+      <PageItem
+        active={false}
+        activeLabel="(current)"
+        disabled={false}
+        key="2"
+        onClick={[Function]}
+      >
+        2
+      </PageItem>
+      <PageItem
+        active={false}
+        activeLabel="(current)"
+        disabled={false}
+        key="3"
+        onClick={[Function]}
+      >
+        3
+      </PageItem>
+      <PageItem
+        active={false}
+        activeLabel="(current)"
+        disabled={false}
+        key="4"
+        onClick={[Function]}
+      >
+        4
+      </PageItem>
+      <PageItem
+        active={false}
+        activeLabel="(current)"
+        disabled={false}
+        key="5"
+        onClick={[Function]}
+      >
+        5
+      </PageItem>
+      <PageItem
+        active={false}
+        activeLabel="(current)"
+        disabled={false}
+        key="6"
+        onClick={[Function]}
+      >
+        6
+      </PageItem>
+      <PageItem
+        active={false}
+        activeLabel="(current)"
+        disabled={false}
+        key="7"
+        onClick={[Function]}
+      >
+        7
+      </PageItem>
+      <PageItem
+        active={false}
+        activeLabel="(current)"
+        disabled={false}
+        key="8"
+        onClick={[Function]}
+      >
+        8
+      </PageItem>
+      <PageItem
+        active={false}
+        activeLabel="(current)"
+        disabled={false}
+        key="9"
+        onClick={[Function]}
+      >
+        9
+      </PageItem>
+    </ForwardRef>
+    <Ellipsis />
+    <Next
+      onClick={[Function]}
+    />
+    <Last
+      onClick={[Function]}
+    />
+  </ForwardRef>
+</Fragment>
+`;
+
 exports[`FacilitiesListContainer should render the Pagination component if > 10 facilities (totalFacilityCount > 10) 1`] = `
 <Fragment>
   <SearchTableLayoutComponent

--- a/schema/deploy/tables/facility.sql
+++ b/schema/deploy/tables/facility.sql
@@ -27,6 +27,7 @@ begin;
 
   --Todo: refactor to add address table in CIIP
   create unique index facility_swrs_report_id_uindex on ggircs_portal.facility(swrs_report_id);
+  create index facility_organisation_id_foreign_key on ggircs_portal.facility(organisation_id);
 
 do
   $grant$


### PR DESCRIPTION
- Show no more than 9 pages in the pagination bar with ellipsis indicating there are more pages ahead/behind active page
- Add tests
- Fix a typo/bad grammar in the help widget for 'requiresProductAmount'