### PR TITLE
List all certification requests for current user by email

### DIFF
--- a/app/containers/Certifier/CertificationRequestsTable.tsx
+++ b/app/containers/Certifier/CertificationRequestsTable.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import {Table, Button, Alert} from 'react-bootstrap';
+import moment from 'moment-timezone';
+import Link from 'next/link';
+import {graphql, createFragmentContainer, RelayProp} from 'react-relay';
+import {CertificationRequestsTable_query} from '__generated__/CertificationRequestsTable_query.graphql';
+
+const TIME_ZONE = 'America/Vancouver';
+
+function formatListViewDate(date) {
+  return date ? moment.tz(date, TIME_ZONE).format('MMM D, YYYY') : '';
+}
+
+interface Props {
+  relay: RelayProp;
+  query: CertificationRequestsTable_query;
+}
+
+export const CertificationRequestsTableComponent: React.FunctionComponent<Props> = ({
+  query
+}) => {
+  return query.certificationRequests.edges.length === 0 ? (
+    <Alert variant="info">You have no current certification requests.</Alert>
+  ) : (
+    <Table striped bordered hover>
+      <thead>
+        <tr>
+          <th>Facility</th>
+          <th>Organisation</th>
+          <th>Status</th>
+          <th>Certified By</th>
+          <th>Date Certified</th>
+          <th />
+        </tr>
+      </thead>
+      <tbody>
+        {query.certificationRequests.edges.map(({node}) => {
+          const status =
+            node.applicationRevisionByApplicationIdAndVersionNumber
+              .applicationRevisionStatusesByApplicationIdAndVersionNumber
+              .edges[0].node.applicationRevisionStatus;
+
+          const facility =
+            node.applicationByApplicationId.facilityByFacilityId.facilityName;
+
+          const organisation =
+            node.applicationByApplicationId.facilityByFacilityId
+              .organisationByOrganisationId.operatorName;
+
+          const certifierName = node.certifiedBy
+            ? `${node.ciipUserByCertifiedBy.firstName} ${node.ciipUserByCertifiedBy.lastName}`
+            : '';
+
+          const applicationId = node.applicationByApplicationId.id;
+          const {
+            versionNumber
+          } = node.applicationByApplicationId.latestDraftRevision;
+
+          return (
+            <tr key={node.id}>
+              <td>{facility}</td>
+              <td>{organisation}</td>
+              <td>{status}</td>
+              <td>{certifierName}</td>
+              <td>{formatListViewDate(node.certifiedAt)}</td>
+              <td>
+                <Link
+                  href={`/certifier/certify?applicationId=${applicationId}&version=${versionNumber}`}
+                >
+                  <Button className="w-100">View</Button>
+                </Link>
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </Table>
+  );
+};
+
+export default createFragmentContainer(CertificationRequestsTableComponent, {
+  query: graphql`
+    fragment CertificationRequestsTable_query on CiipUser {
+      certificationRequests {
+        edges {
+          node {
+            id
+            certifiedAt
+            certifiedBy
+            ciipUserByCertifiedBy {
+              firstName
+              lastName
+            }
+            applicationByApplicationId {
+              id
+              latestDraftRevision {
+                versionNumber
+              }
+              facilityByFacilityId {
+                facilityName
+                organisationByOrganisationId {
+                  operatorName
+                }
+              }
+            }
+            applicationRevisionByApplicationIdAndVersionNumber {
+              applicationRevisionStatusesByApplicationIdAndVersionNumber {
+                edges {
+                  node {
+                    applicationRevisionStatus
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+});

--- a/app/cypress/integration/reporter-certifier-access.spec.js
+++ b/app/cypress/integration/reporter-certifier-access.spec.js
@@ -33,5 +33,9 @@ describe('When logged in as a reporter', () => {
     ).click();
     cy.contains('Certifier Signature');
     cy.get('.btn-success').click();
+    cy.visit('/certifier/requests');
+    cy.get('#page-content');
+    cy.contains('View').click();
+    cy.url().should('include', '/certifier/certify');
   });
 });

--- a/app/pages/certifier/requests.tsx
+++ b/app/pages/certifier/requests.tsx
@@ -1,0 +1,43 @@
+import React, {Component} from 'react';
+import {graphql} from 'react-relay';
+import {NextRouter} from 'next/router';
+import {CiipPageComponentProps} from 'next-env';
+import {requestsQueryResponse} from 'requestsQuery.graphql';
+import DefaultLayout from 'layouts/default-layout';
+import {USER} from 'data/group-constants';
+import CertificationRequestsTable from 'containers/Certifier/CertificationRequestsTable';
+
+const ALLOWED_GROUPS = [USER];
+
+interface Props extends CiipPageComponentProps {
+  query: requestsQueryResponse['query'];
+  router: NextRouter;
+}
+
+export default class CertifierRequests extends Component<Props> {
+  static query = graphql`
+    query requestsQuery {
+      query {
+        session {
+          ciipUserBySub {
+            ...CertificationRequestsTable_query
+          }
+          ...defaultLayout_session
+        }
+      }
+    }
+  `;
+
+  render() {
+    const {query} = this.props;
+    return (
+      <DefaultLayout
+        title="Certification Requests"
+        session={query.session}
+        allowedGroups={ALLOWED_GROUPS}
+      >
+        <CertificationRequestsTable query={query.session.ciipUserBySub} />
+      </DefaultLayout>
+    );
+  }
+}

--- a/app/server/schema.graphql
+++ b/app/server/schema.graphql
@@ -2178,6 +2178,29 @@ type CiipUser implements Node {
     orderBy: [BenchmarksOrderBy!] = [PRIMARY_KEY_ASC]
   ): BenchmarksConnection!
 
+  """
+  Computed column returns all latest certification requests associated with a user email
+  """
+  certificationRequests(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): CertificationUrlsConnection!
+
   """Reads and enables pagination through a set of `CertificationUrl`."""
   certificationUrlsByCertifiedBy(
     """Read all values in the set after (below) this cursor."""

--- a/app/server/schema.json
+++ b/app/server/schema.json
@@ -7083,6 +7083,73 @@
               "deprecationReason": null
             },
             {
+              "name": "certificationRequests",
+              "description": "Computed column returns all latest certification requests associated with a user email",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Read all values in the set after (below) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Read all values in the set before (above) this cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Cursor",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Only read the first `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor based pagination. May not be used with `last`.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CertificationUrlsConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "certificationUrlsByCertifiedBy",
               "description": "Reads and enables pagination through a set of `CertificationUrl`.",
               "args": [
@@ -13059,464 +13126,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "CertificationUrlCondition",
-          "description": "A condition to be used against `CertificationUrl` object types. All fields are tested for equality and combined with a logical ‘and.’",
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "applicationId",
-              "description": "Checks for equality with the object’s `applicationId` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "certificationRequestSentAt",
-              "description": "Checks for equality with the object’s `certificationRequestSentAt` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Datetime",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "certificationSignature",
-              "description": "Checks for equality with the object’s `certificationSignature` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "certifiedAt",
-              "description": "Checks for equality with the object’s `certifiedAt` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Datetime",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "certifiedBy",
-              "description": "Checks for equality with the object’s `certifiedBy` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "certifierEmail",
-              "description": "Checks for equality with the object’s `certifierEmail` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "certifierUrl",
-              "description": "Checks for equality with the object’s `certifierUrl` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "createdAt",
-              "description": "Checks for equality with the object’s `createdAt` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Datetime",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "createdBy",
-              "description": "Checks for equality with the object’s `createdBy` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "deletedAt",
-              "description": "Checks for equality with the object’s `deletedAt` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Datetime",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "deletedBy",
-              "description": "Checks for equality with the object’s `deletedBy` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "expiresAt",
-              "description": "Checks for equality with the object’s `expiresAt` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Datetime",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "formResultsMd5",
-              "description": "Checks for equality with the object’s `formResultsMd5` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "recertificationRequestSent",
-              "description": "Checks for equality with the object’s `recertificationRequestSent` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "rowId",
-              "description": "Checks for equality with the object’s `rowId` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "sendCertificationRequest",
-              "description": "Checks for equality with the object’s `sendCertificationRequest` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "updatedAt",
-              "description": "Checks for equality with the object’s `updatedAt` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Datetime",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "updatedBy",
-              "description": "Checks for equality with the object’s `updatedBy` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "versionNumber",
-              "description": "Checks for equality with the object’s `versionNumber` field.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "CertificationUrlsOrderBy",
-          "description": "Methods to use when ordering `CertificationUrl`.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "APPLICATION_ID_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "APPLICATION_ID_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CERTIFICATION_REQUEST_SENT_AT_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CERTIFICATION_REQUEST_SENT_AT_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CERTIFICATION_SIGNATURE_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CERTIFICATION_SIGNATURE_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CERTIFIED_AT_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CERTIFIED_AT_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CERTIFIED_BY_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CERTIFIED_BY_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CERTIFIER_EMAIL_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CERTIFIER_EMAIL_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CERTIFIER_URL_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CERTIFIER_URL_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CREATED_AT_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CREATED_AT_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CREATED_BY_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CREATED_BY_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "DELETED_AT_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "DELETED_AT_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "DELETED_BY_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "DELETED_BY_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "EXPIRES_AT_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "EXPIRES_AT_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FORM_RESULTS_MD5_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FORM_RESULTS_MD5_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ID_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ID_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "NATURAL",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "PRIMARY_KEY_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "PRIMARY_KEY_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "RECERTIFICATION_REQUEST_SENT_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "RECERTIFICATION_REQUEST_SENT_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SEND_CERTIFICATION_REQUEST_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SEND_CERTIFICATION_REQUEST_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "UPDATED_AT_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "UPDATED_AT_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "UPDATED_BY_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "UPDATED_BY_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "VERSION_NUMBER_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "VERSION_NUMBER_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
           "name": "CertificationUrlsConnection",
           "description": "A connection to a list of `CertificationUrl` values.",
@@ -14009,6 +13618,464 @@
             }
           ],
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CertificationUrlCondition",
+          "description": "A condition to be used against `CertificationUrl` object types. All fields are tested for equality and combined with a logical ‘and.’",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "applicationId",
+              "description": "Checks for equality with the object’s `applicationId` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "certificationRequestSentAt",
+              "description": "Checks for equality with the object’s `certificationRequestSentAt` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "certificationSignature",
+              "description": "Checks for equality with the object’s `certificationSignature` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "certifiedAt",
+              "description": "Checks for equality with the object’s `certifiedAt` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "certifiedBy",
+              "description": "Checks for equality with the object’s `certifiedBy` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "certifierEmail",
+              "description": "Checks for equality with the object’s `certifierEmail` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "certifierUrl",
+              "description": "Checks for equality with the object’s `certifierUrl` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "createdAt",
+              "description": "Checks for equality with the object’s `createdAt` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "createdBy",
+              "description": "Checks for equality with the object’s `createdBy` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "deletedAt",
+              "description": "Checks for equality with the object’s `deletedAt` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "deletedBy",
+              "description": "Checks for equality with the object’s `deletedBy` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "expiresAt",
+              "description": "Checks for equality with the object’s `expiresAt` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "formResultsMd5",
+              "description": "Checks for equality with the object’s `formResultsMd5` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "recertificationRequestSent",
+              "description": "Checks for equality with the object’s `recertificationRequestSent` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "rowId",
+              "description": "Checks for equality with the object’s `rowId` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "sendCertificationRequest",
+              "description": "Checks for equality with the object’s `sendCertificationRequest` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "updatedAt",
+              "description": "Checks for equality with the object’s `updatedAt` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "updatedBy",
+              "description": "Checks for equality with the object’s `updatedBy` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "versionNumber",
+              "description": "Checks for equality with the object’s `versionNumber` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "CertificationUrlsOrderBy",
+          "description": "Methods to use when ordering `CertificationUrl`.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "APPLICATION_ID_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "APPLICATION_ID_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CERTIFICATION_REQUEST_SENT_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CERTIFICATION_REQUEST_SENT_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CERTIFICATION_SIGNATURE_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CERTIFICATION_SIGNATURE_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CERTIFIED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CERTIFIED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CERTIFIED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CERTIFIED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CERTIFIER_EMAIL_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CERTIFIER_EMAIL_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CERTIFIER_URL_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CERTIFIER_URL_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CREATED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CREATED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CREATED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CREATED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DELETED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DELETED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DELETED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DELETED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "EXPIRES_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "EXPIRES_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FORM_RESULTS_MD5_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FORM_RESULTS_MD5_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ID_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ID_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NATURAL",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PRIMARY_KEY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PRIMARY_KEY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RECERTIFICATION_REQUEST_SENT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RECERTIFICATION_REQUEST_SENT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SEND_CERTIFICATION_REQUEST_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SEND_CERTIFICATION_REQUEST_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UPDATED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UPDATED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UPDATED_BY_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UPDATED_BY_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "VERSION_NUMBER_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "VERSION_NUMBER_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {

--- a/app/tests/unit/pages/__snapshots__/certifier-requests.test.tsx.snap
+++ b/app/tests/unit/pages/__snapshots__/certifier-requests.test.tsx.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`certifier requests list page It matches the last accepted Snapshot 1`] = `
+<Relay(DefaultLayout)
+  allowedGroups={
+    Array [
+      "User",
+    ]
+  }
+  session={
+    Object {
+      " $fragmentRefs": Object {
+        "defaultLayout_session": true,
+      },
+      "ciipUserBySub": Object {
+        " $fragmentRefs": Object {
+          "CertificationRequestsTable_query": true,
+        },
+      },
+    }
+  }
+  title="Certification Requests"
+>
+  <Relay(CertificationRequestsTableComponent)
+    query={
+      Object {
+        " $fragmentRefs": Object {
+          "CertificationRequestsTable_query": true,
+        },
+      }
+    }
+  />
+</Relay(DefaultLayout)>
+`;

--- a/app/tests/unit/pages/certifier-requests.test.tsx
+++ b/app/tests/unit/pages/certifier-requests.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import CertifierRequests from 'pages/certifier/requests';
+import {requestsQueryResponse} from 'requestsQuery.graphql';
+
+const query: requestsQueryResponse['query'] = {
+  session: {
+    ' $fragmentRefs': {
+      defaultLayout_session: true
+    },
+    ciipUserBySub: {
+      ' $fragmentRefs': {
+        CertificationRequestsTable_query: true
+      }
+    }
+  }
+};
+
+describe('certifier requests list page', () => {
+  it('It matches the last accepted Snapshot', () => {
+    const wrapper = shallow(<CertifierRequests query={query} router={null} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('It passes a query to the CertificationRequestsTable component', () => {
+    const wrapper = shallow(<CertifierRequests query={query} router={null} />);
+    expect(
+      wrapper
+        .find('Relay(CertificationRequestsTableComponent)')
+        .first()
+        .prop('query')
+    ).toBe(query.session.ciipUserBySub);
+  });
+});

--- a/schema/deploy/computed_columns/ciip_user_certification_requests.sql
+++ b/schema/deploy/computed_columns/ciip_user_certification_requests.sql
@@ -1,0 +1,27 @@
+-- Deploy ggircs-portal:function_ciip_user_certification_requests to pg
+-- requires: table_ciip_user
+-- requires: table_certification_url
+-- requires: table_application
+
+begin;
+
+  create or replace function ggircs_portal.ciip_user_certification_requests(
+    ciip_user ggircs_portal.ciip_user
+  )
+  returns setof ggircs_portal.certification_url
+  as
+  $body$
+    declare
+    begin
+      return query (
+        select * from ggircs_portal.certification_url where certifier_email = ciip_user.email_address and expires_at > now()
+      );
+    end;
+  $body$
+  language 'plpgsql' stable;
+
+  grant execute on function ggircs_portal.ciip_user_certification_requests to ciip_administrator, ciip_analyst, ciip_industry_user;
+
+  comment on function ggircs_portal.ciip_user_certification_requests is 'Computed column returns all latest certification requests associated with a user email';
+
+commit;

--- a/schema/revert/computed_columns/ciip_user_certification_requests.sql
+++ b/schema/revert/computed_columns/ciip_user_certification_requests.sql
@@ -1,0 +1,7 @@
+-- Revert ggircs-portal:function_ciip_user_certification_requests from pg
+
+BEGIN;
+
+drop function ggircs_portal.ciip_user_certification_requests;
+
+COMMIT;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -103,3 +103,4 @@ policies/application_revision_policies [database_functions/get_valid_application
 policies/application_policies [tables/certification_url] 2020-05-12T20:44:30Z Dylan Leard <dylan@button.is> # Applies row-level security for table application
 policies/form_result_policies [database_functions/get_valid_applications_for_reporter database_functions/get_valid_applications_for_certifier] 2020-05-12T22:22:42Z Dylan Leard <dylan@button.is> # Applies row-level security policies for form_result table
 policies/facility_policies [tables/certification_url] 2020-05-12T23:05:04Z Dylan Leard <dylan@button.is> # Applies row-level security policies to the facility table
+computed_columns/ciip_user_certification_requests [tables/ciip_user tables/certification_url tables/application] 2020-05-13T17:23:35Z Kristen Cooke <kristen@button.is> # Computed column returns all certification requests (latest drafts) associated with a user's email

--- a/schema/test/unit/computed_columns/ciip_user_certification_requests_test.sql
+++ b/schema/test/unit/computed_columns/ciip_user_certification_requests_test.sql
@@ -1,0 +1,38 @@
+set client_min_messages to warning;
+create extension if not exists pgtap;
+reset client_min_messages;
+
+begin;
+select plan(3);
+
+select has_function(
+  'ggircs_portal', 'ciip_user_certification_requests', array['ggircs_portal.ciip_user'],
+  'Function ggircs_portal.ciip_user_certification_requests should exist'
+);
+
+insert into ggircs_portal.certification_url(application_id, version_number, certifier_email) values (1,2,'ciip@mailinator.com');
+insert into ggircs_portal.certification_url(application_id, version_number, certifier_email) values (1,2,'certifier@certi.fy');
+
+select is(
+  (
+    with record as (select row(ciip_user.*)::ggircs_portal.ciip_user from ggircs_portal.ciip_user where email_address = 'certifier@certi.fy')
+    select certifier_email from ggircs_portal.ciip_user_certification_requests((select * from record))
+  ),
+  'certifier@certi.fy'::varchar(1000),
+  'ciip_user_certification_requests returns only the certification_url results for the user specified'
+);
+
+insert into ggircs_portal.certification_url(application_id, version_number, certifier_email) values (2,1,'certifier@certi.fy');
+
+select set_eq(
+  $$
+    with record as (select row(ciip_user.*)::ggircs_portal.ciip_user from ggircs_portal.ciip_user where email_address = 'certifier@certi.fy')
+    select count(*) from ggircs_portal.ciip_user_certification_requests((select * from record));
+  $$,
+  ARRAY['2'::bigint],
+  'ciip_user_certification_requests returns a set of certification_url results for a user'
+);
+
+select finish();
+
+rollback;

--- a/schema/verify/computed_columns/ciip_user_certification_requests.sql
+++ b/schema/verify/computed_columns/ciip_user_certification_requests.sql
@@ -1,0 +1,7 @@
+-- Verify ggircs-portal:function_ciip_user_certification_requests on pg
+
+BEGIN;
+
+select pg_get_functiondef('ggircs_portal.ciip_user_certification_requests(ggircs_portal.ciip_user)'::regprocedure);
+
+ROLLBACK;


### PR DESCRIPTION
- Adds a computed column that lists all non-expired certification requests directed to the current user (as determined by their email address).
- Adds a page at /certifer/requests` listing these requests where the certifier can click through to certify individual applications.
[GGIRCS-1393](https://youtrack.button.is/issue/GGIRCS-1393)