### PR TITLE
feat: yarn start uses --unhandled-rejections=strict option

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,7 @@
     "build:relay": "relay-compiler --verbose",
     "build:next": "next build",
     "build:storybook": "build-storybook -o static/storybook",
-    "start": "NODE_ENV=production node server",
+    "start": "NODE_ENV=production node --unhandled-rejections=strict server",
     "format": "xo --fix",
     "lint": "xo",
     "prestorybook": "npm run build:relay",


### PR DESCRIPTION
This makes the app crash when the graphile worker fails to connect to the db,
instead of silently continuing to work