### PR TITLE
Fix: incorrect review status

### DIFF
--- a/app/containers/Applications/ApplicationCommentsContainer.tsx
+++ b/app/containers/Applications/ApplicationCommentsContainer.tsx
@@ -154,7 +154,7 @@ export default createFragmentContainer(ApplicationCommentsComponent, {
       applicationByApplicationId {
         id
         rowId
-        applicationRevisionStatus {
+        applicationRevisionStatus(versionNumberInput: $version) {
           applicationRevisionStatus
         }
       }

--- a/app/containers/Applications/ApplicationDetailsPdf.tsx
+++ b/app/containers/Applications/ApplicationDetailsPdf.tsx
@@ -206,7 +206,7 @@ export default createFragmentContainer(ApplicationDetailsPdf, {
   application: graphql`
     fragment ApplicationDetailsPdf_application on Application
       @argumentDefinitions(version: {type: "String!"}) {
-      applicationRevisionStatus {
+      applicationRevisionStatus(versionNumberInput: $version) {
         applicationRevisionStatus
       }
       reportingYear

--- a/app/containers/Applications/ApplicationRevisionStatusContainer.tsx
+++ b/app/containers/Applications/ApplicationRevisionStatusContainer.tsx
@@ -36,7 +36,8 @@ export const ApplicationRevisionStatusComponent: React.FunctionComponent<Props> 
           applicationRevisionStatus: eventKey,
           versionNumber: props.applicationRevisionStatus.versionNumber
         }
-      }
+      },
+      version: props.applicationRevisionStatus.versionNumber.toString()
     };
     const response = await createApplicationRevisionStatusMutation(
       props.relay.environment,

--- a/app/mutations/application/createApplicationRevisionStatusMutation.ts
+++ b/app/mutations/application/createApplicationRevisionStatusMutation.ts
@@ -18,7 +18,7 @@ const mutation = graphql`
         applicationRevisionByApplicationIdAndVersionNumber {
           applicationByApplicationId {
             id
-            applicationRevisionStatus {
+            applicationRevisionStatus(versionNumberInput: $version) {
               id
               applicationRevisionStatus
             }

--- a/app/mutations/application/createApplicationRevisionStatusMutation.ts
+++ b/app/mutations/application/createApplicationRevisionStatusMutation.ts
@@ -9,6 +9,7 @@ import BaseMutation from 'mutations/BaseMutation';
 const mutation = graphql`
   mutation createApplicationRevisionStatusMutation(
     $input: CreateApplicationRevisionStatusInput!
+    $version: String
   ) {
     createApplicationRevisionStatus(input: $input) {
       clientMutationId

--- a/app/pages/analyst/application-review.tsx
+++ b/app/pages/analyst/application-review.tsx
@@ -29,7 +29,9 @@ class ApplicationReview extends Component<Props> {
         }
         application(id: $applicationId) {
           rowId
-          applicationRevisionStatus {
+          reviewRevisionStatus: applicationRevisionStatus(
+            versionNumberInput: $version
+          ) {
             ...ApplicationRevisionStatusContainer_applicationRevisionStatus
           }
           ...ApplicationDetailsContainer_application
@@ -63,9 +65,7 @@ class ApplicationReview extends Component<Props> {
         allowedGroups={ALLOWED_GROUPS}
       >
         <ApplicationRevisionStatusContainer
-          applicationRevisionStatus={
-            query.application.applicationRevisionStatus
-          }
+          applicationRevisionStatus={query.application.reviewRevisionStatus}
           applicationRowId={query.application.rowId}
         />
         <hr />

--- a/app/pages/reporter/view-application.tsx
+++ b/app/pages/reporter/view-application.tsx
@@ -35,7 +35,7 @@ class ViewApplication extends Component<Props> {
         ...ReviseApplicationButtonContainer_query
 
         application(id: $applicationId) {
-          applicationRevisionStatus {
+          applicationRevisionStatus(versionNumberInput: $version) {
             applicationRevisionStatus
           }
           orderedFormResults(versionNumberInput: $version) {

--- a/app/server/schema.graphql
+++ b/app/server/schema.graphql
@@ -32,7 +32,7 @@ type Application implements Node {
   """
   Computed column for graphql to traverse to an application_revision_status from application
   """
-  applicationRevisionStatus: ApplicationRevisionStatus
+  applicationRevisionStatus(versionNumberInput: String): ApplicationRevisionStatus
 
   """Reads and enables pagination through a set of `CertificationUrl`."""
   certificationUrlsByApplicationId(

--- a/app/server/schema.json
+++ b/app/server/schema.json
@@ -5329,7 +5329,18 @@
             {
               "name": "applicationRevisionStatus",
               "description": "Computed column for graphql to traverse to an application_revision_status from application",
-              "args": [],
+              "args": [
+                {
+                  "name": "versionNumberInput",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
               "type": {
                 "kind": "OBJECT",
                 "name": "ApplicationRevisionStatus",
@@ -5924,6 +5935,16 @@
               "ofType": null
             }
           ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -12375,16 +12396,6 @@
               "ofType": null
             }
           ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "String",
-          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },

--- a/app/tests/unit/pages/__snapshots__/application-review.test.tsx.snap
+++ b/app/tests/unit/pages/__snapshots__/application-review.test.tsx.snap
@@ -45,11 +45,6 @@ exports[`The application-review page It matches the last accepted Snapshot 1`] =
             " $fragmentRefs": Object {
               "ApplicationDetailsContainer_application": true,
             },
-            "applicationRevisionStatus": Object {
-              " $fragmentRefs": Object {
-                "ApplicationRevisionStatusContainer_applicationRevisionStatus": true,
-              },
-            },
             "orderedFormResults": Object {
               "edges": Array [
                 Object {
@@ -61,6 +56,11 @@ exports[`The application-review page It matches the last accepted Snapshot 1`] =
                   },
                 },
               ],
+            },
+            "reviewRevisionStatus": Object {
+              " $fragmentRefs": Object {
+                "ApplicationRevisionStatusContainer_applicationRevisionStatus": true,
+              },
             },
             "rowId": 1,
           }
@@ -75,11 +75,6 @@ exports[`The application-review page It matches the last accepted Snapshot 1`] =
               " $fragmentRefs": Object {
                 "ApplicationDetailsContainer_application": true,
               },
-              "applicationRevisionStatus": Object {
-                " $fragmentRefs": Object {
-                  "ApplicationRevisionStatusContainer_applicationRevisionStatus": true,
-                },
-              },
               "orderedFormResults": Object {
                 "edges": Array [
                   Object {
@@ -92,11 +87,16 @@ exports[`The application-review page It matches the last accepted Snapshot 1`] =
                   },
                 ],
               },
+              "reviewRevisionStatus": Object {
+                " $fragmentRefs": Object {
+                  "ApplicationRevisionStatusContainer_applicationRevisionStatus": true,
+                },
+              },
               "rowId": 1,
             },
             "applicationRevision": Object {
               " $fragmentRefs": Object {
-                "IncentiveCalculatorContainer_application_revision": true,
+                "IncentiveCalculatorContainer_applicationRevision": true,
               },
             },
             "session": Object {
@@ -112,7 +112,7 @@ exports[`The application-review page It matches the last accepted Snapshot 1`] =
         applicationRevision={
           Object {
             " $fragmentRefs": Object {
-              "IncentiveCalculatorContainer_application_revision": true,
+              "IncentiveCalculatorContainer_applicationRevision": true,
             },
           }
         }

--- a/app/tests/unit/pages/__snapshots__/view-application.test.tsx.snap
+++ b/app/tests/unit/pages/__snapshots__/view-application.test.tsx.snap
@@ -52,6 +52,7 @@ exports[`It matches the last accepted Snapshot 1`] = `
           Object {
             " $fragmentRefs": Object {
               "ApplicationDetailsContainer_query": true,
+              "ReviseApplicationButtonContainer_query": true,
             },
             "application": Object {
               " $fragmentRefs": Object {

--- a/app/tests/unit/pages/application-review.test.tsx
+++ b/app/tests/unit/pages/application-review.test.tsx
@@ -15,7 +15,7 @@ describe('The application-review page', () => {
         ApplicationDetailsContainer_application: true
       },
       rowId: 1,
-      applicationRevisionStatus: {
+      reviewRevisionStatus: {
         ' $fragmentRefs': {
           ApplicationRevisionStatusContainer_applicationRevisionStatus: true
         }
@@ -35,7 +35,7 @@ describe('The application-review page', () => {
     },
     applicationRevision: {
       ' $fragmentRefs': {
-        IncentiveCalculatorContainer_application_revision: true
+        IncentiveCalculatorContainer_applicationRevision: true
       }
     },
     ' $fragmentRefs': {

--- a/app/tests/unit/pages/view-application.test.tsx
+++ b/app/tests/unit/pages/view-application.test.tsx
@@ -5,7 +5,8 @@ import {viewApplicationQueryResponse} from 'viewApplicationQuery.graphql';
 
 const query: viewApplicationQueryResponse['query'] = {
   ' $fragmentRefs': {
-    ApplicationDetailsContainer_query: true
+    ApplicationDetailsContainer_query: true,
+    ReviseApplicationButtonContainer_query: true
   },
   session: {
     ' $fragmentRefs': {

--- a/schema/deploy/computed_columns/application_application_revision_status.sql
+++ b/schema/deploy/computed_columns/application_application_revision_status.sql
@@ -4,18 +4,25 @@
 
 begin;
 
-create or replace function ggircs_portal.application_application_revision_status(application ggircs_portal.application)
+create or replace function ggircs_portal.application_application_revision_status(application ggircs_portal.application, version_number_input text)
     returns ggircs_portal.application_revision_status
 as
 $function$
 declare
+  conditional_version_number int;
 begin
+    if version_number_input is not null then
+      conditional_version_number := version_number_input::int;
+    else
+      conditional_version_number := (select max(version_number) from ggircs_portal.application_revision as _application_revision
+                                where _application_revision.application_id = application.id);
+    end if;
+
     return (
         select row(_application_revision_status.*)
         from ggircs_portal.application_revision_status as _application_revision_status
         where _application_revision_status.application_id = application.id
-        and _application_revision_status.version_number = (select max(version_number) from ggircs_portal.application_revision as _application_revision
-          where _application_revision.application_id = application.id)
+        and _application_revision_status.version_number = conditional_version_number
         order by _application_revision_status.created_at desc
         limit 1
     );

--- a/schema/revert/computed_columns/application_application_revision_status.sql
+++ b/schema/revert/computed_columns/application_application_revision_status.sql
@@ -2,6 +2,6 @@
 
 begin;
 
-drop function ggircs_portal.application_application_revision_status(ggircs_portal.application);
+drop function ggircs_portal.application_application_revision_status(ggircs_portal.application, text);
 
 commit;

--- a/schema/verify/computed_columns/application_application_revision_status.sql
+++ b/schema/verify/computed_columns/application_application_revision_status.sql
@@ -2,6 +2,6 @@
 
 begin;
 
-select pg_get_functiondef('ggircs_portal.application_application_revision_status(ggircs_portal.application)'::regprocedure);
+select pg_get_functiondef('ggircs_portal.application_application_revision_status(ggircs_portal.application, text)'::regprocedure);
 
 rollback;


### PR DESCRIPTION
The computed column `application_application_revision_status` was pulling the latest status for the application, where it should have been getting the status for the revision being viewed.
Resolved by adding a versionNumberInput variable to the computed column.