### PR TITLE
Fix: requires_emission_allocation sanity check

### DIFF
--- a/app/containers/Forms/Form.tsx
+++ b/app/containers/Forms/Form.tsx
@@ -98,6 +98,31 @@ export const FormComponent: React.FunctionComponent<Props> = ({
       return result?.requiresEmissionAllocation === true;
     });
 
+  const customValidation = (formData, errors) => {
+    let hasFalseRequiresEmissionAllocation = false;
+    let nonEnergyProductCount = 0;
+    const productsInConflict = [];
+    if (formData[0]?.productRowId) {
+      formData.forEach((product, index: number) => {
+        if (product.requiresEmissionAllocation === false)
+          hasFalseRequiresEmissionAllocation = true;
+        if (product.productRowId > 7) {
+          nonEnergyProductCount++;
+          productsInConflict.push(index + 1);
+        }
+      });
+    }
+
+    if (hasFalseRequiresEmissionAllocation && nonEnergyProductCount > 1)
+      errors['0'].addError(
+        `More than one non-energy product that does not require allocation of emissions cannot be reported together. -- Products in conflict: ${productsInConflict.join(
+          ','
+        )}`
+      );
+
+    return errors;
+  };
+
   const formClass = uiSchema?.['ui:className'] || '';
   return (
     <div className={formClass}>
@@ -112,6 +137,7 @@ export const FormComponent: React.FunctionComponent<Props> = ({
       <JsonSchemaForm
         safeRenderCompletion
         noHtml5Validate
+        validate={customValidation}
         showErrorList={false}
         ArrayFieldTemplate={FormArrayFieldTemplate}
         FieldTemplate={FormFieldTemplate}

--- a/app/containers/Forms/Form.tsx
+++ b/app/containers/Forms/Form.tsx
@@ -106,7 +106,7 @@ export const FormComponent: React.FunctionComponent<Props> = ({
       formData.forEach((product, index: number) => {
         if (product.requiresEmissionAllocation === false)
           hasFalseRequiresEmissionAllocation = true;
-        if (product.productRowId > 7) {
+        if (product.isEnergyProduct === false) {
           nonEnergyProductCount++;
           productsInConflict.push(index + 1);
         }
@@ -115,9 +115,9 @@ export const FormComponent: React.FunctionComponent<Props> = ({
 
     if (hasFalseRequiresEmissionAllocation && nonEnergyProductCount > 1)
       errors['0'].addError(
-        `More than one non-energy product that does not require allocation of emissions cannot be reported together. -- Products in conflict: ${productsInConflict.join(
+        `Products: ${productsInConflict.join(
           ','
-        )}`
+        )} cannot be reported together as at least one of these products does not require manual allocation of emissions.`
       );
 
     return errors;

--- a/app/containers/Forms/ProductField.tsx
+++ b/app/containers/Forms/ProductField.tsx
@@ -50,7 +50,8 @@ export const ProductFieldComponent: React.FunctionComponent<Props> = (
       productRowId,
       productUnits: product?.units,
       requiresEmissionAllocation: product?.requiresEmissionAllocation,
-      requiresProductAmount: product?.requiresProductAmount
+      requiresProductAmount: product?.requiresProductAmount,
+      isEnergyProduct: product?.isEnergyProduct
     });
   };
 
@@ -79,6 +80,7 @@ export default createFragmentContainer(ProductFieldComponent, {
             productState
             requiresEmissionAllocation
             requiresProductAmount
+            isEnergyProduct
           }
         }
       }

--- a/app/containers/Products/ProductCreatorContainer.tsx
+++ b/app/containers/Products/ProductCreatorContainer.tsx
@@ -33,6 +33,7 @@ export const ProductCreator: React.FunctionComponent<Props> = ({
           productState: 'DRAFT' as CiipProductState,
           requiresEmissionAllocation: e.formData.requiresEmissionAllocation,
           isCiipProduct: e.formData.isCiipProduct,
+          isEnergyProduct: false,
           addPurchasedElectricityEmissions:
             e.formData.addPurchasedElectricityEmissions,
           subtractExportedElectricityEmissions:

--- a/app/containers/Products/ProductRowItemContainer.tsx
+++ b/app/containers/Products/ProductRowItemContainer.tsx
@@ -172,6 +172,7 @@ export const ProductRowItemComponent: React.FunctionComponent<Props> = ({
           productState: product.productState,
           requiresEmissionAllocation: e.formData.requiresEmissionAllocation,
           isCiipProduct: e.formData.isCiipProduct,
+          isEnergyProduct: false,
           addPurchasedElectricityEmissions:
             e.formData.addPurchasedElectricityEmissions,
           subtractExportedElectricityEmissions:

--- a/app/server/schema.graphql
+++ b/app/server/schema.graphql
@@ -9523,6 +9523,11 @@ type Product implements Node {
   isCiipProduct: Boolean!
 
   """
+  Boolean value indicates if the product is an energy product that is reported alongside other products
+  """
+  isEnergyProduct: Boolean!
+
+  """
   Boolean value indicates if the product is read-only and cannot be changed regardless of state
   """
   isReadOnly: Boolean!
@@ -9618,6 +9623,9 @@ input ProductCondition {
   """Checks for equality with the object’s `isCiipProduct` field."""
   isCiipProduct: Boolean
 
+  """Checks for equality with the object’s `isEnergyProduct` field."""
+  isEnergyProduct: Boolean
+
   """Checks for equality with the object’s `isReadOnly` field."""
   isReadOnly: Boolean
 
@@ -9706,6 +9714,11 @@ input ProductInput {
   Boolean value indicates if the product is benchmarked and has an associated incentive
   """
   isCiipProduct: Boolean
+
+  """
+  Boolean value indicates if the product is an energy product that is reported alongside other products
+  """
+  isEnergyProduct: Boolean
 
   """
   Boolean value indicates if the product is read-only and cannot be changed regardless of state
@@ -9808,6 +9821,11 @@ input ProductPatch {
   Boolean value indicates if the product is benchmarked and has an associated incentive
   """
   isCiipProduct: Boolean
+
+  """
+  Boolean value indicates if the product is an energy product that is reported alongside other products
+  """
+  isEnergyProduct: Boolean
 
   """
   Boolean value indicates if the product is read-only and cannot be changed regardless of state
@@ -9916,6 +9934,8 @@ enum ProductsOrderBy {
   ID_DESC
   IS_CIIP_PRODUCT_ASC
   IS_CIIP_PRODUCT_DESC
+  IS_ENERGY_PRODUCT_ASC
+  IS_ENERGY_PRODUCT_DESC
   IS_READ_ONLY_ASC
   IS_READ_ONLY_DESC
   NATURAL

--- a/app/server/schema.json
+++ b/app/server/schema.json
@@ -12329,6 +12329,22 @@
               "deprecationReason": null
             },
             {
+              "name": "isEnergyProduct",
+              "description": "Boolean value indicates if the product is an energy product that is reported alongside other products",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "isReadOnly",
               "description": "Boolean value indicates if the product is read-only and cannot be changed regardless of state",
               "args": [],
@@ -22323,6 +22339,16 @@
               "defaultValue": null
             },
             {
+              "name": "isEnergyProduct",
+              "description": "Checks for equality with the object’s `isEnergyProduct` field.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
               "name": "isReadOnly",
               "description": "Checks for equality with the object’s `isReadOnly` field.",
               "type": {
@@ -22569,6 +22595,18 @@
             },
             {
               "name": "IS_CIIP_PRODUCT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "IS_ENERGY_PRODUCT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "IS_ENERGY_PRODUCT_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -34779,6 +34817,16 @@
               "defaultValue": null
             },
             {
+              "name": "isEnergyProduct",
+              "description": "Boolean value indicates if the product is an energy product that is reported alongside other products",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
               "name": "isReadOnly",
               "description": "Boolean value indicates if the product is read-only and cannot be changed regardless of state",
               "type": {
@@ -45881,6 +45929,16 @@
             {
               "name": "isCiipProduct",
               "description": "Boolean value indicates if the product is benchmarked and has an associated incentive",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "isEnergyProduct",
+              "description": "Boolean value indicates if the product is an energy product that is reported alongside other products",
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",

--- a/app/tests/integration/Forms/__snapshots__/Form.test.tsx.snap
+++ b/app/tests/integration/Forms/__snapshots__/Form.test.tsx.snap
@@ -2215,7 +2215,7 @@ exports[`Form should match the snapshot with the production form 1`] = `
                       onKeyDown={[Function]}
                       onMouseUp={[Function]}
                       type="text"
-                      value="-60,000,000"
+                      value="-20,000,000"
                     />
                     <span
                       className="font-italic text-muted"
@@ -2250,7 +2250,7 @@ exports[`Form should match the snapshot with the production form 1`] = `
                       readOnly={true}
                       required={true}
                       type="text"
-                      value="consequat Ut Duis"
+                      value="in qui"
                     />
                     <span
                       className="font-italic text-muted"
@@ -2272,6 +2272,15 @@ exports[`Form should match the snapshot with the production form 1`] = `
                       id="root_0_requiresProductAmount"
                       type="hidden"
                       value={true}
+                    />
+                  </div>
+                  <div
+                    className="hidden"
+                  >
+                    <input
+                      id="root_0_isEnergyProduct"
+                      type="hidden"
+                      value={false}
                     />
                   </div>
                 </div>
@@ -2364,6 +2373,15 @@ exports[`Form should match the snapshot with the production form 1`] = `
                   >
                     <input
                       id="root_1_requiresProductAmount"
+                      type="hidden"
+                      value={false}
+                    />
+                  </div>
+                  <div
+                    className="hidden"
+                  >
+                    <input
+                      id="root_1_isEnergyProduct"
                       type="hidden"
                       value={false}
                     />

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationDetailsPdf.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationDetailsPdf.test.tsx.snap
@@ -1032,17 +1032,23 @@ exports[`ApplicationDetailsPdf should render application pdf donwload link 1`] =
               formData={
                 Array [
                   Object {
-                    "productRowId": 0,
+                    "isEnergyProduct": false,
+                    "productAmount": -20000000,
+                    "productEmissions": -60000000,
+                    "productRowId": -40000000,
+                    "productUnits": "in qui",
+                    "requiresEmissionAllocation": true,
+                    "requiresProductAmount": true,
+                  },
+                  Object {
+                    "isEnergyProduct": false,
+                    "productRowId": -20000000,
                     "requiresEmissionAllocation": false,
                     "requiresProductAmount": false,
                   },
                   Object {
-                    "productRowId": -40000000,
-                    "requiresEmissionAllocation": false,
-                    "requiresProductAmount": false,
-                  },
-                  Object {
-                    "productRowId": -40000000,
+                    "isEnergyProduct": false,
+                    "productRowId": -60000000,
                     "requiresEmissionAllocation": false,
                     "requiresProductAmount": false,
                   },
@@ -1116,6 +1122,9 @@ exports[`ApplicationDetailsPdf should render application pdf donwload link 1`] =
                         },
                       },
                       "properties": Object {
+                        "isEnergyProduct": Object {
+                          "type": "boolean",
+                        },
                         "productRowId": Object {
                           "title": "Product or Service",
                           "type": "integer",
@@ -1146,6 +1155,9 @@ exports[`ApplicationDetailsPdf should render application pdf donwload link 1`] =
               uiSchema={
                 Object {
                   "items": Object {
+                    "isEnergyProduct": Object {
+                      "ui:widget": "hidden",
+                    },
                     "productAmount": Object {
                       "ui:col-md": 4,
                       "ui:help": "Report the annual production for the product, following the guidance document provided",

--- a/app/tests/unit/containers/Forms/__snapshots__/Form.test.tsx.snap
+++ b/app/tests/unit/containers/Forms/__snapshots__/Form.test.tsx.snap
@@ -71,6 +71,7 @@ exports[`The Form Component should match the snapshot 1`] = `
     showErrorList={false}
     transformErrors={[Function]}
     uiSchema={Object {}}
+    validate={[Function]}
     widgets={
       Object {
         "SearchWidget": [Function],
@@ -684,6 +685,7 @@ exports[`The Form Component should not render an alert reminder to check the gui
     showErrorList={false}
     transformErrors={[Function]}
     uiSchema={Object {}}
+    validate={[Function]}
     widgets={
       Object {
         "SearchWidget": [Function],
@@ -1303,6 +1305,7 @@ exports[`The Form Component should render alert reminder to check the guidance i
     showErrorList={false}
     transformErrors={[Function]}
     uiSchema={Object {}}
+    validate={[Function]}
     widgets={
       Object {
         "SearchWidget": [Function],

--- a/app/tests/unit/containers/Forms/__snapshots__/ProductionFields.test.tsx.snap
+++ b/app/tests/unit/containers/Forms/__snapshots__/ProductionFields.test.tsx.snap
@@ -173,6 +173,9 @@ exports[`The ProductionFields Component with archived product should match the s
           },
         },
         "properties": Object {
+          "isEnergyProduct": Object {
+            "type": "boolean",
+          },
           "productRowId": Object {
             "title": "Product or Service",
             "type": "integer",
@@ -195,6 +198,9 @@ exports[`The ProductionFields Component with archived product should match the s
     uiSchema={
       Object {
         "items": Object {
+          "isEnergyProduct": Object {
+            "ui:widget": "hidden",
+          },
           "productAmount": Object {
             "ui:col-md": 4,
             "ui:help": "Report the annual production for the product, following the guidance document provided",
@@ -382,6 +388,9 @@ exports[`The ProductionFields Component with published product should match the 
         },
       },
       "properties": Object {
+        "isEnergyProduct": Object {
+          "type": "boolean",
+        },
         "productRowId": Object {
           "title": "Product or Service",
           "type": "integer",
@@ -404,6 +413,9 @@ exports[`The ProductionFields Component with published product should match the 
   uiSchema={
     Object {
       "items": Object {
+        "isEnergyProduct": Object {
+          "ui:widget": "hidden",
+        },
         "productAmount": Object {
           "ui:col-md": 4,
           "ui:help": "Report the annual production for the product, following the guidance document provided",

--- a/schema/data/prod/energy_product.sql
+++ b/schema/data/prod/energy_product.sql
@@ -3,16 +3,16 @@ begin;
 alter table ggircs_portal.product disable trigger _protect_read_only_products;
 
 with rows as (
-insert into ggircs_portal.product(id, product_name, units, product_state, requires_emission_allocation, requires_product_amount, is_read_only)
+insert into ggircs_portal.product(id, product_name, units, product_state, requires_emission_allocation, requires_product_amount, is_read_only, is_energy_product)
 overriding system value
 values
-(1, 'Exported electricity', 'MWh', 'published' ,true, true, true),
-(2, 'Exported heat', 'GJ', 'published' ,true, true, true),
-(3, 'Purchased electricity', 'GWh', 'published' ,true, true, true),
-(4, 'Purchased heat', 'GJ', 'published' ,true, true, true),
-(5, 'Generated electricity', 'GWh', 'published' ,true, true, true),
-(6, 'Generated heat', 'GJ', 'published' ,true, true, true),
-(7, 'Emissions from EIOs', 'GJ', 'published' ,true, true, true)
+(1, 'Exported electricity', 'MWh', 'published' ,true, true, true, true),
+(2, 'Exported heat', 'GJ', 'published' ,true, true, true, true),
+(3, 'Purchased electricity', 'GWh', 'published' ,true, true, true, true),
+(4, 'Purchased heat', 'GJ', 'published' ,true, true, true, true),
+(5, 'Generated electricity', 'GWh', 'published' ,true, true, true, true),
+(6, 'Generated heat', 'GJ', 'published' ,true, true, true, true),
+(7, 'Emissions from EIOs', 'GJ', 'published' ,true, true, true, true)
 on conflict(id) do update
 set
 product_name=excluded.product_name,
@@ -20,7 +20,8 @@ units=excluded.units,
 product_state=excluded.product_state,
 requires_emission_allocation=excluded.requires_emission_allocation,
 requires_product_amount=excluded.requires_product_amount,
-is_read_only=excluded.is_read_only
+is_read_only=excluded.is_read_only,
+is_energy_product=excluded.is_energy_product
 returning 1
 ) select 'Inserted ' || count(*) || ' rows into ggircs_portal.product' from rows;
 

--- a/schema/data/prod/form_json/production.json
+++ b/schema/data/prod/form_json/production.json
@@ -17,6 +17,9 @@
           },
           "requiresProductAmount": {
             "type": "boolean"
+          },
+          "isEnergyProduct": {
+            "type": "boolean"
           }
         },
 
@@ -95,7 +98,9 @@
         "ui:help": "Report emissions associated to CIIP product, in tCO2e"
       },
       "requiresEmissionAllocation": { "ui:widget": "hidden" },
-      "requiresProductAmount": { "ui:widget": "hidden" }
+      "requiresProductAmount": { "ui:widget": "hidden" },
+      "isEnergyProduct": { "ui:widget": "hidden" }
+
     }
   }
 }

--- a/schema/data/test/product.sql
+++ b/schema/data/test/product.sql
@@ -3,43 +3,43 @@ begin;
 alter table ggircs_portal.product disable trigger _protect_read_only_products;
 
 with rows as (
-insert into ggircs_portal.product(id, product_name, units, product_state, requires_emission_allocation, requires_product_amount, is_read_only)
+insert into ggircs_portal.product(id, product_name, units, product_state, requires_emission_allocation, requires_product_amount, is_read_only, is_energy_product)
 overriding system value
 values
-(8, 'Aluminum Smelting','tonnes of aluminum produced','published', true, true, false),
-(9, 'Cannabis (flowers and seedlings) grown under cover', 'hectares of growing space', 'published',true, true, false),
-(10, 'Cement equivalent', 'tonnes of cement equivalent','published',true, true, false),
-(11, 'Centrifugal Compression ','MWh','published',true, true, false),
-(12, 'Chemical Pulp', 'bone-dry tonnes','published' ,true, true, false),
-(13, 'Copper equivalent (open pit)','tonnes of Copper equivalent','published' ,true, true, false),
-(14, 'Copper equivalent (underground)','tonnes of Copper equivalent','published' ,true, true, false),
-(15, 'Food (including seedlings) grown under cover', 'hectares of growing space', 'published' ,true, true, false),
-(16, 'District energy (heat)', 'MWh','published' ,true, true, false),
-(17, 'Gold equivalent','tonnes of gold equivalent','published', true, true, false),
-(18, 'Forged steel balls (grinding media <3.5")','tonnes','published', true, true, false),
-(19, 'Forged steel balls (grinding media >4")','tonnes','published', true, true, false),
-(20, 'Gypsum wallboard','square meters','published', true, true, false),
-(21, 'Lime', 'tonnes','published', true, true, false),
-(22, 'Hot dip galvanizing','tonnes of wire processed','published' ,true, true, false),
-(23, 'Hydrogen Peroxide (H2O2)', 'tonnes of pure (100%) Hydrogen Peroxide produced','published' ,true, true, false),
-(24, 'Lead-Zinc Smelting','tonnes of lead and zinc','published',true, true, false),
-(25, 'Sweet Gas Plants','e3m3OE','published', true, true, false),
-(26, 'Sour Gas Plants','e3m3OE','published', true, true, false),
-(27, 'Sugar (liquid)', 'tonnes','published', true, true, false),
-(28, 'Sugar (solid)', 'tonnes','published', true, true, false),
-(29, 'Liquefied Natural Gas (LNG)', 'tonnes', 'published', true, true, false),
-(30, 'Lumber', 'cubic meters', 'published', true, true, false),
-(31, 'Coal','tonnes','published', true, true, false),
-(32, 'Veneer', 'cubic meters', 'published', true, true, false),
-(33, 'Wood Panels (Plywood, MDF, OSB)', 'cubic meters','published', true, true, false),
-(34, 'Other Pulp (Mechanical pulp, paper, newsprint)', 'bone-dry tonnes','published', true, true, false),
-(35, 'Wire draw production','tonnes of wire processed','published', true, true, false),
-(36, 'Reciprocating Compression ','MWh','published', true, true, false),
-(37, 'Silver Equivalent','tonnes of Silver equivalent','published', true, true, false),
-(38, 'Petroleum Refining','BC refining complexity factor unit','published',true, true, false),
-(39, 'Wood pellets', 'bone dry tonnes','published', true, true, false),
-(40, 'Wood chips', 'bone dry tonnes','published', true, true, false),
-(41, 'Waste rendering', 'tonnes','published', true, true, false)
+(8, 'Aluminum Smelting','tonnes of aluminum produced','published', true, true, false, false),
+(9, 'Cannabis (flowers and seedlings) grown under cover', 'hectares of growing space', 'published',true, true, false, false),
+(10, 'Cement equivalent', 'tonnes of cement equivalent','published',true, true, false, false),
+(11, 'Centrifugal Compression ','MWh','published',true, true, false, false),
+(12, 'Chemical Pulp', 'bone-dry tonnes','published' ,true, true, false, false),
+(13, 'Copper equivalent (open pit)','tonnes of Copper equivalent','published' ,true, true, false, false),
+(14, 'Copper equivalent (underground)','tonnes of Copper equivalent','published' ,true, true, false, false),
+(15, 'Food (including seedlings) grown under cover', 'hectares of growing space', 'published' ,true, true, false, false),
+(16, 'District energy (heat)', 'MWh','published' ,true, true, false, false),
+(17, 'Gold equivalent','tonnes of gold equivalent','published', true, true, false, false),
+(18, 'Forged steel balls (grinding media <3.5")','tonnes','published', true, true, false, false),
+(19, 'Forged steel balls (grinding media >4")','tonnes','published', true, true, false, false),
+(20, 'Gypsum wallboard','square meters','published', true, true, false, false),
+(21, 'Lime', 'tonnes','published', true, true, false, false),
+(22, 'Hot dip galvanizing','tonnes of wire processed','published' ,true, true, false, false),
+(23, 'Hydrogen Peroxide (H2O2)', 'tonnes of pure (100%) Hydrogen Peroxide produced','published' ,true, true, false, false),
+(24, 'Lead-Zinc Smelting','tonnes of lead and zinc','published',true, true, false, false),
+(25, 'Sweet Gas Plants','e3m3OE','published', true, true, false, false),
+(26, 'Sour Gas Plants','e3m3OE','published', true, true, false, false),
+(27, 'Sugar (liquid)', 'tonnes','published', true, true, false, false),
+(28, 'Sugar (solid)', 'tonnes','published', true, true, false, false),
+(29, 'Liquefied Natural Gas (LNG)', 'tonnes', 'published', true, true, false, false),
+(30, 'Lumber', 'cubic meters', 'published', true, true, false, false),
+(31, 'Coal','tonnes','published', true, true, false, false),
+(32, 'Veneer', 'cubic meters', 'published', true, true, false, false),
+(33, 'Wood Panels (Plywood, MDF, OSB)', 'cubic meters','published', true, true, false, false),
+(34, 'Other Pulp (Mechanical pulp, paper, newsprint)', 'bone-dry tonnes','published', true, true, false, false),
+(35, 'Wire draw production','tonnes of wire processed','published', true, true, false, false),
+(36, 'Reciprocating Compression ','MWh','published', true, true, false, false),
+(37, 'Silver Equivalent','tonnes of Silver equivalent','published', true, true, false, false),
+(38, 'Petroleum Refining','BC refining complexity factor unit','published',true, true, false, false),
+(39, 'Wood pellets', 'bone dry tonnes','published', true, true, false, false),
+(40, 'Wood chips', 'bone dry tonnes','published', true, true, false, false),
+(41, 'Waste rendering', 'tonnes','published', true, true, false, false)
 
 -- NOTE: Any changes to this file affects prod/energy_product.sql.
 --       Remember to update the IDs as necessary in that file as well.
@@ -50,7 +50,8 @@ units=excluded.units,
 product_state=excluded.product_state,
 requires_emission_allocation=excluded.requires_emission_allocation,
 requires_product_amount=excluded.requires_product_amount,
-is_read_only=excluded.is_read_only
+is_read_only=excluded.is_read_only,
+is_energy_product=excluded.is_energy_product
 returning 1
 ) select 'Inserted ' || count(*) || ' rows into ggircs_portal.product' from rows;
 

--- a/schema/deploy/computed_columns/application_revision_ciip_incentive.sql
+++ b/schema/deploy/computed_columns/application_revision_ciip_incentive.sql
@@ -50,7 +50,7 @@ returns setof ggircs_portal.ciip_incentive_by_product as $function$
     );
 
     -- ** Test for invalid number of products when a reported product.requires_emission_allocation = false ** --
-    non-energy_product_count := 0;
+    non_energy_product_count := 0;
     for i in 1..array_length(reported_products, 1)
       loop
         if reported_products[i].product_id > 7 then

--- a/schema/deploy/computed_columns/application_revision_ciip_incentive.sql
+++ b/schema/deploy/computed_columns/application_revision_ciip_incentive.sql
@@ -53,7 +53,7 @@ returns setof ggircs_portal.ciip_incentive_by_product as $function$
     non_energy_product_count := 0;
     for i in 1..array_length(reported_products, 1)
       loop
-        if reported_products[i].product_id > 7 then
+        if reported_products[i].is_energy_product = false then
           non_energy_product_count = non_energy_product_count+1;
         end if;
       end loop;

--- a/schema/deploy/computed_columns/application_revision_ciip_incentive.sql
+++ b/schema/deploy/computed_columns/application_revision_ciip_incentive.sql
@@ -50,13 +50,14 @@ returns setof ggircs_portal.ciip_incentive_by_product as $function$
     );
 
     -- ** Test for invalid number of products when a reported product.requires_emission_allocation = false ** --
-    non_energy_product_count := 0;
-    for i in 1..array_length(reported_products, 1)
-      loop
-        if reported_products[i].is_energy_product = false then
-          non_energy_product_count = non_energy_product_count+1;
-        end if;
-      end loop;
+    non_energy_product_count := (
+      select count(*)
+      from ggircs_portal.ciip_production
+      where
+        version_number = application_revision.version_number
+        and application_id = application_revision.application_id
+        and is_energy_product=false
+    );
 
     if (select count(*) from ggircs_portal.ciip_production
       where

--- a/schema/deploy/computed_columns/application_revision_ciip_incentive.sql
+++ b/schema/deploy/computed_columns/application_revision_ciip_incentive.sql
@@ -25,6 +25,7 @@ returns setof ggircs_portal.ciip_incentive_by_product as $function$
     benchmark_data ggircs_portal.benchmark;
     product_data ggircs_portal.product;
     product_return ggircs_portal.ciip_incentive_by_product;
+    non_energy_product_count integer;
 
   begin
 
@@ -47,6 +48,26 @@ returns setof ggircs_portal.ciip_incentive_by_product as $function$
         version_number = application_revision.version_number
         and application_id = application_revision.application_id
     );
+
+    -- ** Test for invalid number of products when a reported product.requires_emission_allocation = false ** --
+    non-energy_product_count := 0;
+    for i in 1..array_length(reported_products, 1)
+      loop
+        if reported_products[i].product_id > 7 then
+          non_energy_product_count = non_energy_product_count+1;
+        end if;
+      end loop;
+
+    if (select count(*) from ggircs_portal.ciip_production
+      where
+        version_number = application_revision.version_number
+        and application_id = application_revision.application_id
+        and requires_emission_allocation = false) > 0
+      and non_energy_product_count > 1
+    then
+      raise exception 'When a product has: requires_emission_allocation = false, only one reported product (excluding energy products) is allowed';
+    end if;
+    -- ** End test ** --
 
     reported_ciip_products = array(
       select row(ciip_production.*)

--- a/schema/deploy/search_functions/search_products.sql
+++ b/schema/deploy/search_functions/search_products.sql
@@ -40,14 +40,14 @@ returns setof ggircs_portal.product as
             'select
               id, product_name, units,
               product_state, requires_emission_allocation, is_ciip_product, requires_product_amount, subtract_exported_electricity_emissions, subtract_exported_electricity_emissions, subtract_exported_heat_emissions, subtract_exported_heat_emissions,
-              subtract_generated_electricity_emissions, subtract_generated_heat_emissions, add_emissions_from_eios, is_read_only, created_at, created_by, updated_at, updated_by, deleted_at, deleted_by
+              subtract_generated_electricity_emissions, subtract_generated_heat_emissions, add_emissions_from_eios, is_read_only, is_energy_product, created_at, created_by, updated_at, updated_by, deleted_at, deleted_by
               from innerTable order by ' || order_by_field || ' ' || direction;
       else
         return query execute search_query_input_query ||
           'select
             id, product_name, units, product_state,
             requires_emission_allocation, is_ciip_product, requires_product_amount, subtract_exported_electricity_emissions, subtract_exported_electricity_emissions, subtract_exported_heat_emissions, subtract_exported_heat_emissions,
-            subtract_generated_electricity_emissions, subtract_generated_heat_emissions, add_emissions_from_eios, is_read_only, created_at, created_by, updated_at, updated_by, deleted_at, deleted_by
+            subtract_generated_electricity_emissions, subtract_generated_heat_emissions, add_emissions_from_eios, is_read_only, is_energy_product, created_at, created_by, updated_at, updated_by, deleted_at, deleted_by
             from innerTable
           where
             '|| search_field || '::text ilike ''%' || search_value || '%''

--- a/schema/deploy/tables/product.sql
+++ b/schema/deploy/tables/product.sql
@@ -19,6 +19,7 @@ create table ggircs_portal.product (
   subtract_generated_heat_emissions boolean not null default false,
   add_emissions_from_eios boolean not null default false,
   is_read_only boolean not null default false,
+  is_energy_product boolean not null default false,
   created_at timestamp with time zone not null default now(),
   created_by int references ggircs_portal.ciip_user,
   updated_at timestamp with time zone not null default now(),
@@ -77,6 +78,7 @@ comment on column ggircs_portal.product.subtract_generated_electricity_emissions
 comment on column ggircs_portal.product.subtract_generated_heat_emissions is  'Boolean value indicates if generated heat emissions should be subtracted from the facility emissions when calculating the product emission intensity (applies only to products where requires_emission_allocation is false)';
 comment on column ggircs_portal.product.add_emissions_from_eios is  'Boolean value indicates if EIO facility emissions should be added to the facility emissions when calculating the product emission intensity';
 comment on column ggircs_portal.product.is_read_only is 'Boolean value indicates if the product is read-only and cannot be changed regardless of state';
+comment on column ggircs_portal.product.is_energy_product is 'Boolean value indicates if the product is an energy product that is reported alongside other products';
 comment on column ggircs_portal.product.product_state is 'The current state of the product within the lifecycle (draft, published, archived)';
 comment on column ggircs_portal.product.created_at is 'Creation date of row';
 comment on column ggircs_portal.product.created_by is 'Creator of row';

--- a/schema/deploy/views/ciip_production.sql
+++ b/schema/deploy/views/ciip_production.sql
@@ -19,7 +19,8 @@ begin;
        (x.production_data ->> 'productRowId')::integer as product_id,
        (x.production_data ->> 'productUnits')::varchar(1000) as product_units,
        (x.production_data ->> 'productEmissions')::numeric as product_emissions,
-       (x.production_data ->> 'requiresEmissionAllocation')::boolean as requires_emission_allocation
+       (x.production_data ->> 'requiresEmissionAllocation')::boolean as requires_emission_allocation,
+       (x.production_data ->> 'isEnergyProduct')::boolean as is_energy_product
     from x
  );
 
@@ -33,5 +34,6 @@ comment on column ggircs_portal.ciip_production.product_id is 'The id of the pro
 comment on column ggircs_portal.ciip_production.product_units is 'The units for the product';
 comment on column ggircs_portal.ciip_production.product_emissions is 'The amount of emissions, in tCO2e, allocated to the product';
 comment on column ggircs_portal.ciip_production.requires_emission_allocation is 'Whether or not the product requires reporting an emission allocaiton';
+comment on column ggircs_portal.ciip_production.is_energy_product is 'Boolean value indicates if the product is an energy product that is reported alongside other products';
 
 commit;

--- a/schema/deploy/views/ciip_production.sql
+++ b/schema/deploy/views/ciip_production.sql
@@ -33,7 +33,7 @@ comment on column ggircs_portal.ciip_production.product_amount is 'The yearly am
 comment on column ggircs_portal.ciip_production.product_id is 'The id of the product';
 comment on column ggircs_portal.ciip_production.product_units is 'The units for the product';
 comment on column ggircs_portal.ciip_production.product_emissions is 'The amount of emissions, in tCO2e, allocated to the product';
-comment on column ggircs_portal.ciip_production.requires_emission_allocation is 'Whether or not the product requires reporting an emission allocaiton';
+comment on column ggircs_portal.ciip_production.requires_emission_allocation is 'Whether or not the product requires reporting an emission allocation';
 comment on column ggircs_portal.ciip_production.is_energy_product is 'Boolean value indicates if the product is an energy product that is reported alongside other products';
 
 commit;

--- a/schema/deploy/views/ciip_production.sql
+++ b/schema/deploy/views/ciip_production.sql
@@ -18,7 +18,8 @@ begin;
        (x.production_data ->> 'productAmount')::numeric as product_amount,
        (x.production_data ->> 'productRowId')::integer as product_id,
        (x.production_data ->> 'productUnits')::varchar(1000) as product_units,
-       (x.production_data ->> 'productEmissions')::numeric as product_emissions
+       (x.production_data ->> 'productEmissions')::numeric as product_emissions,
+       (x.production_data ->> 'requiresEmissionAllocation')::boolean as requires_emission_allocation
     from x
  );
 
@@ -31,5 +32,6 @@ comment on column ggircs_portal.ciip_production.product_amount is 'The yearly am
 comment on column ggircs_portal.ciip_production.product_id is 'The id of the product';
 comment on column ggircs_portal.ciip_production.product_units is 'The units for the product';
 comment on column ggircs_portal.ciip_production.product_emissions is 'The amount of emissions, in tCO2e, allocated to the product';
+comment on column ggircs_portal.ciip_production.requires_emission_allocation is 'Whether or not the product requires reporting an emission allocaiton';
 
 commit;

--- a/schema/test/unit/computed_columns/application_revision_ciip_incentive_test.sql
+++ b/schema/test/unit/computed_columns/application_revision_ciip_incentive_test.sql
@@ -30,42 +30,43 @@ insert into ggircs_portal.product (
 )
 overriding system value
 values
-  (1, 'simple product (no allocation, emissions = facility emissions)', 'published',
+  (1, 'Purchased electricity', 'published',
+  true, false, true, false, false, false, false, false, false, false),
+  (2, 'Exported electricity', 'published',
+  true, true, true, false, false, false, false, false, false, false),
+  (3, 'Purchased heat', 'published',
+  true, false, true, false, false, false, false, false, false, false),
+  (4, 'Exported heat', 'published',
+  true, true, true, false, false, false, false, false, false, false),
+  (5, 'Electricity generated on site', 'published',
+  true, false, true, false, false, false, false, false, false, false),
+  (6, 'Heat generated on site', 'published',
+  true, false, true, false, false, false, false, false, false, false),
+  (7, 'Emissions from EIOs', 'published',
+  true, false, true, false, false, false, false, false, false, false),
+  (8, 'simple product (no allocation, emissions = facility emissions)', 'published',
   false, true, true, false, false, false, false, false, false, false),
-  (2, 'product A with allocation of emissions', 'published',
+  (9, 'product A with allocation of emissions', 'published',
   true, true, true, false, false, false, false, false, false, false),
-  (3, 'product B with allocation of emissions', 'published',
+  (10, 'product B with allocation of emissions', 'published',
   true, true, true, false, false, false, false, false, false, false),
-  (4, 'non-ciip product', 'published',
+  (11, 'non-ciip product', 'published',
   true, false, true, false, false, false, false, false, false, false),
-  (5, 'product with added purchased electricity emissions', 'published',
+  (12, 'product with added purchased electricity emissions', 'published',
   false, true, true, true, false, false, false, false, false, false),
-  (6, 'product with excluded exported electricity emissions', 'published',
+  (13, 'product with excluded exported electricity emissions', 'published',
   false, true, true, false, true, false, false, false, false, false),
-  (7, 'product with added purchased heat emissions', 'published',
+  (14, 'product with added purchased heat emissions', 'published',
   false, true, true, false, false, true, false, false, false, false),
-  (8, 'product with excluded exported heat emissions', 'published',
+  (15, 'product with excluded exported heat emissions', 'published',
   false, true, true, false, false, false, true, false, false, false),
-  (9, 'product with excluded generated electricity emissions', 'published',
+  (16, 'product with excluded generated electricity emissions', 'published',
   false, true, true, false, false, false, false, true, false, false),
-  (10, 'product with excluded generated heat emissions', 'published',
+  (17, 'product with excluded generated heat emissions', 'published',
   false, true, true, false, false, false, false, false, true, false),
-  (11, 'Purchased electricity', 'published',
-  true, false, true, false, false, false, false, false, false, false),
-  (12, 'Exported electricity', 'published',
-  true, true, true, false, false, false, false, false, false, false),
-  (13, 'Purchased heat', 'published',
-  true, false, true, false, false, false, false, false, false, false),
-  (14, 'Exported heat', 'published',
-  true, true, true, false, false, false, false, false, false, false),
-  (15, 'Electricity generated on site', 'published',
-  true, false, true, false, false, false, false, false, false, false),
-  (16, 'Heat generated on site', 'published',
-  true, false, true, false, false, false, false, false, false, false),
-  (17, 'product with added EIO emissions', 'published',
-  false, true, true, false, false, false, false, false, false, true),
-  (18, 'Emissions from EIOs', 'published',
-  true, false, true, false, false, false, false, false, false, false)
+  (18, 'product with added EIO emissions', 'published',
+  false, true, true, false, false, false, false, false, false, true)
+
 ;
 
 insert into ggircs_portal.benchmark
@@ -82,14 +83,14 @@ insert into ggircs_portal.benchmark
 )
 overriding system value
 values
-(1, 1, 0.25, 0.75, 1, 2018, 2018, 0, 1),
-(2, 2, 0.10, 0.30, 1, 2018, 2018, 0, 1),
-(3, 3, 0, 1, 1, 2018, 2018, 0.42, 0.42),
-(4, 5, 0, 1, 1, 2018, 2018, 0.42, 0.42),
-(5, 6, 0, 1, 1, 2018, 2018, 0.42, 0.42),
-(6, 7, 0, 1, 1, 2018, 2018, 0.42, 0.42),
-(8, 9, 0, 1, 1, 2018, 2018, 0.42, 0.42),
-(9, 17, 0, 1, 1, 2018, 2018, 0.42, 0.42);
+(1, 8, 0.25, 0.75, 1, 2018, 2018, 0, 1),
+(2, 9, 0.10, 0.30, 1, 2018, 2018, 0, 1),
+(3, 10, 0, 1, 1, 2018, 2018, 0.42, 0.42),
+(4, 11, 0, 1, 1, 2018, 2018, 0.42, 0.42),
+(5, 12, 0, 1, 1, 2018, 2018, 0.42, 0.42),
+(6, 13, 0, 1, 1, 2018, 2018, 0.42, 0.42),
+(8, 14, 0, 1, 1, 2018, 2018, 0.42, 0.42),
+(9, 18, 0, 1, 1, 2018, 2018, 0.42, 0.42);
 
 
 alter table ggircs_portal.application_revision_status disable trigger _status_change_email;
@@ -142,7 +143,7 @@ select lives_ok(
 update ggircs_portal.form_result
 set form_result = '[
   {
-    "productRowId": 1,
+    "productRowId": 8,
     "productAmount": 100
   }
 ]'
@@ -161,17 +162,17 @@ select is(
 update ggircs_portal.form_result
 set form_result = '[
   {
-    "productRowId": 2,
+    "productRowId": 9,
     "productAmount": 100,
     "productEmissions": 15
   },
   {
-    "productRowId": 3,
+    "productRowId": 10,
     "productAmount": 100,
     "productEmissions": 5
   },
   {
-    "productRowId": 4,
+    "productRowId": 11,
     "productAmount": 100,
     "productEmissions": 20
   }
@@ -187,7 +188,7 @@ select is(
     select incentive_ratio
     from ggircs_portal.application_revision_ciip_incentive(
       (select * from record)
-    ) where product_id = 2
+    ) where product_id = 9
   ),
   0.75,
   'the correct incentive ratio is returned with a product with allocation of emissions'
@@ -202,9 +203,9 @@ select is(
     select payment_allocation_factor
     from ggircs_portal.application_revision_ciip_incentive(
       (select * from record)
-    ) where product_id = 2
+    ) where product_id = 9
   ),
-  0.75, -- product 2 has 15t and product 3 5t,
+  0.75, -- product 9 has 15t and product 3 5t,
   'payment is automatically allocated between ciip products based on their share of emissions'
 );
 
@@ -217,7 +218,7 @@ select is(
     select incentive_ratio
     from ggircs_portal.application_revision_ciip_incentive(
       (select * from record)
-    ) where product_id = 3
+    ) where product_id = 10
   ),
   0.42,
   'incentive ratio is bound by minimum and maximum'
@@ -228,11 +229,11 @@ select is(
 update ggircs_portal.form_result
 set form_result = '[
   {
-    "productRowId": 5,
+    "productRowId": 12,
     "productAmount": 100
   },
   {
-    "productRowId": 11,
+    "productRowId": 1,
     "productAmount": 42,
     "productEmissions": 11
   }
@@ -248,7 +249,7 @@ select is(
     select product_emissions
     from ggircs_portal.application_revision_ciip_incentive(
       (select * from record)
-    ) where product_id = 5
+    ) where product_id = 12
   ),
   61.0,
   'purchased electricity emissions are added to the facility emissions for products that require it'
@@ -258,11 +259,11 @@ select is(
 update ggircs_portal.form_result
 set form_result = '[
   {
-    "productRowId": 6,
+    "productRowId": 13,
     "productAmount": 100
   },
   {
-    "productRowId": 12,
+    "productRowId": 2,
     "productAmount": 42,
     "productEmissions": 12
   }
@@ -278,7 +279,7 @@ select is(
     select product_emissions
     from ggircs_portal.application_revision_ciip_incentive(
       (select * from record)
-    ) where product_id = 6
+    ) where product_id = 13
   ),
   38.0,
   'exported electricity emissions are added to the facility emissions for products that require it'
@@ -288,11 +289,11 @@ select is(
 update ggircs_portal.form_result
 set form_result = '[
   {
-    "productRowId": 7,
+    "productRowId": 14,
     "productAmount": 100
   },
   {
-    "productRowId": 13,
+    "productRowId": 3,
     "productAmount": 42,
     "productEmissions": 13
   }
@@ -308,7 +309,7 @@ select is(
     select product_emissions
     from ggircs_portal.application_revision_ciip_incentive(
       (select * from record)
-    ) where product_id = 7
+    ) where product_id = 14
   ),
   63.0,
   'purchased heat emissions are removed from the facility emissions for products that require it'
@@ -318,11 +319,11 @@ select is(
 update ggircs_portal.form_result
 set form_result = '[
   {
-    "productRowId": 8,
+    "productRowId": 15,
     "productAmount": 100
   },
   {
-    "productRowId": 14,
+    "productRowId": 4,
     "productAmount": 42,
     "productEmissions": 14
   }
@@ -338,7 +339,7 @@ select is(
     select product_emissions
     from ggircs_portal.application_revision_ciip_incentive(
       (select * from record)
-    ) where product_id = 8
+    ) where product_id = 15
   ),
   36.0,
   'exported heat emissions are removed from the facility emissions for products that require it'
@@ -348,11 +349,11 @@ select is(
 update ggircs_portal.form_result
 set form_result = '[
   {
-    "productRowId": 17,
+    "productRowId": 18,
     "productAmount": 100
   },
   {
-    "productRowId": 18,
+    "productRowId": 7,
     "productAmount": 42,
     "productEmissions": 11
   }
@@ -368,10 +369,68 @@ select is(
     select product_emissions
     from ggircs_portal.application_revision_ciip_incentive(
       (select * from record)
-    ) where product_id = 17
+    ) where product_id = 18
   ),
   61.0,
   'EIO Emissions are added to the facility emissions for products that require it'
+);
+
+-- Report 2 non-energy products with requires_emission_allocation = false
+update ggircs_portal.form_result
+set form_result = '[
+  {
+    "productRowId": 11,
+    "productAmount": 100,
+    "requiresEmissionAllocation": false
+  },
+  {
+    "productRowId": 12,
+    "productAmount": 42,
+    "requiresEmissionAllocation": true
+  }
+]'
+where application_id = 1 and version_number = 1 and form_id = 4;
+
+select throws_like(
+  $$
+    with record as (
+      select row(application_revision.*)::ggircs_portal.application_revision
+      from ggircs_portal.application_revision where application_id = 1 and version_number = 1
+    )
+    select ggircs_portal.application_revision_ciip_incentive((select * from record))
+  $$,
+  '%When a product has: requires_emission_allocation = false%',
+  'Throws when 2 non-energy products are reported and requires_emission_allocation=false'
+);
+
+-- Report 2 non-energy products with requires_emission_allocation = false
+update ggircs_portal.form_result
+set form_result = '[
+  {
+    "productRowId": 18,
+    "productAmount": 100,
+    "requiresEmissionAllocation": false
+  },
+  {
+    "productRowId": 7,
+    "productAmount": 42
+  },
+  {
+    "productRowId": 1,
+    "productAmount": 42
+  }
+]'
+where application_id = 1 and version_number = 1 and form_id = 4;
+
+select lives_ok(
+  $$
+    with record as (
+      select row(application_revision.*)::ggircs_portal.application_revision
+      from ggircs_portal.application_revision where application_id = 1 and version_number = 1
+    )
+    select ggircs_portal.application_revision_ciip_incentive((select * from record))
+  $$,
+  'Does not throw when 2 non-energy products are reported and requires_emission_allocation=false but all other products are energy products'
 );
 
 -- Test roles

--- a/schema/test/unit/computed_columns/application_revision_ciip_incentive_test.sql
+++ b/schema/test/unit/computed_columns/application_revision_ciip_incentive_test.sql
@@ -26,46 +26,47 @@ insert into ggircs_portal.product (
   subtract_exported_heat_emissions,
   subtract_generated_electricity_emissions,
   subtract_generated_heat_emissions,
-  add_emissions_from_eios
+  add_emissions_from_eios,
+  is_energy_product
 )
 overriding system value
 values
   (1, 'Purchased electricity', 'published',
-  true, false, true, false, false, false, false, false, false, false),
+  true, false, true, false, false, false, false, false, false, false, true),
   (2, 'Exported electricity', 'published',
-  true, true, true, false, false, false, false, false, false, false),
+  true, true, true, false, false, false, false, false, false, false, true),
   (3, 'Purchased heat', 'published',
-  true, false, true, false, false, false, false, false, false, false),
+  true, false, true, false, false, false, false, false, false, false, true),
   (4, 'Exported heat', 'published',
-  true, true, true, false, false, false, false, false, false, false),
+  true, true, true, false, false, false, false, false, false, false, true),
   (5, 'Electricity generated on site', 'published',
-  true, false, true, false, false, false, false, false, false, false),
+  true, false, true, false, false, false, false, false, false, false, true),
   (6, 'Heat generated on site', 'published',
-  true, false, true, false, false, false, false, false, false, false),
+  true, false, true, false, false, false, false, false, false, false, true),
   (7, 'Emissions from EIOs', 'published',
-  true, false, true, false, false, false, false, false, false, false),
+  true, false, true, false, false, false, false, false, false, false, true),
   (8, 'simple product (no allocation, emissions = facility emissions)', 'published',
-  false, true, true, false, false, false, false, false, false, false),
+  false, true, true, false, false, false, false, false, false, false, false),
   (9, 'product A with allocation of emissions', 'published',
-  true, true, true, false, false, false, false, false, false, false),
+  true, true, true, false, false, false, false, false, false, false, false),
   (10, 'product B with allocation of emissions', 'published',
-  true, true, true, false, false, false, false, false, false, false),
+  true, true, true, false, false, false, false, false, false, false, false),
   (11, 'non-ciip product', 'published',
-  true, false, true, false, false, false, false, false, false, false),
+  true, false, true, false, false, false, false, false, false, false, false),
   (12, 'product with added purchased electricity emissions', 'published',
-  false, true, true, true, false, false, false, false, false, false),
+  false, true, true, true, false, false, false, false, false, false, false),
   (13, 'product with excluded exported electricity emissions', 'published',
-  false, true, true, false, true, false, false, false, false, false),
+  false, true, true, false, true, false, false, false, false, false, false),
   (14, 'product with added purchased heat emissions', 'published',
-  false, true, true, false, false, true, false, false, false, false),
+  false, true, true, false, false, true, false, false, false, false, false),
   (15, 'product with excluded exported heat emissions', 'published',
-  false, true, true, false, false, false, true, false, false, false),
+  false, true, true, false, false, false, true, false, false, false, false),
   (16, 'product with excluded generated electricity emissions', 'published',
-  false, true, true, false, false, false, false, true, false, false),
+  false, true, true, false, false, false, false, true, false, false, false),
   (17, 'product with excluded generated heat emissions', 'published',
-  false, true, true, false, false, false, false, false, true, false),
+  false, true, true, false, false, false, false, false, true, false, false),
   (18, 'product with added EIO emissions', 'published',
-  false, true, true, false, false, false, false, false, false, true)
+  false, true, true, false, false, false, false, false, false, true, false)
 
 ;
 
@@ -381,12 +382,14 @@ set form_result = '[
   {
     "productRowId": 11,
     "productAmount": 100,
-    "requiresEmissionAllocation": false
+    "requiresEmissionAllocation": false,
+    "isEnergyProduct": false
   },
   {
     "productRowId": 12,
     "productAmount": 42,
-    "requiresEmissionAllocation": true
+    "requiresEmissionAllocation": true,
+    "isEnergyProduct": false
   }
 ]'
 where application_id = 1 and version_number = 1 and form_id = 4;


### PR DESCRIPTION
- Adds a database exception in application_revision_ciip_incentive if:
  - 2 products are reported where requires_emission_allocation = false AND
  - Both products are non-energy products
- Adds front-end custom validation that will throw an error in the production form for the same conditions.