### PR TITLE
Set robots header to noindex for non-production environments

### DIFF
--- a/app/server/index.js
+++ b/app/server/index.js
@@ -154,6 +154,15 @@ app.prepare().then(() => {
   server.use(bodyParser.json());
   server.use(cors());
 
+  // Tell search + crawlers not to index non-production environments:
+  server.use(({res, next}) => {
+    if (!process.env.NAMESPACE || !process.env.NAMESPACE.endsWith('-prod')) {
+      res.append('X-Robots-Tag', 'noindex, noimageindex, nofollow, noarchive');
+    }
+
+    next();
+  });
+
   const store = new PgSession({
     pool: pgPool,
     schemaName: 'ggircs_portal_private',


### PR DESCRIPTION
- Configures a middleware setting the `X-Robots-Tag` header for all non-production domains, per [GGIRCS-1631](https://youtrack.button.is/issue/GGIRCS-1631)
  * covers all assets, including static assets like images
  * [read about the directives here](https://developers.google.com/search/reference/robots_meta_tag#directives)