### PR TITLE
fix: pending analysts should not be allowed on user/profile page

### DIFF
--- a/app/layouts/default-layout.tsx
+++ b/app/layouts/default-layout.tsx
@@ -56,19 +56,22 @@ const DefaultLayout: React.FunctionComponent<Props> = ({
     return null;
   }
 
+  // Redirect users attempting to access a page that their group doesn't allow
+  // to their landing route. This needs to happen before redirecting to the registration
+  // to ensure that a pending analyst doesn't get redirect to the registration page
+  if (!canAccess) {
+    router.push({
+      pathname: getUserGroupLandingRoute(userGroups)
+    });
+    return null;
+  }
+
   if (needsUser && !session.ciipUserBySub) {
     router.push({
       pathname: '/registration',
       query: {
         redirectTo: router.asPath
       }
-    });
-    return null;
-  }
-
-  if (!canAccess) {
-    router.push({
-      pathname: getUserGroupLandingRoute(userGroups)
     });
     return null;
   }

--- a/app/pages/user/profile.tsx
+++ b/app/pages/user/profile.tsx
@@ -3,7 +3,9 @@ import {graphql} from 'react-relay';
 import {profileQueryResponse} from 'profileQuery.graphql';
 import DefaultLayout from 'layouts/default-layout';
 import UserProfileContainer from 'containers/User/UserProfile';
+import {INCENTIVE_ANALYST, ADMIN_GROUP, USER} from 'data/group-constants';
 
+const ALLOWED_GROUPS = [INCENTIVE_ANALYST, ...ADMIN_GROUP, USER];
 interface Props {
   query: profileQueryResponse['query'];
 }
@@ -25,7 +27,7 @@ class Profile extends Component<Props> {
     const {session} = this.props.query;
 
     return (
-      <DefaultLayout session={session}>
+      <DefaultLayout session={session} allowedGroups={ALLOWED_GROUPS}>
         <UserProfileContainer user={session ? session.ciipUserBySub : null} />
       </DefaultLayout>
     );

--- a/app/tests/unit/pages/user/__snapshots__/profile.test.tsx.snap
+++ b/app/tests/unit/pages/user/__snapshots__/profile.test.tsx.snap
@@ -1,7 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`user profile matches snapshot 1`] = `
-<Relay(DefaultLayout)>
+<Relay(DefaultLayout)
+  allowedGroups={
+    Array [
+      "Incentive Analyst",
+      "Realm Administrator",
+      "Incentive Administrator",
+      "User",
+    ]
+  }
+>
   <Relay(UserProfile)
     user={null}
   />


### PR DESCRIPTION
They will be redirected to their landing page
We don't have a test IDIR so we can't have an e2e test for this