### PR TITLE
chore: add temporary resolution for npm advisory 1523

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -239,6 +239,7 @@
     "xo": "^0.30.0"
   },
   "resolutions": {
+    "**/lodash": "https://github.com/bcgov/cas-lodash#patch-SNYK-JS-LODASH-567746",
     "@storybook/**/marked": ">=0.7.0",
     "**/minimist": "1.2.5",
     "**/yargs-parser": "18.1.2"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -12119,15 +12119,9 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
-lodash@4.17.14:
-  version "4.17.14"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
-  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
-
-lodash@4.17.15, "lodash@>=4 <5", lodash@^4.11.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+lodash@4.17.14, lodash@4.17.15, "lodash@>=4 <5", lodash@^4.11.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, "lodash@https://github.com/bcgov/cas-lodash#patch-SNYK-JS-LODASH-567746":
+  version "4.17.16-rc.1"
+  resolved "https://github.com/bcgov/cas-lodash#47e669b107cdcdca2bd07c57dc09bd23577adb3e"
 
 log-symbols@3.0.0, log-symbols@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Update resolution to point to the next patch version
once https://github.com/lodash/lodash/pull/4759 is merged