### PR TITLE
feat: Separate pages for CIIP application disclaimer vs. website disclaimer

### DIFF
--- a/app/components/LegalDisclaimerText.tsx
+++ b/app/components/LegalDisclaimerText.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default () => {
+const LegalDisclaimerText: React.FunctionComponent = () => {
   return (
     <>
       <ol id="glossary">
@@ -137,3 +137,5 @@ export default () => {
     </>
   );
 };
+
+export default LegalDisclaimerText;

--- a/app/pages/certifier/certify.tsx
+++ b/app/pages/certifier/certify.tsx
@@ -66,7 +66,7 @@ class Certify extends Component<Props> {
             <Card.Text style={{padding: '10px 0 10px 0'}}>
               Please review the information below before approving an
               application.{' '}
-              <a href="/resources/disclaimer" target="_blank">
+              <a href="/resources/application-disclaimer" target="_blank">
                 (<FontAwesomeIcon icon={faExternalLinkAlt} />
                 expand)
               </a>

--- a/app/pages/resources/application-disclaimer.tsx
+++ b/app/pages/resources/application-disclaimer.tsx
@@ -1,16 +1,18 @@
 import React, {Component} from 'react';
+import {Container} from 'react-bootstrap';
 import {graphql} from 'react-relay';
 import {CiipPageComponentProps} from 'next-env';
-import {disclaimerQueryResponse} from 'disclaimerQuery.graphql';
+import {applicationDisclaimerQueryResponse} from 'applicationDisclaimerQuery.graphql';
 import DefaultLayout from 'layouts/default-layout';
+import LegalDisclaimerText from 'components/LegalDisclaimerText';
 
 interface Props extends CiipPageComponentProps {
-  query: disclaimerQueryResponse['query'];
+  query: applicationDisclaimerQueryResponse['query'];
 }
 
-class Disclaimer extends Component<Props> {
+class ApplicationDisclaimer extends Component<Props> {
   static query = graphql`
-    query disclaimerQuery {
+    query applicationDisclaimerQuery {
       query {
         session {
           ...defaultLayout_session
@@ -27,10 +29,14 @@ class Disclaimer extends Component<Props> {
         session={session}
         needsSession={false}
         needsUser={false}
-        title="Disclaimer"
-      />
+        title="CIIP Application Disclaimer"
+      >
+        <Container>
+          <LegalDisclaimerText />
+        </Container>
+      </DefaultLayout>
     );
   }
 }
 
-export default Disclaimer;
+export default ApplicationDisclaimer;

--- a/app/tests/unit/components/LegalDisclaimerText.test.tsx
+++ b/app/tests/unit/components/LegalDisclaimerText.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import LegalDisclaimerText from 'components/LegalDisclaimerText';
+
+describe('LegalDisclaimerText Component', () => {
+  it('should match the last snapshot', () => {
+    const render = shallow(<LegalDisclaimerText />);
+    expect(render).toMatchSnapshot();
+  });
+});

--- a/app/tests/unit/components/__snapshots__/LegalDisclaimerText.test.tsx.snap
+++ b/app/tests/unit/components/__snapshots__/LegalDisclaimerText.test.tsx.snap
@@ -1,0 +1,149 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LegalDisclaimerText Component should match the last snapshot 1`] = `
+<Fragment>
+  <ol
+    id="glossary"
+  >
+    <li>
+      (a) "CIIP" means the
+       
+      <a
+        href="https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry/cleanbc-industrial-incentive-program"
+      >
+        CleanBC Industrial Incentive Program;
+      </a>
+    </li>
+    <li>
+      (b) "Certifying Official" means the person who approves this application on behalf of the Operator;
+    </li>
+    <li>
+      (c) "GGIRCA" means
+       
+      <em>
+        Greenhouse Gas Industrial Reporting and Control Act
+      </em>
+      ;
+    </li>
+    <li>
+      (d) "Operator" means the person identified in the Greenhouse Gas Emission Reporting Regulation responsible for the industrial operation considered in this application;
+    </li>
+    <li>
+      (e) "Province" means Her Majesty the Queen in Right of British Columbia;
+    </li>
+    <li>
+      (f) "Reporting Operation" means the industrial operation identified in the application;
+    </li>
+    <li>
+      (g) "Representative" means the individual completing this application.
+    </li>
+  </ol>
+  <p>
+    By the Certifying Official approving and the Representative or Operator submitting an application to the CleanBC Industrial Incentive Program:
+  </p>
+  <ol
+    className="jsx-3350969095"
+    id="consents"
+  >
+    <li
+      className="jsx-3350969095"
+    >
+      The Certifying Official warrants and represents that the Certifying Official has the authority to, on behalf of the Operator, enter into the following terms and provide the following consents and certifications.
+    </li>
+    <li
+      className="jsx-3350969095"
+    >
+      The Certifying Official and Operator certify that Certifying Official has reviewed the information being submitted, and has exercised due diligence to ensure that the information is true and complete, and that, to the best of the Certifying Official's knowledge, the information submitted herein is accurate and based on reasonable estimates using available data.
+    </li>
+    <li
+      className="jsx-3350969095"
+    >
+      The Operator agrees to repay any incentive amounts erroneously paid or which are, upon audit or review by the Province of British Columbia, are determined by the Province to be either inconsistent with
+       
+      <a
+        className="jsx-3350969095"
+        href="https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry/cleanbc-industrial-incentive-program"
+      >
+        CIIP Rules
+      </a>
+       
+      or not supported by evidence related to fuel usage and tax paid, and acknowledges that any repayment amount may be deducted from a following year's incentive payment, or other payments due to the Operator from the Province.
+    </li>
+    <li
+      className="jsx-3350969095"
+    >
+      The Operator consents to the release by the Province's Ministry of Finance, to the Ministry of Environment and Climate Change Strategy, of information collected in the Operator's carbon tax account(s), and if applicable, other required taxpayer information about the Operator, whether supplied by the Operator or by a third party, for the purpose of administering GGIRCA. This consent is specific to information relating to the two taxation years (April 1st to March 31st) prior to the year of this consent and the current taxation year and is effective on the date the Representative submits this form. The consent will remain in effect for one year.
+    </li>
+    <li
+      className="jsx-3350969095"
+    >
+      The Operator consents to the release, by government employees responsible for administering GGIRCA, to employees, contractors and agencies of the Province responsible for administering the CleanBC Program for Industry of information contained in emission reports made under GGIRCA and submitted in relation to the Reporting Operation, for the purposes of administering the CleanBC Program for Industry. This consent is specific to emission reports made in respect of the three reporting periods prior to the submission of this application and will remain in effect for one year.
+    </li>
+    <li
+      className="jsx-3350969095"
+    >
+      The Operator consents to the release, by government employees responsible for administering CleanBC Program for Industry, to employees responsible for administering GGIRCA, of information contained in this application, for the purposes of administering GGIRCA. This consent is specific to this application and will remain in effect for one year.
+    </li>
+    <li
+      className="jsx-3350969095"
+    >
+      The Operator acknowledges that information provided by the Ministry of Environment and Climate Change Strategy to the Ministry of Finance may be used for the purposes of administering and enforcing the
+       
+      <em
+        className="jsx-3350969095"
+      >
+        Carbon Tax Act
+      </em>
+      .
+    </li>
+    <li
+      className="jsx-3350969095"
+    >
+      All information for which consent has been granted will be subject to government policies, directives and standards relating to the confidentiality of information.
+    </li>
+    <li
+      className="jsx-3350969095"
+    >
+      The Operator may at any time withdrawal its consent under paragraph
+       
+      <strong
+        className="jsx-3350969095"
+      >
+        d
+      </strong>
+       by submitting a withdrawal of consent in a form specified by the Province's Fuel and Carbon Tax Section. Forms may be obtained by submitting a request in writing to the Fuel and Carbon Tax Section, Consumer Taxation Programs Branch, Ministry of Finance, PO Box 9447 Stn Prov Govt, Victoria BC V8W 9V7.
+    </li>
+    <li
+      className="jsx-3350969095"
+    >
+      The Operator may at any time withdrawal its consent under paragraph
+       
+      <strong
+        className="jsx-3350969095"
+      >
+        e
+      </strong>
+       or 
+      <strong
+        className="jsx-3350969095"
+      >
+        f
+      </strong>
+       by submitting a withdrawal of consent in a form specified by the director appointed under GGIRCA. Forms may be obtained by submitting an email request to
+       
+      <a
+        className="jsx-3350969095"
+        href="mailto:ghgregulator@gov.bc.ca"
+      >
+        ghgregulator@gov.bc.ca
+      </a>
+      .
+    </li>
+    <JSXStyle
+      id="3350969095"
+    >
+      ol#glossary{list-style-type:none;padding-left:0.5em;}ol#consents{list-style-type:lower-alpha;}
+    </JSXStyle>
+  </ol>
+</Fragment>
+`;

--- a/app/tests/unit/pages/__snapshots__/application-disclaimer.test.tsx.snap
+++ b/app/tests/unit/pages/__snapshots__/application-disclaimer.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Program application-specific disclaimer page It matches the last accepted Snapshot 1`] = `
+<Relay(DefaultLayout)
+  needsSession={false}
+  needsUser={false}
+  session={
+    Object {
+      " $fragmentRefs": Object {
+        "defaultLayout_session": true,
+      },
+    }
+  }
+  title="CIIP Application Disclaimer"
+>
+  <Container
+    fluid={false}
+  >
+    <LegalDisclaimerText />
+  </Container>
+</Relay(DefaultLayout)>
+`;

--- a/app/tests/unit/pages/application-disclaimer.test.tsx
+++ b/app/tests/unit/pages/application-disclaimer.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import ApplicationDisclaimer from 'pages/resources/application-disclaimer';
+import {applicationDisclaimerQueryResponse} from 'applicationDisclaimerQuery.graphql';
+
+const query: applicationDisclaimerQueryResponse['query'] = {
+  session: {
+    ' $fragmentRefs': {
+      defaultLayout_session: true
+    }
+  }
+};
+
+const router = {
+  query: {
+    applicationId: 'skjdh839',
+    hasSwrsReport: true,
+    version: 1
+  }
+};
+
+describe('Program application-specific disclaimer page', () => {
+  it('It matches the last accepted Snapshot', () => {
+    const wrapper = shallow(
+      <ApplicationDisclaimer query={query} router={router} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Addendum to [GGIRCS-1517](https://youtrack.button.is/issue/GGIRCS-1517) which added a page for a CIIP-specific disclaimer. However, we want to reserve space at this URL (`/resources/disclaimer`) for the boilerplate website disclaimer from Devhub.

The CIIP-specific disclaimer will now live at `/resources/application-disclaimer` instead.