### PR TITLE
fix: diff table - NO DATA ENTERED

### DIFF
--- a/app/containers/Forms/SummaryEmissionGasFields.tsx
+++ b/app/containers/Forms/SummaryEmissionGasFields.tsx
@@ -59,19 +59,11 @@ const EmissionGasFields: React.FunctionComponent<FieldProps> = (props) => {
           (props.formData.annualEmission || previousEmission) ? (
             <>
               <span className="diffFrom">
-                {previousEmission || previousEmission === 0 ? (
-                  previousEmission
-                ) : (
-                  <i>[No Data Entered]</i>
-                )}
+                {previousEmission ?? <i>[No Data Entered]</i>}
               </span>
               &nbsp;---&gt;&nbsp;
               <span className="diffTo">
-                {props.formData.annualEmission ? (
-                  props.formData.annualEmission
-                ) : (
-                  <i>[No Data Entered]</i>
-                )}
+                {props.formData.annualEmission ?? <i>[No Data Entered]</i>}
               </span>
             </>
           ) : (
@@ -94,19 +86,11 @@ const EmissionGasFields: React.FunctionComponent<FieldProps> = (props) => {
           (props.formData.annualCO2e || previousAnnualCO2e) ? (
             <>
               <span className="diffFrom">
-                {previousAnnualCO2e || previousAnnualCO2e === 0 ? (
-                  previousAnnualCO2e
-                ) : (
-                  <i>[No Data Entered]</i>
-                )}
+                {previousAnnualCO2e ?? <i>[No Data Entered]</i>}
               </span>
               &nbsp;---&gt;&nbsp;
               <span className="diffTo">
-                {props.formData.annualCO2e ? (
-                  props.formData.annualCO2e
-                ) : (
-                  <i>[No Data Entered]</i>
-                )}
+                {props.formData.annualCO2e ?? <i>[No Data Entered]</i>}
               </span>
             </>
           ) : (

--- a/app/containers/Forms/SummaryEmissionGasFields.tsx
+++ b/app/containers/Forms/SummaryEmissionGasFields.tsx
@@ -59,7 +59,11 @@ const EmissionGasFields: React.FunctionComponent<FieldProps> = (props) => {
           (props.formData.annualEmission || previousEmission) ? (
             <>
               <span className="diffFrom">
-                {previousEmission ? previousEmission : <i>[No Data Entered]</i>}
+                {previousEmission || previousEmission === 0 ? (
+                  previousEmission
+                ) : (
+                  <i>[No Data Entered]</i>
+                )}
               </span>
               &nbsp;---&gt;&nbsp;
               <span className="diffTo">
@@ -90,7 +94,7 @@ const EmissionGasFields: React.FunctionComponent<FieldProps> = (props) => {
           (props.formData.annualCO2e || previousAnnualCO2e) ? (
             <>
               <span className="diffFrom">
-                {previousAnnualCO2e ? (
+                {previousAnnualCO2e || previousAnnualCO2e === 0 ? (
                   previousAnnualCO2e
                 ) : (
                   <i>[No Data Entered]</i>


### PR DESCRIPTION
values of 0 were being treated as falsey in the logic determining whether to display the value or NO DATA ENTERED. I fixed the logic to display the 0 instead of NO DATA ENTERED.
https://youtrack.button.is/issue/GGIRCS-1570