### PR TITLE
Update additional date in landing page copy

### DIFF
--- a/app/components/RegistrationLoginButtons.tsx
+++ b/app/components/RegistrationLoginButtons.tsx
@@ -2,7 +2,13 @@ import React from 'react';
 import {Col, Card} from 'react-bootstrap';
 import LoginButton from './LoginButton';
 
-const RegistrationLoginButtons = () => {
+interface Props {
+  applicationDeadline: string;
+}
+
+const RegistrationLoginButtons: React.FunctionComponent<Props> = ({
+  applicationDeadline
+}) => {
   return (
     <Col md={{span: 5, offset: 1}}>
       <Card style={{width: '100%', margin: '30px 0'}}>
@@ -11,9 +17,9 @@ const RegistrationLoginButtons = () => {
             Apply for the CleanBC Industrial Incentive Program (CIIP)
           </Card.Title>
           <Card.Text style={{padding: '10px 0 10px 0'}}>
-            Operators must submit a CIIP application form by June 30, 2019. As
-            part of the application, information about the operation’s energy
-            use, emissions, and production is required.
+            Operators must submit a CIIP application form by{' '}
+            {applicationDeadline}. As part of the application, information about
+            the operation’s energy use, emissions, and production is required.
           </Card.Text>
           <LoginButton
             style={{padding: '15px'}}

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -119,7 +119,9 @@ export default class Index extends Component<Props> {
               emissions benchmarks.
             </p>
           </Col>
-          <RegistrationLoginButtons />
+          <RegistrationLoginButtons
+            applicationDeadline={endDate.format('MMMM DD, YYYY')}
+          />
         </Row>
 
         <Row style={{marginTop: '100px'}} id="value-props">

--- a/app/pages/login-redirect.tsx
+++ b/app/pages/login-redirect.tsx
@@ -5,6 +5,10 @@ import {loginRedirectQueryResponse} from 'loginRedirectQuery.graphql';
 import {CiipPageComponentProps} from 'next-env';
 import DefaultLayout from 'layouts/default-layout';
 import RegistrationLoginButtons from 'components/RegistrationLoginButtons';
+import moment from 'moment-timezone';
+
+const TIME_ZONE = 'America/Vancouver';
+
 interface Props extends CiipPageComponentProps {
   query: loginRedirectQueryResponse['query'];
 }
@@ -16,13 +20,28 @@ export default class LoginRedirect extends Component<Props> {
         session {
           ...defaultLayout_session
         }
+        openedReportingYear {
+          applicationCloseTime
+        }
+        nextReportingYear {
+          applicationCloseTime
+        }
       }
     }
   `;
 
   render() {
     const {query} = this.props;
-    const {session} = query || {};
+    const {session, openedReportingYear, nextReportingYear} = query || {};
+
+    const deadline = moment
+      .tz(
+        openedReportingYear?.applicationCloseTime ??
+          nextReportingYear?.applicationCloseTime,
+        TIME_ZONE
+      )
+      .format('MMMM DD, YYYY');
+
     return (
       <DefaultLayout
         showSubheader={false}
@@ -41,7 +60,7 @@ export default class LoginRedirect extends Component<Props> {
               You will be redirected to the requested page after doing so.
             </p>
           </Col>
-          <RegistrationLoginButtons />
+          <RegistrationLoginButtons applicationDeadline={deadline} />
         </Row>
       </DefaultLayout>
     );

--- a/app/tests/unit/pages/__snapshots__/index.test.tsx.snap
+++ b/app/tests/unit/pages/__snapshots__/index.test.tsx.snap
@@ -44,7 +44,9 @@ exports[`landing It matches the last accepted Snapshot 1`] = `
         The CIIP helps industrial operations across the province by reducing net carbon-tax costs for facilities near world-leading emissions benchmarks.
       </p>
     </Col>
-    <RegistrationLoginButtons />
+    <RegistrationLoginButtons
+      applicationDeadline="December 30, 2019"
+    />
   </Row>
   <Row
     id="value-props"

--- a/app/tests/unit/pages/__snapshots__/login-redirect.test.tsx.snap
+++ b/app/tests/unit/pages/__snapshots__/login-redirect.test.tsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Login redirect page It matches the last accepted Snapshot 1`] = `
+<Relay(DefaultLayout)
+  needsSession={false}
+  needsUser={false}
+  session={null}
+  showSubheader={false}
+>
+  <Row
+    noGutters={false}
+    style={
+      Object {
+        "marginTop": "60px",
+      }
+    }
+  >
+    <Col
+      md={6}
+    >
+      <h3
+        className="blue"
+      >
+        You need to be logged in to access this page.
+      </h3>
+      <p>
+        Please log in or register in order to access this page.
+        <br />
+        You will be redirected to the requested page after doing so.
+      </p>
+    </Col>
+    <RegistrationLoginButtons
+      applicationDeadline="August 31, 2020"
+    />
+  </Row>
+</Relay(DefaultLayout)>
+`;

--- a/app/tests/unit/pages/login-redirect.test.tsx
+++ b/app/tests/unit/pages/login-redirect.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import LoginRedirect from 'pages/login-redirect';
+import {loginRedirectQueryResponse} from 'loginRedirectQuery.graphql';
+
+const query: loginRedirectQueryResponse['query'] = {
+  session: null,
+  openedReportingYear: {
+    applicationCloseTime: '2020-08-31 23:59:59.999-07'
+  },
+  nextReportingYear: {
+    applicationCloseTime: '2021-12-30 14:49:54.191-08'
+  }
+};
+
+describe('Login redirect page', () => {
+  it('It matches the last accepted Snapshot', () => {
+    const wrapper = shallow(<LoginRedirect query={query} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('It passes an application deadline to the RegistrationLoginButtons component', () => {
+    const wrapper = shallow(<LoginRedirect query={query} />);
+    expect(
+      wrapper
+        .find('RegistrationLoginButtons')
+        .first()
+        .prop('applicationDeadline')
+    ).toBe('August 31, 2020');
+  });
+});


### PR DESCRIPTION
- Updates the application close date in another place on the landing page, just above Register and Apply (missed in guidance doc for #667 aka. [GGIRCS-570](https://youtrack.button.is/issue/GGIRCS-570)). This date is no longer hard-coded in the copy.
- Adds a snapshot for the login-redirect page, where the above "Register and apply" component is also included.