### PR TITLE
Remove unused older version of Bootstrap

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -124,7 +124,6 @@
     "@react-pdf/styled-components": "^1.4.0",
     "ace-builds": "^1.4.11",
     "body-parser": "^1.19.0",
-    "bootstrap": "^3.4.1",
     "cors": "^2.8.5",
     "deep-diff": "^1.0.2",
     "dotenv": "^8.2.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -4697,11 +4697,6 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bootstrap@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
-  integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
-
 boxen@^4.1.0, boxen@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-4.2.0.tgz#e411b62357d6d6d36587c8ac3d5d974daa070e64"


### PR DESCRIPTION
Removes Bootstrap (specified as 3.x) from our direct dependencies.

This project currently has two versions of Bootstrap installed:
- 3.x in our direct dependencies but not in use - made redundant by `react-bootstrap` which imports its own Bootstrap
- 4.x - required by `react-bootstrap` and is the version in use