### PR TITLE
feat(schema): swrs schema is created by sqitch if not exists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,6 @@ jobs:
           name: deploy schema
           command: |
             source ~/.bashrc
-            psql -d ciip_portal_dev -c 'create schema swrs'
             pushd schema
             sqitch deploy
             sqitch verify

--- a/schema/deploy/schema_swrs.sql
+++ b/schema/deploy/schema_swrs.sql
@@ -1,0 +1,7 @@
+-- Deploy ggircs-portal:schema_swrs to pg
+
+begin;
+
+create schema if not exists swrs ;
+-- This schema will either exist or have a comment imported by pg_restore, so adding a comment here is not neeed
+commit;

--- a/schema/revert/schema_swrs.sql
+++ b/schema/revert/schema_swrs.sql
@@ -1,0 +1,10 @@
+-- Revert ggircs-portal:schema_swrs from pg
+
+begin;
+
+do $$
+begin
+raise notice 'swrs schema is not dropped as it may contain objects which are not managed by this sqitch project';
+end$$;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -2,6 +2,7 @@
 %project=ggircs-portal
 %uri=https://github.com/bcgov/cas-ggircs/app
 
+schema_swrs 2020-04-15T01:19:51Z Matthieu Foucault <matthieu@button.is> # Add a schema for SWRS
 schema_ggircs_portal 2019-07-11T18:30:51Z Hamza Javed <hamza@button.is> # Add a schema for the GGIRCS Industry Portal (GIP)
 schema_ggircs_portal_private 2020-02-04T19:34:27Z Dylan Leard <dylan@button.is> # Private schema for entities needed in the portal that should not be exposed to the API
 database_functions/graphile_worker_job_definer [schema_ggircs_portal_private] 2020-02-28T23:07:39Z Dylan Leard <dylan@button.is> # Wrapper for graphile_worker.add_job to run as security definer

--- a/schema/verify/schema_swrs.sql
+++ b/schema/verify/schema_swrs.sql
@@ -1,0 +1,7 @@
+-- Verify ggircs-portal:schema_swrs on pg
+
+begin;
+
+select pg_catalog.has_schema_privilege('swrs', 'usage');
+
+rollback;


### PR DESCRIPTION
It is not dropped when reverting as it may contain
objects created by other sqitch projects, or by pg_restore.
This allows the CI schema job to only run sqitch deploy.

https://youtrack.button.is/issue/GGIRCS-1224