### PR TITLE
feat: helm hook for first cert provision

### DIFF
--- a/app/server/index.js
+++ b/app/server/index.js
@@ -309,7 +309,7 @@ app.prepare().then(() => {
       'utf8'
     );
     const cert = fs.readFileSync(
-      `/root/.acme.sh/${domain}/${domain}.crt`,
+      `/root/.acme.sh/${domain}/fullchain.cer`,
       'utf8'
     );
     const options = {key, cert};

--- a/helm/cas-ciip-portal/templates/cron-acme-issue.yaml
+++ b/helm/cas-ciip-portal/templates/cron-acme-issue.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ template "cas-ciip-portal.fullname" . }}-acme-issue
   labels:
 {{ include "cas-ciip-portal.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": "post-upgrade,post-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "-5"
 
 spec:
   suspend: true # This cron job is intended to be triggered manually
@@ -34,11 +38,14 @@ spec:
                 - -c
                 - |
                   set -euxo pipefail;
-                  git clone --branch 2.8.6 https://github.com/acmesh-official/acme.sh.git /root/acme.sh;
-                  cd /root/acme.sh;
-                  ./acme.sh install --force;
-                  . "/root/.acme.sh/acme.sh.env";
-                  ./acme.sh --issue -d {{ .Values.route.host }} -w /root;
+                  if [ ! -f /root/.acme.sh/{{ .Values.route.host }}/{{ .Values.route.host }}.cer ]; then
+                    echo "Getting a new cert from Let's Encrypt for {{ .Values.route.host }}";
+                    git clone --branch 2.8.6 https://github.com/acmesh-official/acme.sh.git /root/acme.sh;
+                    cd /root/acme.sh;
+                    ./acme.sh install --force;
+                    . "/root/.acme.sh/acme.sh.env";
+                    ./acme.sh --issue -d {{ .Values.route.host }} -w /root;
+                  fi;
               volumeMounts:
                 - mountPath: /root/.acme.sh
                   name: acme-home

--- a/helm/cas-ciip-portal/values-wksv3k-dev.yaml
+++ b/helm/cas-ciip-portal/values-wksv3k-dev.yaml
@@ -1,7 +1,7 @@
 replicas: 2
 route:
   host: dev.ciip.gov.bc.ca
-  insecure: true # temporary setting until cert is generated
+  insecure: false # cert has been issued
 
 env:
   smtpConnectionString: smtp://apps.smtp.gov.bc.ca/?port=25&ignoreTLS=true&secure=false


### PR DESCRIPTION
🐉🐉🐉
additionally, turns on SSL in dev & uses the issued cert
TODO: still need automated renewal cron & app restart logic