### PR TITLE
404 page

### DIFF
--- a/app/pages/404.tsx
+++ b/app/pages/404.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {Row, Col} from 'react-bootstrap';
+import DefaultLayout from 'layouts/default-layout';
+import Link from 'next/link';
+
+export default () => {
+  return (
+    <>
+      <DefaultLayout needsUser={false} needsSession={false} session={null}>
+        <Row className="justify-content-center" style={{paddingTop: '3em'}}>
+          <Col md={{span: 6}} style={{textAlign: 'center'}}>
+            <h1>Page not found</h1>
+            <p>Sorry, we couldn&apos;t find the page you were looking for.</p>
+            <p>
+              <Link href="/">
+                <a className="full-width btn btn-primary">Return Home</a>
+              </Link>
+            </p>
+          </Col>
+        </Row>
+      </DefaultLayout>
+      <style jsx>{`
+        p {
+          margin: 2em 0;
+        }
+      `}</style>
+    </>
+  );
+};

--- a/app/tests/unit/pages/404.test.tsx
+++ b/app/tests/unit/pages/404.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import FourOhFour from 'pages/404';
+
+describe('404 page', () => {
+  it('It matches the last accepted Snapshot', () => {
+    const wrapper = shallow(<FourOhFour />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/app/tests/unit/pages/__snapshots__/404.test.tsx.snap
+++ b/app/tests/unit/pages/__snapshots__/404.test.tsx.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`404 page It matches the last accepted Snapshot 1`] = `
+<Fragment>
+  <Relay(DefaultLayout)
+    needsSession={false}
+    needsUser={false}
+    session={null}
+  >
+    <Row
+      className="justify-content-center"
+      noGutters={false}
+      style={
+        Object {
+          "paddingTop": "3em",
+        }
+      }
+    >
+      <Col
+        md={
+          Object {
+            "span": 6,
+          }
+        }
+        style={
+          Object {
+            "textAlign": "center",
+          }
+        }
+      >
+        <h1
+          className="jsx-3660830980"
+        >
+          Page not found
+        </h1>
+        <p
+          className="jsx-3660830980"
+        >
+          Sorry, we couldn't find the page you were looking for.
+        </p>
+        <p
+          className="jsx-3660830980"
+        >
+          <Link
+            href="/"
+          >
+            <a
+              className="jsx-3660830980 full-width btn btn-primary"
+            >
+              Return Home
+            </a>
+          </Link>
+        </p>
+      </Col>
+    </Row>
+  </Relay(DefaultLayout)>
+  <JSXStyle
+    id="3660830980"
+  >
+    p.jsx-3660830980{margin:2em 0;}
+  </JSXStyle>
+</Fragment>
+`;


### PR DESCRIPTION
404 page that makes use of Next's built-in statically optimized [404 page](https://nextjs.org/docs/advanced-features/custom-error-page). [GGIRCS-1651](https://youtrack.button.is/issue/GGIRCS-1651)

### Note: 
There is an awkward limitation in using the built-in static 404 page functionality, which is due to the combination of Next's file name constraint (`404.tsx`) and the naming constraints built in with Relay (queries must be named after the module or page, but javascript variables cannot start with a number).

As a result, it's not possible for the header navigation to recognize if the user is logged in and will appear as though they aren't, showing the links to register or login regardless. It's a bit of an unfortunate pattern, although this wouldn't be the first site I've seen it - it's not uncommon to use a static page for this purpose.