### PR TITLE
Register button leads directly to SSO registration page

### DIFF
--- a/app/components/Layout/Header.tsx
+++ b/app/components/Layout/Header.tsx
@@ -49,9 +49,9 @@ const HeaderLayout = ({isLoggedIn = false, isRegistered = false}) => (
                 ) : (
                   <Form.Row>
                     <Col>
-                      <LoginButton type="submit" variant="outline-light">
-                        Register
-                      </LoginButton>
+                      <Link href="/register">
+                        <a className="btn btn-outline-light">Register</a>
+                      </Link>
                     </Col>
                     <Col>
                       <LoginButton type="submit" variant="outline-light">

--- a/app/components/RegistrationLoginButtons.tsx
+++ b/app/components/RegistrationLoginButtons.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Col, Card} from 'react-bootstrap';
 import LoginButton from './LoginButton';
+import Link from 'next/link';
 
 interface Props {
   applicationDeadline: string;
@@ -21,14 +22,14 @@ const RegistrationLoginButtons: React.FunctionComponent<Props> = ({
             {applicationDeadline}. As part of the application, information about
             the operation’s energy use, emissions, and production is required.
           </Card.Text>
-          <LoginButton
-            style={{padding: '15px'}}
-            className="full-width"
-            variant="primary"
-            size="lg"
-          >
-            Register and Apply
-          </LoginButton>
+          <Link href="/register">
+            <a
+              style={{padding: '15px', display: 'block'}}
+              className="full-width btn btn-primary btn-lg"
+            >
+              Register and Apply
+            </a>
+          </Link>
         </Card.Body>
       </Card>
       <LoginButton className="login-link" variant="outline-dark">

--- a/app/server/index.js
+++ b/app/server/index.js
@@ -190,6 +190,13 @@ app.prepare().then(() => {
     'public-client': true,
     'confidential-port': 0
   };
+  const kcRegistrationUrl = `${kcConfig['auth-server-url']}/realms/${
+    kcConfig.realm
+  }/protocol/openid-connect/registrations?client_id=${
+    kcConfig.resource
+  }&response_type=code&scope=openid&redirect_uri=${encodeURIComponent(
+    `${process.env.HOST}/login?auth_callback=1`
+  )}`;
   const keycloak = new Keycloak({store}, kcConfig);
 
   // Nuke the siteminder session token on logout if we can
@@ -342,6 +349,8 @@ app.prepare().then(() => {
 
   // Keycloak callbak; do not keycloak.protect() to avoid users being authenticated against their will via XSS attack
   server.get('/login', (req, res) => res.redirect(302, getRedirectURL(req)));
+
+  server.get('/register', ({res}) => res.redirect(302, kcRegistrationUrl));
 
   server.get('*', async (req, res) => {
     return handle(req, res);

--- a/app/tests/unit/components/Layout/__snapshots__/Header.test.tsx.snap
+++ b/app/tests/unit/components/Layout/__snapshots__/Header.test.tsx.snap
@@ -46,12 +46,15 @@ exports[`It matches the last accepted Snapshot 1`] = `
             >
               <FormRow>
                 <Col>
-                  <LoginForm
-                    type="submit"
-                    variant="outline-light"
+                  <Link
+                    href="/register"
                   >
-                    Register
-                  </LoginForm>
+                    <a
+                      className="jsx-2453800556 btn btn-outline-light"
+                    >
+                      Register
+                    </a>
+                  </Link>
                 </Col>
                 <Col>
                   <LoginForm


### PR DESCRIPTION
Direct link to SSO registration page per [GGIRCS-1703](https://youtrack.button.is/issue/GGIRCS-1703).

Adds 2 public runtime env variables to the Next config: 
- `HOST`
  * to compute the post-registration `redirect_uri`
- `NAMESPACE`
  * to compute the keycloak namespace to link to (ie: `sso[-dev|-test].pathfinder` vs. `sso.pathfinder`)

### Decision: 
We've decided to ship this for now without support for post-registration redirects, due to some difficulties that would add precious time to debug before impending use by the public. We'll prioritize and revisit support at a later date. Those difficulties are:
- Return trip to `/login` after registering returns a 403 (however the user is still created, and subsequently clicking "Login" automatically logs them in).
  - the login service improperly decodes the `redirectTo` query param. Not sure why or how relevant.
- Failing Storyshots test suite related to using the router in the Header component.

~TODO:~
- ~Ensure `redirectTo` query param is respected~