### PR TITLE
Fix: javascript decimals

### DIFF
--- a/app/containers/Forms/EmissionGasFields.tsx
+++ b/app/containers/Forms/EmissionGasFields.tsx
@@ -85,7 +85,9 @@ const EmissionGasFields: React.FunctionComponent<FieldProps> = ({
                 onChange({
                   ...formData,
                   annualEmission: value,
-                  annualCO2e: normalizeDecimal(value).times(formData.gwp)
+                  annualCO2e: value
+                    ? Number(normalizeDecimal(value).times(formData.gwp))
+                    : 0
                 })
               }
             />

--- a/app/containers/Forms/EmissionGasFields.tsx
+++ b/app/containers/Forms/EmissionGasFields.tsx
@@ -35,7 +35,7 @@ const EmissionGasFields: React.FunctionComponent<FieldProps> = ({
   const hideRow = formData.annualEmission === 0 ? 'zero-emission' : '';
 
   // Function fixes javascript decimal error example: 0.1 + 0.2 = 3.0000000004
-  const normalizeDecimal = (value) => {
+  const normalizeDecimal = (value: number) => {
     const normalizedValue = new Decimal(value);
     return normalizedValue;
   };

--- a/app/containers/Forms/EmissionGasFields.tsx
+++ b/app/containers/Forms/EmissionGasFields.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {FieldProps} from 'react-jsonschema-form';
 import {Form, Col} from 'react-bootstrap';
 import {JSONSchema6} from 'json-schema';
+import {Decimal} from 'decimal.js-light';
 import ErrorList from 'components/Forms/ErrorList';
 
 const EmissionGasFields: React.FunctionComponent<FieldProps> = ({
@@ -32,6 +33,13 @@ const EmissionGasFields: React.FunctionComponent<FieldProps> = ({
   // Not using the types defined in @types/react-jsonschema-form as they are out of date
 
   const hideRow = formData.annualEmission === 0 ? 'zero-emission' : '';
+
+  // Function fixes javascript decimal error example: 0.1 + 0.2 = 3.0000000004
+  const normalizeDecimal = (value) => {
+    const normalizedValue = new Decimal(value);
+    return normalizedValue;
+  };
+
   return (
     <Col xs={12} md={12} className={`${hideRow} emission-row`}>
       <Form.Row>
@@ -77,7 +85,7 @@ const EmissionGasFields: React.FunctionComponent<FieldProps> = ({
                 onChange({
                   ...formData,
                   annualEmission: value,
-                  annualCO2e: value * formData.gwp
+                  annualCO2e: normalizeDecimal(value).times(formData.gwp)
                 })
               }
             />

--- a/app/package.json
+++ b/app/package.json
@@ -129,6 +129,7 @@
     "ace-builds": "^1.4.11",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
+    "decimal.js-light": "^2.5.0",
     "deep-diff": "^1.0.2",
     "dotenv": "^8.2.0",
     "dotenv-webpack": "^1.7.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -6701,6 +6701,11 @@ decamelize@^1.1.0, decamelize@^1.1.2, decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
+decimal.js-light@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/decimal.js-light/-/decimal.js-light-2.5.0.tgz#ca7faf504c799326df94b0ab920424fdfc125348"
+  integrity sha512-b3VJCbd2hwUpeRGG3Toob+CRo8W22xplipNhP3tN7TSVB/cyMX71P1vM2Xjc9H74uV6dS2hDDmo/rHq8L87Upg==
+
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"


### PR DESCRIPTION
uses the 'decimal.js-light' library to properly parse decimal values.