### PR TITLE
fix: cron charts should be pre-install/upgrade hooks

### DIFF
--- a/helm/cas-ciip-portal/templates/airflow-dag-trigger.yaml
+++ b/helm/cas-ciip-portal/templates/airflow-dag-trigger.yaml
@@ -14,6 +14,7 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "0"
 {{- end }}
 spec:
   backoffLimit: 0

--- a/helm/cas-ciip-portal/templates/cron-app-users.yaml
+++ b/helm/cas-ciip-portal/templates/cron-app-users.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ template "cas-ciip-portal.fullname" . }}-app-user
   labels:
 {{ include "cas-ciip-portal.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-upgrade,pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "-5"
 spec:
   suspend: true # This cron job is intended to be triggered manually
   schedule: "* * * * *"

--- a/helm/cas-ciip-portal/templates/cron-deploy-data.yaml
+++ b/helm/cas-ciip-portal/templates/cron-deploy-data.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ template "cas-ciip-portal.fullname" . }}-schema-deploy-data
   labels:
 {{ include "cas-ciip-portal.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-upgrade,pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "-5"
 spec:
   suspend: true # This cron job is intended to be triggered manually
   schedule: "* * * * *"

--- a/helm/cas-ciip-portal/templates/cron-init-db.yaml
+++ b/helm/cas-ciip-portal/templates/cron-init-db.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ template "cas-ciip-portal.fullname" . }}-init-db
   labels:
 {{ include "cas-ciip-portal.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-upgrade,pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "-5"
 spec:
   suspend: true # This cron job is intended to be triggered manually
   schedule: "* * * * *"

--- a/helm/cas-ciip-portal/templates/cron-init-graphile-schema.yaml
+++ b/helm/cas-ciip-portal/templates/cron-init-graphile-schema.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ template "cas-ciip-portal.fullname" . }}-init-graphile-schema
   labels:
 {{ include "cas-ciip-portal.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-upgrade,pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "-5"
 spec:
   suspend: true # This cron job is intended to be triggered manually
   schedule: "* * * * *"

--- a/helm/cas-ciip-portal/templates/cron-swrs-import.yaml
+++ b/helm/cas-ciip-portal/templates/cron-swrs-import.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ template "cas-ciip-portal.fullname" . }}-swrs-import
   labels:
 {{ include "cas-ciip-portal.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-upgrade,pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "-5"
 spec:
   suspend: true # This cron job is intended to be triggered manually
   schedule: "* * * * *"


### PR DESCRIPTION
The templates need to be updated before the airflow-dag-trigger runs