### PR TITLE
Update snowplow collector to production origin

### DIFF
--- a/app/components/Layout/Analytics.jsx
+++ b/app/components/Layout/Analytics.jsx
@@ -6,7 +6,7 @@ const SNOWPLOW_TRACKER = `
 p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
 };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
 n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/MDWay3UqFnIiGVLIo7aoMi4xMC4y.js","snowplow"));
-var collector = 'spm.apps.gov.bc.ca';
+var collector = 'spt.apps.gov.bc.ca';
 window.snowplow('newTracker','rt',collector, {
   appId: "Snowplow_standalone",
   platform: 'web',


### PR DESCRIPTION
Slight modification requested by GDX to graduate us to the production-ready tracker. [GGIRCS-1671](https://youtrack.button.is/issue/GGIRCS-1671)

This is still in our test env only, and they'll do another round of tests and give us the okay to deploy it in our prod environment.