### PR TITLE
fix: searchTable reset button behaving badly

### DIFF
--- a/app/components/SearchBox.tsx
+++ b/app/components/SearchBox.tsx
@@ -6,7 +6,7 @@ import FormFieldTemplate from 'containers/Forms/FormFieldTemplate';
 import FormObjectFieldTemplate from 'containers/Forms/FormObjectFieldTemplate';
 
 interface Props {
-  handleEvent: (action: string, value?: string) => Promise<void>;
+  handleEvent: (action: string, value?: string) => any;
   dropdownSortItems: string[];
   displayNameToColumnNameMap: object;
 }

--- a/app/components/SearchBox.tsx
+++ b/app/components/SearchBox.tsx
@@ -6,7 +6,7 @@ import FormFieldTemplate from 'containers/Forms/FormFieldTemplate';
 import FormObjectFieldTemplate from 'containers/Forms/FormObjectFieldTemplate';
 
 interface Props {
-  handleEvent: (action: string, value?: string) => any;
+  handleEvent: (action: string, column?: string, value?: string) => void;
   dropdownSortItems: string[];
   displayNameToColumnNameMap: object;
 }
@@ -18,17 +18,16 @@ const SearchBox: React.FunctionComponent<Props> = ({
 }) => {
   const handleSubmit = async (e: IChangeEvent) => {
     if (e.formData.searchField) {
-      await handleEvent(
-        'applySearchField',
-        displayNameToColumnNameMap[e.formData.searchField]
+      handleEvent(
+        'applySearch',
+        displayNameToColumnNameMap[e.formData.searchField],
+        e.formData.searchValue
       );
-      handleEvent('applySearchValue', e.formData.searchValue);
     }
   };
 
   const handleClear = () => {
-    handleEvent('applySearchField', undefined);
-    handleEvent('applySearchValue', undefined);
+    handleEvent('applySearch', undefined, undefined);
   };
 
   const schema: JSONSchema6 = {

--- a/app/components/SearchBox.tsx
+++ b/app/components/SearchBox.tsx
@@ -6,7 +6,7 @@ import FormFieldTemplate from 'containers/Forms/FormFieldTemplate';
 import FormObjectFieldTemplate from 'containers/Forms/FormObjectFieldTemplate';
 
 interface Props {
-  handleEvent: (action: string, value?: string) => void;
+  handleEvent: (action: string, value?: string) => Promise<void>;
   dropdownSortItems: string[];
   displayNameToColumnNameMap: object;
 }
@@ -16,9 +16,9 @@ const SearchBox: React.FunctionComponent<Props> = ({
   dropdownSortItems,
   displayNameToColumnNameMap
 }) => {
-  const handleSubmit = (e: IChangeEvent) => {
-    if (e.formData.searchField !== undefined) {
-      handleEvent(
+  const handleSubmit = async (e: IChangeEvent) => {
+    if (e.formData.searchField) {
+      await handleEvent(
         'applySearchField',
         displayNameToColumnNameMap[e.formData.searchField]
       );

--- a/app/components/SearchTable.tsx
+++ b/app/components/SearchTable.tsx
@@ -36,7 +36,7 @@ class SearchTableComponent extends Component<Props> {
   };
 
   applySearchValue = (value) => {
-    if (this.state.searchField !== undefined) {
+    if (this.state.searchField) {
       this.setState({searchValue: value});
     }
   };

--- a/app/components/SearchTable.tsx
+++ b/app/components/SearchTable.tsx
@@ -28,21 +28,22 @@ class SearchTableComponent extends Component<Props> {
     });
   };
 
-  applySearchField = (column) => {
-    this.setState({
-      searchField: column,
-      searchValue: null
-    });
-  };
-
-  applySearchValue = (value) => {
-    if (this.state.searchField) {
-      this.setState({searchValue: value});
+  applySearch = (column, value) => {
+    if (column)
+      this.setState({
+        searchField: column,
+        searchValue: value
+      });
+    else {
+      this.setState({
+        searchField: undefined,
+        searchValue: undefined
+      });
     }
   };
 
-  handleEvent = (action, value) => {
-    this[action](value);
+  handleEvent = (action, value, column) => {
+    this[action](value, column);
   };
 
   render() {

--- a/app/components/SearchTableLayout.tsx
+++ b/app/components/SearchTableLayout.tsx
@@ -3,7 +3,7 @@ import {Container, Row, Col, Table} from 'react-bootstrap';
 import SortableTableHeader from 'components/SortableTableHeader';
 import SearchBox from 'components/SearchBox';
 interface Props {
-  handleEvent: (...args: any[]) => void;
+  handleEvent: (action: string, value?: string) => any;
   handleSelectAll?: (...args: any[]) => void;
   allSelected?: boolean;
   displayNameToColumnNameMap: any;

--- a/app/components/SearchTableLayout.tsx
+++ b/app/components/SearchTableLayout.tsx
@@ -3,7 +3,7 @@ import {Container, Row, Col, Table} from 'react-bootstrap';
 import SortableTableHeader from 'components/SortableTableHeader';
 import SearchBox from 'components/SearchBox';
 interface Props {
-  handleEvent: (action: string, value?: string) => any;
+  handleEvent: (action: string, value?: string, column?: string) => any;
   handleSelectAll?: (...args: any[]) => void;
   allSelected?: boolean;
   displayNameToColumnNameMap: any;


### PR DESCRIPTION
Setting the searchValue depended on the searchField being set in state, but the searchField handleEvent was happening first, causing a re-render and refetch before searchValue was set. Setting both values in state at the same time fixes the issue
https://youtrack.button.is/issue/GGIRCS-1598