### PR TITLE
fix: hardcoded limit in search functions

### DIFF
--- a/app/containers/Certifier/CertificationRequestsContainer.tsx
+++ b/app/containers/Certifier/CertificationRequestsContainer.tsx
@@ -54,6 +54,7 @@ export const CertificationRequestsComponent: React.FunctionComponent<Props> = ({
 
   const [offsetValue, setOffset] = useState(0);
   const [activePage, setActivePage] = useState(1);
+  const maxResultsPerPage = 20;
 
   useEffect(() => {
     const refetchVariables = {
@@ -62,6 +63,7 @@ export const CertificationRequestsComponent: React.FunctionComponent<Props> = ({
       orderByField,
       direction,
       offsetValue,
+      maxResultsPerPage,
       forceRefetch
     };
     relay.refetch(refetchVariables, undefined, (error) => {
@@ -83,6 +85,7 @@ export const CertificationRequestsComponent: React.FunctionComponent<Props> = ({
     orderByField,
     direction,
     offsetValue,
+    maxResultsPerPage,
     forceRefetch,
     query
   ]);
@@ -179,8 +182,6 @@ export const CertificationRequestsComponent: React.FunctionComponent<Props> = ({
     </tbody>
   );
 
-  const maxResultsPerPage = 20;
-
   const totalRequestCount =
     query?.searchCertificationRequests?.edges[0]?.node?.totalRequestCount || 0;
 
@@ -217,6 +218,7 @@ export default createRefetchContainer(
           direction: {type: "String"}
           offsetValue: {type: "Int"}
           forceRefetch: {type: "Int"}
+          maxResultsPerPage: {type: "Int"}
         ) {
         searchCertificationRequests(
           searchField: $searchField
@@ -224,6 +226,7 @@ export default createRefetchContainer(
           orderByField: $orderByField
           direction: $direction
           offsetValue: $offsetValue
+          maxResultsPerPage: $maxResultsPerPage
         ) {
           edges {
             node {
@@ -260,6 +263,7 @@ export default createRefetchContainer(
       $direction: String
       $offsetValue: Int
       $forceRefetch: Int
+      $maxResultsPerPage: Int
     ) {
       query {
         ...CertificationRequestsContainer_query
@@ -270,6 +274,7 @@ export default createRefetchContainer(
             searchValue: $searchValue
             offsetValue: $offsetValue
             forceRefetch: $forceRefetch
+            maxResultsPerPage: $maxResultsPerPage
           )
       }
     }

--- a/app/containers/Facilities/FacilitiesListContainer.tsx
+++ b/app/containers/Facilities/FacilitiesListContainer.tsx
@@ -38,6 +38,7 @@ export const FacilitiesList: React.FunctionComponent<Props> = ({
   let [facilityCount, updateFacilityCount] = useState(facilityNumber);
   const [offsetValue, setOffset] = useState(0);
   const [activePage, setActivePage] = useState(1);
+  const maxResultsPerPage = 10;
   useEffect(() => {
     const refetchVariables = {
       searchField,
@@ -45,6 +46,7 @@ export const FacilitiesList: React.FunctionComponent<Props> = ({
       orderByField,
       direction,
       facilityCount,
+      maxResultsPerPage,
       offsetValue
     };
     relay.refetch(refetchVariables);
@@ -78,8 +80,6 @@ export const FacilitiesList: React.FunctionComponent<Props> = ({
     console.log(response);
     updateFacilityCount((facilityCount += 1));
   };
-
-  const maxResultsPerPage = 10;
 
   const totalFacilityCount =
     query?.searchAllFacilities?.edges[0]?.node?.totalFacilityCount || 0;
@@ -123,6 +123,7 @@ export default createRefetchContainer(
           organisationRowId: {type: "String"}
           facilityCount: {type: "Int"}
           offsetValue: {type: "Int"}
+          maxResultsPerPage: {type: "Int"}
         ) {
         ...FacilitiesRowItemContainer_query
         searchAllFacilities(
@@ -132,6 +133,7 @@ export default createRefetchContainer(
           organisationRowId: $organisationRowId
           direction: $direction
           offsetValue: $offsetValue
+          maxResultsPerPage: $maxResultsPerPage
         ) {
           edges {
             node {
@@ -163,6 +165,7 @@ export default createRefetchContainer(
       $organisationRowId: String
       $facilityCount: Int
       $offsetValue: Int
+      $maxResultsPerPage: Int
     ) {
       query {
         ...FacilitiesListContainer_query
@@ -175,6 +178,7 @@ export default createRefetchContainer(
             organisationId: $organisationId
             facilityCount: $facilityCount
             offsetValue: $offsetValue
+            maxResultsPerPage: $maxResultsPerPage
           )
       }
     }

--- a/app/pages/certifier/requests.tsx
+++ b/app/pages/certifier/requests.tsx
@@ -27,6 +27,7 @@ export default class CertifierRequests extends Component<Props> {
       $orderByField: String
       $direction: String
       $offsetValue: Int
+      $maxResultsPerPage: Int
     ) {
       query {
         session {
@@ -39,6 +40,7 @@ export default class CertifierRequests extends Component<Props> {
             orderByField: $orderByField
             direction: $direction
             offsetValue: $offsetValue
+            maxResultsPerPage: $maxResultsPerPage
           )
       }
     }
@@ -59,7 +61,8 @@ export default class CertifierRequests extends Component<Props> {
       variables: {
         orderByField: 'facility_name',
         direction: 'ASC',
-        offsetValue: 0
+        offsetValue: 0,
+        maxResultsPerPage: 20
       }
     };
   }

--- a/app/pages/reporter/facilities-list.tsx
+++ b/app/pages/reporter/facilities-list.tsx
@@ -23,6 +23,7 @@ class FacilitiesList extends Component<Props> {
       $organisationId: ID!
       $organisationRowId: String
       $offsetValue: Int
+      $maxResultsPerPage: Int
     ) {
       query {
         ...FacilitiesListContainer_query
@@ -34,6 +35,7 @@ class FacilitiesList extends Component<Props> {
             organisationId: $organisationId
             organisationRowId: $organisationRowId
             offsetValue: $offsetValue
+            maxResultsPerPage: $maxResultsPerPage
           )
         session {
           ...defaultLayout_session
@@ -47,7 +49,8 @@ class FacilitiesList extends Component<Props> {
       variables: {
         orderByField: 'facility_name',
         direction: 'ASC',
-        offsetValue: 0
+        offsetValue: 0,
+        maxResultsPerPage: 10
       }
     };
   }

--- a/app/server/schema.graphql
+++ b/app/server/schema.graphql
@@ -10862,6 +10862,7 @@ type Query implements Node {
 
     """Only read the last `n` values of the set."""
     last: Int
+    maxResultsPerPage: Int
 
     """
     Skip the first `n` values from our `after` cursor, an alternative to cursor
@@ -10918,6 +10919,7 @@ type Query implements Node {
 
     """Only read the last `n` values of the set."""
     last: Int
+    maxResultsPerPage: Int
 
     """
     Skip the first `n` values from our `after` cursor, an alternative to cursor

--- a/app/server/schema.json
+++ b/app/server/schema.json
@@ -3552,6 +3552,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "maxResultsPerPage",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "offset",
                   "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor based pagination. May not be used with `last`.",
                   "type": {
@@ -3778,6 +3788,16 @@
                 {
                   "name": "last",
                   "description": "Only read the last `n` values of the set.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "maxResultsPerPage",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",

--- a/schema/deploy/search_functions/search_all_facilities.sql
+++ b/schema/deploy/search_functions/search_all_facilities.sql
@@ -4,7 +4,7 @@
 
 begin;
 
-create or replace function ggircs_portal.search_all_facilities(search_field text, search_value text, order_by_field text, direction text, organisation_row_id text, offset_value int)
+create or replace function ggircs_portal.search_all_facilities(search_field text, search_value text, order_by_field text, direction text, organisation_row_id text, offset_value int, max_results_per_page int)
 
   returns setof ggircs_portal.facility_search_result as
     $function$
@@ -69,11 +69,11 @@ create or replace function ggircs_portal.search_all_facilities(search_field text
 
         if search_field is null or search_value is null
           then return query execute search_query_input_query ||
-          'select organisationInfo.*, total_facility_count from organisationInfo, total_count order by ' || order_by_field || ' ' || direction || ' limit 10 offset ' || offset_value;
+          'select organisationInfo.*, total_facility_count from organisationInfo, total_count order by ' || order_by_field || ' ' || direction || ' limit '|| max_results_per_page ||'  offset ' || offset_value;
         else
           return query execute search_query_input_query ||
             'select organisationInfo.*, total_facility_count from organisationInfo, total_count
-            where '|| search_field || '::text ilike ''%' || search_value || '%'' order by '|| order_by_field || ' ' || direction || ' limit 10 offset ' || offset_value;
+            where '|| search_field || '::text ilike ''%' || search_value || '%'' order by '|| order_by_field || ' ' || direction || ' limit '|| max_results_per_page ||' offset ' || offset_value;
         end if;
       end
     $function$ language plpgsql stable;

--- a/schema/deploy/search_functions/search_certification_requests.sql
+++ b/schema/deploy/search_functions/search_certification_requests.sql
@@ -8,7 +8,8 @@ begin;
     search_value text[],
     order_by_field text,
     direction text,
-    offset_value int
+    offset_value int,
+    max_results_per_page int
   )
   returns setof ggircs_portal.search_certification_url_result
   as
@@ -70,7 +71,7 @@ begin;
 
         if search_field[1] is null then
           return query execute
-            search_query || ' where certifier_email = ' || quote_literal(user_email) || ' ' || order_by_string || ' limit 20 offset ' || offset_value;
+            search_query || ' where certifier_email = ' || quote_literal(user_email) || ' ' || order_by_string || ' limit '|| max_results_per_page ||' offset ' || offset_value;
         else
           case
 
@@ -93,7 +94,7 @@ begin;
 
       return query execute
         search_query ||
-        ' where certifier_email = ' || quote_literal(user_email)|| ' ' || search_string || order_by_string || ' limit 20 offset ' || offset_value;
+        ' where certifier_email = ' || quote_literal(user_email)|| ' ' || search_string || order_by_string || ' limit '|| max_results_per_page ||' offset ' || offset_value;
       end if;
     end;
   $body$

--- a/schema/test/unit/search_functions/function_search_all_facilities_test.sql
+++ b/schema/test/unit/search_functions/function_search_all_facilities_test.sql
@@ -7,14 +7,14 @@ begin;
 select plan(3);
 
 select has_function(
-  'ggircs_portal', 'search_all_facilities', array['text', 'text', 'text', 'text', 'text', 'int'],
+  'ggircs_portal', 'search_all_facilities', array['text', 'text', 'text', 'text', 'text', 'int', 'int'],
   'Function search_all_facilities should exist'
 );
 
 set jwt.claims.sub to '00000000-0000-0000-0000-000000000000';
 
 select is(
-  (select count(*) from ggircs_portal.search_all_facilities(null, null, 'id', 'asc', null, 0)),
+  (select count(*) from ggircs_portal.search_all_facilities(null, null, 'id', 'asc', null, 0, 10000)),
   (select count(*) from ggircs_portal.facility f
     join ggircs_portal.ciip_user_organisation cuo on f.organisation_id = cuo.organisation_id
     join ggircs_portal.ciip_user cu on cuo.user_id = cu.id
@@ -22,7 +22,7 @@ select is(
   'The search_all_facilities function should return all the facilities attached to organisations the user has access to if there is organisaion_row_id is null');
 
 select is(
-  (select count(*) from ggircs_portal.search_all_facilities(null, null, 'id', 'asc', '8', 0)),
+  (select count(*) from ggircs_portal.search_all_facilities(null, null, 'id', 'asc', '8', 0, 10000)),
   (select count(*) from ggircs_portal.facility f
     join ggircs_portal.ciip_user_organisation cuo on f.organisation_id = cuo.organisation_id
     and f.organisation_id = 8

--- a/schema/test/unit/search_functions/search_certification_requests_test.sql
+++ b/schema/test/unit/search_functions/search_certification_requests_test.sql
@@ -10,7 +10,7 @@ alter table ggircs_portal.certification_url disable trigger _certification_reque
 set jwt.claims.sub to '00000000-0000-0000-0000-000000000000';
 
 select has_function(
-  'ggircs_portal', 'search_certification_requests', array['text[]', 'text[]', 'text', 'text', 'int'],
+  'ggircs_portal', 'search_certification_requests', array['text[]', 'text[]', 'text', 'text', 'int','int'],
   'Function ggircs_portal.search_certification_requests should exist'
 );
 
@@ -19,7 +19,7 @@ insert into ggircs_portal.certification_url(application_id, version_number, cert
 
 select is(
   (
-    select certifier_email from ggircs_portal.search_certification_requests(ARRAY['facility_name'], ARRAY['a'], 'facility_name', 'asc', '0')
+    select certifier_email from ggircs_portal.search_certification_requests(ARRAY['facility_name'], ARRAY['a'], 'facility_name', 'asc', '0', 10000)
   ),
   'ciip@mailinator.com'::varchar(1000),
   'search_certification_requests returns only the certification_url results for the logged in user'

--- a/schema/verify/search_functions/search_all_facilities.sql
+++ b/schema/verify/search_functions/search_all_facilities.sql
@@ -2,6 +2,6 @@
 
 begin;
 
-select pg_get_functiondef('ggircs_portal.search_all_facilities(text,text,text,text,text,int)'::regprocedure);
+select pg_get_functiondef('ggircs_portal.search_all_facilities(text,text,text,text,text,int,int)'::regprocedure);
 
 rollback;

--- a/schema/verify/search_functions/search_certification_requests.sql
+++ b/schema/verify/search_functions/search_certification_requests.sql
@@ -2,6 +2,6 @@
 
 begin;
 
-select pg_get_functiondef('ggircs_portal.search_certification_requests(text[],text[],text,text,int)'::regprocedure);
+select pg_get_functiondef('ggircs_portal.search_certification_requests(text[],text[],text,text,int,int)'::regprocedure);
 
 rollback;


### PR DESCRIPTION
The limit value was hardcoded in the search functions, making `maxResultsPerPage` do nothing. I've updated the search functions to use `maxResultsPerPage` as the limit in the search query.