### PR TITLE
fix: Certifier clipboard URL should have protocol

### DIFF
--- a/app/containers/Applications/ApplicationWizardConfirmation.tsx
+++ b/app/containers/Applications/ApplicationWizardConfirmation.tsx
@@ -69,22 +69,17 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
 
     console.log(response);
     try {
-      setUrl(
-        `${
-          window.location.host
-        }/certifier/certification-redirect?rowId=${encodeURIComponent(
-          response.createCertificationUrl.certificationUrl.rowId
-        )}&id=${encodeURIComponent(props.application.id)}`
-      );
+      const certifierUrl = `${window.location.protocol}//${
+        window.location.host
+      }/certifier/certification-redirect?rowId=${encodeURIComponent(
+        response.createCertificationUrl.certificationUrl.rowId
+      )}&id=${encodeURIComponent(props.application.id)}`;
+      setUrl(certifierUrl);
       const updateVariables = {
         input: {
           id: response.createCertificationUrl.certificationUrl.id,
           certificationUrlPatch: {
-            certifierUrl: `${
-              window.location.host
-            }/certifier/certification-redirect?rowId=${encodeURIComponent(
-              response.createCertificationUrl.certificationUrl.rowId
-            )}&id=${encodeURIComponent(props.application.id)}`,
+            certifierUrl,
             certifierEmail: email,
             sendCertificationRequest: sendEmail
           }

--- a/app/server/emailTemplates/certificationRequest.js
+++ b/app/server/emailTemplates/certificationRequest.js
@@ -31,7 +31,7 @@ const createCertificationRequestMail = ({
             <strong>Please follow the steps below to certify the facility's CIIP application:</strong>
             <ul>
               <li>
-                Please log in to the CIIP Portal to <a href="https://${certifierUrl}">review a summary of the data</a> contained in the CIIP application. The application details can be found <a href="https://${certifierUrl}">here</a>.
+                Please log in to the CIIP Portal to <a href="${certifierUrl}">review a summary of the data</a> contained in the CIIP application. The application details can be found <a href="${certifierUrl}">here</a>.
                 <ul>
                   <li>Complete the certification by reading the legal statement, signing in the grey "Certifying Official Signature" box or uploading a signature file, and then clicking the green "Sign" button at the bottom of the page.</li>
                 </ul>


### PR DESCRIPTION
Certification link copied to clipboard was missing the protocol at the beginning, causing it not to be a workable link if dropped into an email.

It was being hard coded in the certification request email, but this reverses that and fixes the root cause.

[GGIRCS-1690](https://youtrack.button.is/issue/GGIRCS-1690)