### PR TITLE
fix: ciip user needs to be dropped on dev

### DIFF
--- a/helm/cas-ciip-portal/values-wksv3k-dev.yaml
+++ b/helm/cas-ciip-portal/values-wksv3k-dev.yaml
@@ -12,6 +12,7 @@ dag:
       -- don't kill the connections to other databases
       and datname = '$(PORTAL_DATABASE)';
       drop database if exists $(PORTAL_DATABASE);
+      drop user if exists $(PORTAL_USER);
     EOF
 
 env:


### PR DESCRIPTION
cas-postgres's create-user-db doesn't reset owner
if the user already exists