### PR TITLE
Feature: Validate BC Corporate Registry Number format

### DIFF
--- a/app/cypress/integration/application-form-validation.spec.js
+++ b/app/cypress/integration/application-form-validation.spec.js
@@ -116,6 +116,11 @@ describe('When reviewing a submitted application as an analyst', () => {
     cy.get('#root_operator_duns +div .error-detail').contains(
       'DUNS number should be nine digits'
     );
+    cy.get(
+      '#root_operator_bcCorporateRegistryNumber +div .error-detail'
+    ).contains(
+      'BC Corporate Registry number should be 1-3 letters followed by 7 digits'
+    );
 
     cy.get(
       '#root_operationalRepresentative_mailingAddress_postalCode +div .error-detail'

--- a/app/tests/integration/Forms/__snapshots__/Form.test.tsx.snap
+++ b/app/tests/integration/Forms/__snapshots__/Form.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`Form should match the snapshot with the administration form 1`] = `
                 readOnly={false}
                 required={true}
                 type="text"
-                value="in qui"
+                value="consequat Ut Duis"
               />
               <span
                 className="font-italic text-muted"
@@ -101,7 +101,7 @@ exports[`Form should match the snapshot with the administration form 1`] = `
                 readOnly={false}
                 required={true}
                 type="text"
-                value="consequat Ut Duis"
+                value="culpa"
               />
               <span
                 className="font-italic text-muted"
@@ -130,7 +130,7 @@ exports[`Form should match the snapshot with the administration form 1`] = `
                 readOnly={false}
                 required={true}
                 type="text"
-                value="4512"
+                value="23"
               />
               <span
                 className="font-italic text-muted"
@@ -159,7 +159,7 @@ exports[`Form should match the snapshot with the administration form 1`] = `
                 readOnly={false}
                 required={true}
                 type="text"
-                value="in qui"
+                value="P5123451"
               />
               <span
                 className="font-italic text-muted"
@@ -188,7 +188,7 @@ exports[`Form should match the snapshot with the administration form 1`] = `
                 readOnly={false}
                 required={true}
                 type="text"
-                value="123451234"
+                value="451234512"
               />
               <span
                 className="font-italic text-muted"
@@ -836,7 +836,7 @@ exports[`Form should match the snapshot with the administration form 1`] = `
                 readOnly={false}
                 required={true}
                 type="text"
-                value="in qui"
+                value="culpa"
               />
               <span
                 className="font-italic text-muted"
@@ -926,7 +926,7 @@ exports[`Form should match the snapshot with the administration form 1`] = `
                 readOnly={false}
                 required={true}
                 type="text"
-                value="51234"
+                value="23"
               />
               <span
                 className="font-italic text-muted"
@@ -955,7 +955,7 @@ exports[`Form should match the snapshot with the administration form 1`] = `
                 readOnly={false}
                 required={true}
                 type="text"
-                value="4512"
+                value="51234"
               />
               <span
                 className="font-italic text-muted"
@@ -1002,7 +1002,7 @@ exports[`Form should match the snapshot with the administration form 1`] = `
                     readOnly={false}
                     required={true}
                     type="text"
-                    value="culpa"
+                    value="consequat Ut Duis"
                   />
                   <span
                     className="font-italic text-muted"
@@ -1031,7 +1031,7 @@ exports[`Form should match the snapshot with the administration form 1`] = `
                     readOnly={false}
                     required={true}
                     type="text"
-                    value="mollit eu esse"
+                    value="in qui"
                   />
                   <span
                     className="font-italic text-muted"
@@ -1060,7 +1060,7 @@ exports[`Form should match the snapshot with the administration form 1`] = `
                     readOnly={false}
                     required={true}
                     type="text"
-                    value="k3u 2p4"
+                    value="f2p5f2"
                   />
                   <span
                     className="font-italic text-muted"
@@ -1085,7 +1085,7 @@ exports[`Form should match the snapshot with the administration form 1`] = `
                     onChange={[Function]}
                     onFocus={[Function]}
                     required={true}
-                    value="British Columbia"
+                    value="Northwest Territories"
                   >
                     <option
                       value=""

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationDetailsPdf.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationDetailsPdf.test.tsx.snap
@@ -85,18 +85,18 @@ exports[`ApplicationDetailsPdf should render application pdf donwload link 1`] =
                 </TEXT>
                 <TEXT>
                    
-                  est dolor
+                  in qui
                 </TEXT>
                 <TEXT>
                    
-                  consequat Ut Duis
+                  mollit eu esse
                   ,
                    
-                  Manitoba
+                  British Columbia
                 </TEXT>
                 <TEXT>
                    
-                  u5f3u5
+                  p4A2p4
                 </TEXT>
               </VIEW>
             </styled.VIEW>
@@ -213,27 +213,27 @@ exports[`ApplicationDetailsPdf should render application pdf donwload link 1`] =
                     "naics": "4512",
                   },
                   "operationalRepresentative": Object {
-                    "email": "mzFgms@AfkpuAfkpuAfkp.ncf",
-                    "fax": "est dolor",
-                    "firstName": "culpa",
-                    "lastName": "in qui",
+                    "email": "gszFg@puAfkpu.cfh",
+                    "fax": "mollit eu esse",
+                    "firstName": "in qui",
+                    "lastName": "est dolor",
                     "mailingAddress": Object {
-                      "city": "culpa",
-                      "postalCode": "A1k4A1",
-                      "province": "New Brunswick",
-                      "streetAddress": "mollit eu esse",
+                      "city": "in qui",
+                      "postalCode": "f2p5f2",
+                      "province": "Northwest Territories",
+                      "streetAddress": "consequat Ut Duis",
                     },
-                    "phone": "consequat Ut Duis",
-                    "position": "mollit eu esse",
+                    "phone": "culpa",
+                    "position": "consequat Ut Duis",
                   },
                   "operator": Object {
-                    "bcCorporateRegistryNumber": "in qui",
+                    "bcCorporateRegistryNumber": "K4512345",
                     "duns": "123451234",
                     "mailingAddress": Object {
-                      "city": "consequat Ut Duis",
-                      "postalCode": "u5f3u5",
-                      "province": "Manitoba",
-                      "streetAddress": "est dolor",
+                      "city": "mollit eu esse",
+                      "postalCode": "p4A2p4",
+                      "province": "British Columbia",
+                      "streetAddress": "in qui",
                     },
                     "naics": "4512",
                     "name": "in qui",
@@ -432,6 +432,7 @@ exports[`ApplicationDetailsPdf should render application pdf donwload link 1`] =
                     "operator": Object {
                       "properties": Object {
                         "bcCorporateRegistryNumber": Object {
+                          "format": "bcCorporateRegistryNumber",
                           "title": "BC Corporate Registry number",
                           "type": "string",
                         },
@@ -650,40 +651,80 @@ exports[`ApplicationDetailsPdf should render application pdf donwload link 1`] =
                     Object {
                       "gases": Array [
                         Object {
-                          "annualCO2e": -80000000,
-                          "annualEmission": 20000000,
-                          "gasDescription": "mollit eu esse",
-                          "gasType": "culpa",
-                          "gwp": -20000000,
+                          "annualCO2e": -60000000,
+                          "annualEmission": 30000000,
+                          "gasDescription": "consequat Ut Duis",
+                          "gasType": "in qui",
+                          "gwp": 0,
                         },
                         Object {
-                          "annualCO2e": -80000000,
-                          "annualEmission": 20000000,
-                          "gasDescription": "mollit eu esse",
-                          "gasType": "culpa",
-                          "gwp": -20000000,
+                          "annualCO2e": -60000000,
+                          "annualEmission": 30000000,
+                          "gasDescription": "consequat Ut Duis",
+                          "gasType": "in qui",
+                          "gwp": 0,
+                        },
+                        Object {
+                          "annualCO2e": -60000000,
+                          "annualEmission": 30000000,
+                          "gasDescription": "consequat Ut Duis",
+                          "gasType": "in qui",
+                          "gwp": 0,
                         },
                       ],
-                      "sourceTypeName": "in qui",
+                      "sourceTypeName": "est dolor",
                     },
                     Object {
                       "gases": Array [
                         Object {
-                          "annualCO2e": -80000000,
-                          "annualEmission": 20000000,
-                          "gasDescription": "mollit eu esse",
-                          "gasType": "culpa",
-                          "gwp": -20000000,
+                          "annualCO2e": -60000000,
+                          "annualEmission": 30000000,
+                          "gasDescription": "consequat Ut Duis",
+                          "gasType": "in qui",
+                          "gwp": 0,
                         },
                         Object {
-                          "annualCO2e": -80000000,
-                          "annualEmission": 20000000,
-                          "gasDescription": "mollit eu esse",
-                          "gasType": "culpa",
-                          "gwp": -20000000,
+                          "annualCO2e": -60000000,
+                          "annualEmission": 30000000,
+                          "gasDescription": "consequat Ut Duis",
+                          "gasType": "in qui",
+                          "gwp": 0,
+                        },
+                        Object {
+                          "annualCO2e": -60000000,
+                          "annualEmission": 30000000,
+                          "gasDescription": "consequat Ut Duis",
+                          "gasType": "in qui",
+                          "gwp": 0,
                         },
                       ],
-                      "sourceTypeName": "in qui",
+                      "sourceTypeName": "est dolor",
+                    },
+                    Object {
+                      "gases": Array [
+                        Object {
+                          "annualCO2e": -60000000,
+                          "annualEmission": 30000000,
+                          "gasDescription": "consequat Ut Duis",
+                          "gasType": "in qui",
+                          "gwp": 0,
+                        },
+                        Object {
+                          "annualCO2e": -60000000,
+                          "annualEmission": 30000000,
+                          "gasDescription": "consequat Ut Duis",
+                          "gasType": "in qui",
+                          "gwp": 0,
+                        },
+                        Object {
+                          "annualCO2e": -60000000,
+                          "annualEmission": 30000000,
+                          "gasDescription": "consequat Ut Duis",
+                          "gasType": "in qui",
+                          "gwp": 0,
+                        },
+                      ],
+                      "sourceTypeName": "est dolor",
                     },
                   ],
                 }
@@ -866,22 +907,10 @@ exports[`ApplicationDetailsPdf should render application pdf donwload link 1`] =
               formData={
                 Array [
                   Object {
-                    "fuelType": "in qui",
-                    "fuelUnits": "culpa",
+                    "fuelType": "est dolor",
+                    "fuelUnits": "in qui",
                     "methodology": "wci 1.0",
-                    "quantity": -40000000,
-                  },
-                  Object {
-                    "fuelType": "mollit eu esse",
-                    "fuelUnits": "est dolor",
-                    "methodology": "wci 2.0",
-                    "quantity": 0,
-                  },
-                  Object {
-                    "fuelType": "culpa",
-                    "fuelUnits": "consequat Ut Duis",
-                    "methodology": "wci 1.0",
-                    "quantity": -60000000,
+                    "quantity": -20000000,
                   },
                 ]
               }
@@ -1017,14 +1046,17 @@ exports[`ApplicationDetailsPdf should render application pdf donwload link 1`] =
               formData={
                 Array [
                   Object {
-                    "productAmount": -40000000,
-                    "productRowId": -60000000,
-                    "productUnits": "culpa",
+                    "productRowId": 0,
                     "requiresEmissionAllocation": false,
-                    "requiresProductAmount": true,
+                    "requiresProductAmount": false,
                   },
                   Object {
-                    "productRowId": 0,
+                    "productRowId": -40000000,
+                    "requiresEmissionAllocation": false,
+                    "requiresProductAmount": false,
+                  },
+                  Object {
+                    "productRowId": -40000000,
                     "requiresEmissionAllocation": false,
                     "requiresProductAmount": false,
                   },

--- a/schema/data/fixtures/change-form-result.sql
+++ b/schema/data/fixtures/change-form-result.sql
@@ -21,7 +21,7 @@ update ggircs_portal.form_result set form_result = '{
   "naics": "12345",
   "tradeName": "trade",
   "duns": "123456789",
-  "bcCorporateRegistryNumber": "1234reg",
+  "bcCorporateRegistryNumber": "nkm8305753",
   "mailingAddress": {
     "city": "Victoria",
     "province": "British Columbia",

--- a/schema/data/fixtures/email-setup.sql
+++ b/schema/data/fixtures/email-setup.sql
@@ -46,7 +46,7 @@ update ggircs_portal.form_result set form_result = '{
   "naics": "12345",
   "tradeName": "trade",
   "duns": "123456789",
-  "bcCorporateRegistryNumber": "1234reg",
+  "bcCorporateRegistryNumber": "HK8394024",
   "mailingAddress": {
     "city": "Victoria",
     "province": "British Columbia",

--- a/schema/data/fixtures/reporter-all-access-setup.sql
+++ b/schema/data/fixtures/reporter-all-access-setup.sql
@@ -52,7 +52,7 @@ update ggircs_portal.form_result set form_result = '{
   "naics": "12345",
   "tradeName": "trade",
   "duns": "123456789",
-  "bcCorporateRegistryNumber": "1234reg",
+  "bcCorporateRegistryNumber": "G4447393",
   "mailingAddress": {
     "city": "Victoria",
     "province": "British Columbia",

--- a/schema/data/prod/form_json/administration.json
+++ b/schema/data/prod/form_json/administration.json
@@ -131,6 +131,7 @@
           },
           "bcCorporateRegistryNumber": {
             "type": "string",
+            "format": "bcCorporateRegistryNumber",
             "title": "BC Corporate Registry number"
           }
         }
@@ -330,12 +331,14 @@
     "duns": "^\\d{9}$",
     "naics": "^\\d+$",
     "bcghgid": "^\\d+$",
+    "bcCorporateRegistryNumber": "^[A-Za-z]{1,3}\\d{7}$",
     "postal-code": "[a-zA-Z][0-9][a-zA-Z]\\s?[0-9][a-zA-Z][0-9]"
   },
   "customFormatsErrorMessages": {
     "duns": "DUNS number should be nine digits",
     "naics": "NAICS code should be numeric",
     "bcghgid": "BCGHGID code should be numeric",
+    "bcCorporateRegistryNumber": "BC Corporate Registry number should be 1-3 letters followed by 7 digits",
     "postal-code": "Format should be A1A 1A1"
   }
 }


### PR DESCRIPTION
- Implements custom format validation of BC Corporate Registry Number in the "Administration Data" section of industry reporter form:
  * 1 to 3 letters followed by 7 digits
  * `^[A-Za-z]{1,3}\d{7}$`
- Updates test snaphots
- Updates E2E test fixtures with correct number format
- Add integration test