### PR TITLE
fix(facility): remove extra join condition on created_at column

### DIFF
--- a/schema/deploy/search_functions/search_all_facilities.sql
+++ b/schema/deploy/search_functions/search_all_facilities.sql
@@ -39,7 +39,6 @@ create or replace function ggircs_portal.search_all_facilities(search_field text
               from ggircs_portal.application a
               join applicationStatus s
               on a.id = s.application_id
-              and s.created_at = (select max(created_at) from applicationStatus)
           ),
 
           tempTable as (select f.*, ad.application_revision_status, ad.id as application_id, r.reporting_period_duration


### PR DESCRIPTION
This line was removed in #595 I'm not sure how it made it back in.