### PR TITLE
fix: acme requires .well-known to be accessible

### DIFF
--- a/app/.well-known/Readme.md
+++ b/app/.well-known/Readme.md
@@ -1,0 +1,1 @@
+This folder will be bound over by a volume to enable acme negotiation for letsencrypt

--- a/app/server/index.js
+++ b/app/server/index.js
@@ -126,6 +126,10 @@ const getRedirectURL = (req) => {
 app.prepare().then(() => {
   const server = express();
 
+  server.use(
+    '/.well-known',
+    express.static(path.resolve(__dirname, '../.well-known'))
+  );
   server.use(bodyParser.json());
   server.use(cors());
 

--- a/helm/cas-ciip-portal/templates/cron-acme-issue.yaml
+++ b/helm/cas-ciip-portal/templates/cron-acme-issue.yaml
@@ -33,16 +33,16 @@ spec:
                 - bash
                 - -c
                 - |
-                  set -euo pipefail;
-                  git clone --branch 2.8.6 https://github.com/acmesh-official/acme.sh.git /root/acme.sh
-                  cd /root/acme.sh
-                  ./acme.sh install --force
-                  . "/root/.acme.sh/acme.sh.env"
-                  acme.sh --issue -d {{ .Values.route.host }} -w /root/static
+                  set -euxo pipefail;
+                  git clone --branch 2.8.6 https://github.com/acmesh-official/acme.sh.git /root/acme.sh;
+                  cd /root/acme.sh;
+                  ./acme.sh install --force;
+                  . "/root/.acme.sh/acme.sh.env";
+                  ./acme.sh --issue -d {{ .Values.route.host }} -w /root;
               volumeMounts:
                 - mountPath: /root/.acme.sh
                   name: acme-home
-                - mountPath: /root/static/.well-known/acme-challenge
+                - mountPath: /root/.well-known/acme-challenge
                   name: acme-challenge
           volumes:
             - name: acme-home

--- a/helm/cas-ciip-portal/templates/deploy.yaml
+++ b/helm/cas-ciip-portal/templates/deploy.yaml
@@ -84,7 +84,7 @@ spec:
         volumeMounts:
           - mountPath: /root/.acme.sh
             name: acme-home
-          - mountPath: /root/static/.well-known/acme-challenge
+          - mountPath: /root/.well-known/acme-challenge
             name: acme-challenge
       volumes:
         - name: acme-home


### PR DESCRIPTION
using the `static` directory didn't work; trying an express middleware instead