### PR TITLE
Notice re: Supported browser versions

### DIFF
--- a/app/components/Forms/ApplicationFormNavbar.tsx
+++ b/app/components/Forms/ApplicationFormNavbar.tsx
@@ -67,7 +67,7 @@ const ApplicationFormNavbarComponent: React.FunctionComponent<Props> = (
             padding: 30px;
             background: #eee;
             border-radius: 6px;
-            margin-bottom: 60px;
+            margin-bottom: 1rem;
           }
           .nav-guide.nav-pills {
             border: 1px solid #00336675;

--- a/app/components/SupportedBrowserNotice.tsx
+++ b/app/components/SupportedBrowserNotice.tsx
@@ -1,0 +1,15 @@
+import React, {useState} from 'react';
+import {Alert} from 'react-bootstrap';
+
+const SupportedBrowserNotice = () => {
+  const [showBrowserNotice, setShowBrowserNotice] = useState(true);
+
+  return (
+    showBrowserNotice &&
+    <Alert variant="warning" dismissible onClose={() => setShowBrowserNotice(false)}>
+      <strong>Note:</strong> For best results, use an updated version of <Alert.Link href="https://www.google.com/chrome/" target="_blank" rel="noopener noreferrer">Chrome</Alert.Link>, <Alert.Link href="https://www.mozilla.org/firefox/new" target="_blank" rel="noopener noreferrer">Firefox</Alert.Link>, <Alert.Link href="https://www.microsoft.com/edge" target="_blank" rel="noopener noreferrer">Edge</Alert.Link> or <Alert.Link href="https://support.apple.com/en-us/HT204416" target="_blank" rel="noopener noreferrer">Safari</Alert.Link>.
+    </Alert>
+  );
+};
+
+export default SupportedBrowserNotice;

--- a/app/containers/Forms/FormSharedStyles.tsx
+++ b/app/containers/Forms/FormSharedStyles.tsx
@@ -33,4 +33,7 @@ export default css.global`
     color: white !important;
     padding: 5px;
   }
+  .form-title {
+    margin-top: 0.5em;
+  }
 `;

--- a/app/containers/Organisations/Organisations.tsx
+++ b/app/containers/Organisations/Organisations.tsx
@@ -13,6 +13,7 @@ import {RelayModernEnvironment} from 'relay-runtime/lib/store/RelayModernEnviron
 import LoadingSpinner from 'components/LoadingSpinner';
 import Organisation from './Organisation';
 import UserOrganisation from './UserOrganisation';
+import SupportedBrowserNotice from 'components/SupportedBrowserNotice';
 
 interface Props {
   query: Organisations_query;
@@ -62,6 +63,7 @@ export const OrganisationsComponent: React.FunctionComponent<Props> = (
   const userOrgs = session.ciipUserBySub.ciipUserOrganisationsByUserId.edges;
   return (
     <>
+      <SupportedBrowserNotice />
       {props.flagCertRequests && (
         <Alert variant="info">
           One or more reporting operations has requested that you certify an

--- a/app/layouts/default-layout.tsx
+++ b/app/layouts/default-layout.tsx
@@ -63,7 +63,7 @@ const DefaultLayout: React.FunctionComponent<Props> = ({
             flex-direction: column;
           }
           .content {
-            padding-top: 50px;
+            padding-top: 1.5em;
             flex: 1 0 auto;
           }
           .footer {
@@ -118,12 +118,6 @@ const DefaultLayout: React.FunctionComponent<Props> = ({
           }
           .container.wide {
             max-width: 1600px;
-          }
-
-          @media screen and (min-width: 992px) {
-            #page-content {
-              padding-top: 110px;
-            }
           }
         `}
       </style>

--- a/app/pages/certifier/certification-redirect.tsx
+++ b/app/pages/certifier/certification-redirect.tsx
@@ -7,6 +7,7 @@ import {CiipPageComponentProps} from 'next-env';
 import {certificationRedirectQueryResponse} from 'certificationRedirectQuery.graphql';
 import DefaultLayout from 'layouts/default-layout';
 import {USER} from 'data/group-constants';
+import SupportedBrowserNotice from 'components/SupportedBrowserNotice';
 
 const ALLOWED_GROUPS = [USER];
 
@@ -88,44 +89,47 @@ class CertificationRedirect extends Component<Props> {
         {certificationUrl ? (
           <Row>
             <Col md={{offset: 3, span: 6}}>
-              <h3 className="blue">Your certification is requested.</h3>
-              <p>
-                <strong>{`${firstName} ${lastName}`}</strong> on behalf of{' '}
-                <strong>{organisationName}</strong>, for facility{' '}
-                <strong>{facilityName}</strong> has requested that you review,
-                certify, and approve the information contained in this CIIP
-                application.
-              </p>
-              {session?.ciipUserBySub ? (
-                <>
-                  <p>Please continue to the certification page.</p>
-                  <Col md={{span: 5, offset: 1}}>
-                    <Button onClick={async () => router.push(redirectURI)}>
-                      Continue
-                    </Button>
-                  </Col>
-                </>
-              ) : (
-                <>
-                  <p>
-                    Please log in or register in order to access this page.
-                    <br />
-                    You will be redirected to the certification page after doing
-                    so.
-                  </p>
+              <SupportedBrowserNotice />
+              <div style={{marginTop: '3em'}}>
+                <h3 className="blue">Your certification is requested.</h3>
+                <p>
+                  <strong>{`${firstName} ${lastName}`}</strong> on behalf of{' '}
+                  <strong>{organisationName}</strong>, for facility{' '}
+                  <strong>{facilityName}</strong> has requested that you review,
+                  certify, and approve the information contained in this CIIP
+                  application.
+                </p>
+                {session?.ciipUserBySub ? (
+                  <>
+                    <p>Please continue to the certification page.</p>
+                    <Col md={{span: 5, offset: 1}}>
+                      <Button onClick={async () => router.push(redirectURI)}>
+                        Continue
+                      </Button>
+                    </Col>
+                  </>
+                ) : (
+                  <>
+                    <p>
+                      Please log in or register in order to access this page.
+                      <br />
+                      You will be redirected to the certification page after
+                      doing so.
+                    </p>
 
-                  <Col md={{span: 5, offset: 1}}>
-                    <Form
-                      action={`/login?redirectTo=${encodeURIComponent(
-                        redirectURI
-                      )}`}
-                      method="post"
-                    >
-                      <Button type="submit">Continue</Button>
-                    </Form>
-                  </Col>
-                </>
-              )}
+                    <Col md={{span: 5, offset: 1}}>
+                      <Form
+                        action={`/login?redirectTo=${encodeURIComponent(
+                          redirectURI
+                        )}`}
+                        method="post"
+                      >
+                        <Button type="submit">Continue</Button>
+                      </Form>
+                    </Col>
+                  </>
+                )}
+              </div>
             </Col>
           </Row>
         ) : expired ? (

--- a/app/pages/certifier/certify.tsx
+++ b/app/pages/certifier/certify.tsx
@@ -9,6 +9,7 @@ import CertificationSignature from 'containers/Forms/CertificationSignature';
 import DefaultLayout from 'layouts/default-layout';
 import {USER} from 'data/group-constants';
 import SignatureDisclaimerCard from 'components/SignatureDisclaimerCard';
+import SupportedBrowserNotice from 'components/SupportedBrowserNotice';
 
 const ALLOWED_GROUPS = [USER];
 
@@ -74,6 +75,7 @@ class Certify extends Component<Props> {
 
     return (
       <DefaultLayout title="Submission Certification" session={query.session}>
+        <SupportedBrowserNotice />
         {hashMatches ? (
           <>
             <ApplicationDetailsContainer

--- a/app/pages/certifier/requests.tsx
+++ b/app/pages/certifier/requests.tsx
@@ -11,6 +11,7 @@ import SearchTable from 'components/SearchTable';
 import CertificationRequestsContainer from 'containers/Certifier/CertificationRequestsContainer';
 import SignatureDisclaimerCard from 'components/SignatureDisclaimerCard';
 import CertificationSignature from 'containers/Forms/CertificationSignature';
+import SupportedBrowserNotice from 'components/SupportedBrowserNotice';
 
 const ALLOWED_GROUPS = [USER];
 
@@ -92,6 +93,7 @@ export default class CertifierRequests extends Component<Props> {
     const {query} = this.props;
     return (
       <DefaultLayout title="Certification Requests" session={query.session}>
+        <SupportedBrowserNotice />
         <SearchTable
           query={this.props.query}
           defaultOrderByField="facility_name"

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -219,7 +219,7 @@ export default class Index extends Component<Props> {
             </p>
           </Col>
         </div>
-        <style jsx>{`
+        <style jsx global>{`
           .value-prop {
             display: flex;
             flex-direction: column;
@@ -242,6 +242,11 @@ export default class Index extends Component<Props> {
           @media (min-width: 767.98px) {
             #photo-row {
               margin-top: 100px;
+            }
+          }
+          @media screen and (min-width: 992px) {
+            #page-content {
+              padding-top: 110px;
             }
           }
         `}</style>

--- a/app/pages/login-redirect.tsx
+++ b/app/pages/login-redirect.tsx
@@ -57,6 +57,13 @@ export default class LoginRedirect extends Component<Props> {
           </Col>
           <RegistrationLoginButtons applicationDeadline={deadline} />
         </Row>
+        <style jsx global>{`
+          @media screen and (min-width: 768px) {
+            #page-content {
+              padding-top: 110px;
+            }
+          }
+        `}</style>
       </DefaultLayout>
     );
   }

--- a/app/pages/reporter/application.tsx
+++ b/app/pages/reporter/application.tsx
@@ -6,6 +6,7 @@ import DefaultLayout from 'layouts/default-layout';
 import ApplicationWizard from 'containers/Applications/ApplicationWizard';
 import {USER} from 'data/group-constants';
 import {NextRouter} from 'next/router';
+import SupportedBrowserNotice from 'components/SupportedBrowserNotice';
 
 const ALLOWED_GROUPS = [USER];
 
@@ -68,6 +69,7 @@ class Application extends Component<Props> {
 
     return (
       <DefaultLayout session={session}>
+        <SupportedBrowserNotice />
         <ApplicationWizard query={query} />
       </DefaultLayout>
     );

--- a/app/pages/reporter/facilities.tsx
+++ b/app/pages/reporter/facilities.tsx
@@ -6,6 +6,7 @@ import SearchTable from 'components/SearchTable';
 import DefaultLayout from 'layouts/default-layout';
 import FacilitiesListContainer from 'containers/Facilities/FacilitiesListContainer';
 import {USER} from 'data/group-constants';
+import SupportedBrowserNotice from 'components/SupportedBrowserNotice';
 
 const ALLOWED_GROUPS = [USER];
 
@@ -59,6 +60,7 @@ class FacilitiesList extends Component<Props> {
     const {session} = this.props.query;
     return (
       <DefaultLayout showSubheader session={session} title="Facilities">
+        <SupportedBrowserNotice />
         <SearchTable
           query={this.props.query}
           defaultOrderByField="facility_name"

--- a/app/pages/reporter/new-application-disclaimer.tsx
+++ b/app/pages/reporter/new-application-disclaimer.tsx
@@ -7,6 +7,7 @@ import {CiipPageComponentProps} from 'next-env';
 import {NextRouter} from 'next/router';
 import DefaultLayout from 'layouts/default-layout';
 import {USER} from 'data/group-constants';
+import SupportedBrowserNotice from 'components/SupportedBrowserNotice';
 
 const ALLOWED_GROUPS = [USER];
 
@@ -56,6 +57,7 @@ class NewApplicationDisclaimer extends Component<Props> {
 
     return (
       <DefaultLayout session={session} title="Legal Disclaimer">
+        <SupportedBrowserNotice />
         <Card className="mb-2">
           <Card.Header>
             Please review and confirm the information below

--- a/app/pages/reporter/view-application.tsx
+++ b/app/pages/reporter/view-application.tsx
@@ -8,6 +8,7 @@ import ApplicationComments from 'containers/Applications/ApplicationCommentsCont
 import ReviseApplicationButton from 'containers/Applications/ReviseApplicationButtonContainer';
 import DefaultLayout from 'layouts/default-layout';
 import {USER} from 'data/group-constants';
+import SupportedBrowserNotice from 'components/SupportedBrowserNotice';
 
 const ALLOWED_GROUPS = [USER];
 
@@ -70,6 +71,7 @@ class ViewApplication extends Component<Props> {
       >
         <Row>
           <Col md={8}>
+            <SupportedBrowserNotice />
             <ApplicationDetails
               query={query}
               application={query.application}

--- a/app/pages/user/profile.tsx
+++ b/app/pages/user/profile.tsx
@@ -29,7 +29,7 @@ class Profile extends Component<Props> {
     const {session} = this.props.query;
 
     return (
-      <DefaultLayout session={session}>
+      <DefaultLayout showSubheader session={session} title="User Profile">
         <UserProfileContainer user={session ? session.ciipUserBySub : null} />
       </DefaultLayout>
     );

--- a/app/pages/user/profile.tsx
+++ b/app/pages/user/profile.tsx
@@ -4,6 +4,7 @@ import {profileQueryResponse} from 'profileQuery.graphql';
 import DefaultLayout from 'layouts/default-layout';
 import UserProfileContainer from 'containers/User/UserProfile';
 import {INCENTIVE_ANALYST, ADMIN_GROUP, USER} from 'data/group-constants';
+import SupportedBrowserNotice from 'components/SupportedBrowserNotice';
 
 const ALLOWED_GROUPS = [INCENTIVE_ANALYST, ...ADMIN_GROUP, USER];
 interface Props {
@@ -30,6 +31,7 @@ class Profile extends Component<Props> {
 
     return (
       <DefaultLayout showSubheader session={session} title="User Profile">
+        <SupportedBrowserNotice />
         <UserProfileContainer user={session ? session.ciipUserBySub : null} />
       </DefaultLayout>
     );

--- a/app/tests/integration/__snapshots__/Storyshots.test.ts.snap
+++ b/app/tests/integration/__snapshots__/Storyshots.test.ts.snap
@@ -2103,6 +2103,58 @@ Array [
           </ul>
         </nav>
       </header>
+      <div>
+        <nav
+          className="jsx-1717546368 navigation-main"
+          id="navbar"
+        >
+          <div
+            className="jsx-1717546368 container"
+          >
+            <ul
+              className="jsx-1717546368"
+            >
+              <li
+                className="jsx-1717546368 active"
+              >
+                <a
+                  className="jsx-1717546368"
+                  href="/reporter"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  My Dashboard
+                </a>
+              </li>
+              <li
+                className="jsx-1717546368 "
+              >
+                <a
+                  className="jsx-1717546368"
+                  href="/reporter/facilities"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  My Applications
+                </a>
+              </li>
+            </ul>
+          </div>
+        </nav>
+      </div>
+      <div
+        className="jsx-3172037009 page-title"
+      >
+        <div
+          className="narrow container"
+        >
+          <h1
+            className="jsx-3172037009"
+          >
+            User Profile
+          </h1>
+        </div>
+      </div>
       <div
         className="content narrow container"
         id="page-content"

--- a/app/tests/integration/__snapshots__/Storyshots.test.ts.snap
+++ b/app/tests/integration/__snapshots__/Storyshots.test.ts.snap
@@ -11,7 +11,7 @@ Array [
     }
   >
     <div
-      className="jsx-1155151846 page-wrap"
+      className="jsx-3172037009 page-wrap"
     >
       <header
         className="jsx-3597025167"
@@ -127,13 +127,13 @@ Array [
         </nav>
       </header>
       <div
-        className="jsx-1155151846 page-title"
+        className="jsx-3172037009 page-title"
       >
         <div
           className="narrow container"
         >
           <h1
-            className="jsx-1155151846"
+            className="jsx-3172037009"
           >
             Administrator Dashboard
           </h1>
@@ -512,7 +512,7 @@ Array [
     }
   >
     <div
-      className="jsx-1155151846 page-wrap"
+      className="jsx-3172037009 page-wrap"
     >
       <header
         className="jsx-3597025167"
@@ -628,13 +628,13 @@ Array [
         </nav>
       </header>
       <div
-        className="jsx-1155151846 page-title"
+        className="jsx-3172037009 page-title"
       >
         <div
           className="narrow container"
         >
           <h1
-            className="jsx-1155151846"
+            className="jsx-3172037009"
           >
             Registration
           </h1>
@@ -997,7 +997,7 @@ Array [
     }
   >
     <div
-      className="jsx-1155151846 page-wrap"
+      className="jsx-3172037009 page-wrap"
     >
       <header
         className="jsx-3597025167"
@@ -1152,13 +1152,13 @@ Array [
         </nav>
       </div>
       <div
-        className="jsx-1155151846 page-title"
+        className="jsx-3172037009 page-title"
       >
         <div
           className="narrow container"
         >
           <h1
-            className="jsx-1155151846"
+            className="jsx-3172037009"
           >
             My Operators
           </h1>
@@ -1654,7 +1654,7 @@ Array [
     }
   >
     <div
-      className="jsx-1155151846 page-wrap"
+      className="jsx-3172037009 page-wrap"
     >
       <header
         className="jsx-3597025167"
@@ -1770,13 +1770,13 @@ Array [
         </nav>
       </header>
       <div
-        className="jsx-1155151846 page-title"
+        className="jsx-3172037009 page-title"
       >
         <div
           className="narrow container"
         >
           <h1
-            className="jsx-1155151846"
+            className="jsx-3172037009"
           >
             User List
           </h1>
@@ -1988,7 +1988,7 @@ Array [
     }
   >
     <div
-      className="jsx-1155151846 page-wrap"
+      className="jsx-3172037009 page-wrap"
     >
       <header
         className="jsx-3597025167"

--- a/app/tests/integration/__snapshots__/Storyshots.test.ts.snap
+++ b/app/tests/integration/__snapshots__/Storyshots.test.ts.snap
@@ -1175,6 +1175,75 @@ Array [
             className="col-md-8"
           >
             <div
+              className="fade alert alert-warning alert-dismissible show"
+              role="alert"
+            >
+              <button
+                className="close"
+                onClick={[Function]}
+                type="button"
+              >
+                <span
+                  aria-hidden="true"
+                >
+                  ×
+                </span>
+                <span
+                  className="sr-only"
+                >
+                  Close alert
+                </span>
+              </button>
+              <strong>
+                Note:
+              </strong>
+               For best results, use an updated version of 
+              <a
+                className="alert-link"
+                href="https://www.google.com/chrome/"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Chrome
+              </a>
+              , 
+              <a
+                className="alert-link"
+                href="https://www.mozilla.org/firefox/new"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Firefox
+              </a>
+              , 
+              <a
+                className="alert-link"
+                href="https://www.microsoft.com/edge"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Edge
+              </a>
+               or 
+              <a
+                className="alert-link"
+                href="https://support.apple.com/en-us/HT204416"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Safari
+              </a>
+              .
+            </div>
+            <div
               className="fade alert alert-info show"
               role="alert"
             >
@@ -2159,6 +2228,75 @@ Array [
         className="content narrow container"
         id="page-content"
       >
+        <div
+          className="fade alert alert-warning alert-dismissible show"
+          role="alert"
+        >
+          <button
+            className="close"
+            onClick={[Function]}
+            type="button"
+          >
+            <span
+              aria-hidden="true"
+            >
+              ×
+            </span>
+            <span
+              className="sr-only"
+            >
+              Close alert
+            </span>
+          </button>
+          <strong>
+            Note:
+          </strong>
+           For best results, use an updated version of 
+          <a
+            className="alert-link"
+            href="https://www.google.com/chrome/"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Chrome
+          </a>
+          , 
+          <a
+            className="alert-link"
+            href="https://www.mozilla.org/firefox/new"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Firefox
+          </a>
+          , 
+          <a
+            className="alert-link"
+            href="https://www.microsoft.com/edge"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Edge
+          </a>
+           or 
+          <a
+            className="alert-link"
+            href="https://support.apple.com/en-us/HT204416"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Safari
+          </a>
+          .
+        </div>
         <div>
           <button
             className="button-edit btn btn-primary"

--- a/app/tests/unit/containers/Forms/__snapshots__/Form.test.tsx.snap
+++ b/app/tests/unit/containers/Forms/__snapshots__/Form.test.tsx.snap
@@ -162,7 +162,7 @@ exports[`The Form Component should match the snapshot 1`] = `
     </div>
   </Form>
   <JSXStyle
-    id="841285729"
+    id="3174955380"
   >
     .
     r
@@ -620,6 +620,36 @@ exports[`The Form Component should match the snapshot 1`] = `
     5
     p
     x
+    ;
+    }
+    .
+    f
+    o
+    r
+    m
+    -
+    t
+    i
+    t
+    l
+    e
+    {
+    m
+    a
+    r
+    g
+    i
+    n
+    -
+    t
+    o
+    p
+    :
+    0
+    .
+    5
+    e
+    m
     ;
     }
   </JSXStyle>
@@ -798,7 +828,7 @@ exports[`The Form Component should not render an alert reminder to check the gui
     </div>
   </Form>
   <JSXStyle
-    id="841285729"
+    id="3174955380"
   >
     .
     r
@@ -1256,6 +1286,36 @@ exports[`The Form Component should not render an alert reminder to check the gui
     5
     p
     x
+    ;
+    }
+    .
+    f
+    o
+    r
+    m
+    -
+    t
+    i
+    t
+    l
+    e
+    {
+    m
+    a
+    r
+    g
+    i
+    n
+    -
+    t
+    o
+    p
+    :
+    0
+    .
+    5
+    e
+    m
     ;
     }
   </JSXStyle>
@@ -1458,7 +1518,7 @@ exports[`The Form Component should render alert reminder to check the guidance i
     </div>
   </Form>
   <JSXStyle
-    id="841285729"
+    id="3174955380"
   >
     .
     r
@@ -1916,6 +1976,36 @@ exports[`The Form Component should render alert reminder to check the guidance i
     5
     p
     x
+    ;
+    }
+    .
+    f
+    o
+    r
+    m
+    -
+    t
+    i
+    t
+    l
+    e
+    {
+    m
+    a
+    r
+    g
+    i
+    n
+    -
+    t
+    o
+    p
+    :
+    0
+    .
+    5
+    e
+    m
     ;
     }
   </JSXStyle>
@@ -2168,7 +2258,7 @@ exports[`The Form Component should render an alert reminder to report any missin
     </div>
   </Form>
   <JSXStyle
-    id="841285729"
+    id="3174955380"
   >
     .
     r
@@ -2626,6 +2716,36 @@ exports[`The Form Component should render an alert reminder to report any missin
     5
     p
     x
+    ;
+    }
+    .
+    f
+    o
+    r
+    m
+    -
+    t
+    i
+    t
+    l
+    e
+    {
+    m
+    a
+    r
+    g
+    i
+    n
+    -
+    t
+    o
+    p
+    :
+    0
+    .
+    5
+    e
+    m
     ;
     }
   </JSXStyle>

--- a/app/tests/unit/containers/Organisation/__snapshots__/Organisations.test.tsx.snap
+++ b/app/tests/unit/containers/Organisation/__snapshots__/Organisations.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Organisations should announce there are certification requests to view 1`] = `
 <Fragment>
+  <SupportedBrowserNotice />
   <Alert
     closeLabel="Close alert"
     show={true}
@@ -246,6 +247,7 @@ exports[`Organisations should announce there are certification requests to view 
 
 exports[`Organisations should render no organisations if the user has not requested any access 1`] = `
 <Fragment>
+  <SupportedBrowserNotice />
   <Card
     bg="light"
     body={false}
@@ -408,6 +410,7 @@ exports[`Organisations should render no organisations if the user has not reques
 
 exports[`Organisations should render the user's requested organisations 1`] = `
 <Fragment>
+  <SupportedBrowserNotice />
   <Card
     bg="light"
     body={false}

--- a/app/tests/unit/containers/ReportingYear/__snapshots__/NewReportingYearFormDialog.test.tsx.snap
+++ b/app/tests/unit/containers/ReportingYear/__snapshots__/NewReportingYearFormDialog.test.tsx.snap
@@ -153,7 +153,7 @@ exports[`NewReportingYearFormDialog Should match last accepted snapshot 1`] = `
     </ModalBody>
   </Bootstrap(Modal)>
   <JSXStyle
-    id="841285729"
+    id="3174955380"
   >
     .
     r
@@ -611,6 +611,36 @@ exports[`NewReportingYearFormDialog Should match last accepted snapshot 1`] = `
     5
     p
     x
+    ;
+    }
+    .
+    f
+    o
+    r
+    m
+    -
+    t
+    i
+    t
+    l
+    e
+    {
+    m
+    a
+    r
+    g
+    i
+    n
+    -
+    t
+    o
+    p
+    :
+    0
+    .
+    5
+    e
+    m
     ;
     }
   </JSXStyle>

--- a/app/tests/unit/containers/ReportingYear/__snapshots__/ReportingYearFormDialog.test.tsx.snap
+++ b/app/tests/unit/containers/ReportingYear/__snapshots__/ReportingYearFormDialog.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`ReportingYearFormDialog Should match last accepted snapshot: no inputs 
     </ModalBody>
   </Bootstrap(Modal)>
   <JSXStyle
-    id="841285729"
+    id="3174955380"
   >
     .
     r
@@ -587,6 +587,36 @@ exports[`ReportingYearFormDialog Should match last accepted snapshot: no inputs 
     5
     p
     x
+    ;
+    }
+    .
+    f
+    o
+    r
+    m
+    -
+    t
+    i
+    t
+    l
+    e
+    {
+    m
+    a
+    r
+    g
+    i
+    n
+    -
+    t
+    o
+    p
+    :
+    0
+    .
+    5
+    e
+    m
     ;
     }
   </JSXStyle>
@@ -722,7 +752,7 @@ exports[`ReportingYearFormDialog Should match last accepted snapshot: some past 
     </ModalBody>
   </Bootstrap(Modal)>
   <JSXStyle
-    id="841285729"
+    id="3174955380"
   >
     .
     r
@@ -1180,6 +1210,36 @@ exports[`ReportingYearFormDialog Should match last accepted snapshot: some past 
     5
     p
     x
+    ;
+    }
+    .
+    f
+    o
+    r
+    m
+    -
+    t
+    i
+    t
+    l
+    e
+    {
+    m
+    a
+    r
+    g
+    i
+    n
+    -
+    t
+    o
+    p
+    :
+    0
+    .
+    5
+    e
+    m
     ;
     }
   </JSXStyle>

--- a/app/tests/unit/layout/__snapshots__/default-layout.test.tsx.snap
+++ b/app/tests/unit/layout/__snapshots__/default-layout.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`The DefaultLayout component matches the last accepted Snapshot 1`] = `
 <div
-  className="jsx-1155151846 page-wrap"
+  className="jsx-3172037009 page-wrap"
 >
   <HeaderLayout
     isLoggedIn={false}
@@ -15,9 +15,9 @@ exports[`The DefaultLayout component matches the last accepted Snapshot 1`] = `
   />
   <Footer />
   <JSXStyle
-    id="1155151846"
+    id="3172037009"
   >
-    html,body,#__next,.page-wrap{height:100%;}.page-wrap{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;}.content{padding-top:50px;-webkit-flex:1 0 auto;-ms-flex:1 0 auto;flex:1 0 auto;}.footer{-webkit-flex-shrink:0;-ms-flex-negative:0;flex-shrink:0;}h1{font-size:30px;display:inline-block;}.page-title{background:#f5f5f5;border-bottom:1px solid #ccc;padding:40px 0 20px;}.page-title h1{font-size:25px;font-weight:400;}h3{margin-bottom:20px;font-weight:500;}.blue{color:#036;}p{line-height:25px;}.ciip-card{border:1px solid #036;padding:15px;border-radius:0;box-shadow:1px 8px 13px -5px #00336694;}button.full-width{width:100%;}.btn-primary{background:#036;border-color:#036;}.with-shadow{box-shadow:1px 8px 13px -5px #00336694;}.accordion button{text-align:left;padding-left:0;color:#1a5a96;}.accordion .card-body{font-size:15px;}.container.wide{max-width:1600px;}@media screen and (min-width:992px){#page-content{padding-top:110px;}}
+    html,body,#__next,.page-wrap{height:100%;}.page-wrap{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;}.content{padding-top:1.5em;-webkit-flex:1 0 auto;-ms-flex:1 0 auto;flex:1 0 auto;}.footer{-webkit-flex-shrink:0;-ms-flex-negative:0;flex-shrink:0;}h1{font-size:30px;display:inline-block;}.page-title{background:#f5f5f5;border-bottom:1px solid #ccc;padding:40px 0 20px;}.page-title h1{font-size:25px;font-weight:400;}h3{margin-bottom:20px;font-weight:500;}.blue{color:#036;}p{line-height:25px;}.ciip-card{border:1px solid #036;padding:15px;border-radius:0;box-shadow:1px 8px 13px -5px #00336694;}button.full-width{width:100%;}.btn-primary{background:#036;border-color:#036;}.with-shadow{box-shadow:1px 8px 13px -5px #00336694;}.accordion button{text-align:left;padding-left:0;color:#1a5a96;}.accordion .card-body{font-size:15px;}.container.wide{max-width:1600px;}
   </JSXStyle>
 </div>
 `;

--- a/app/tests/unit/pages/__snapshots__/certification-redirect.test.tsx.snap
+++ b/app/tests/unit/pages/__snapshots__/certification-redirect.test.tsx.snap
@@ -25,48 +25,57 @@ exports[`Login redirect page It matches the last accepted Snapshot 1`] = `
         }
       }
     >
-      <h3
-        className="blue"
-      >
-        Your certification is requested.
-      </h3>
-      <p>
-        <strong>
-          Old MacDonald
-        </strong>
-         on behalf of
-         
-        <strong>
-          MacDonald's Agriculture Ltd.
-        </strong>
-        , for facility
-         
-        <strong>
-          Farm
-        </strong>
-         has requested that you review, certify, and approve the information contained in this CIIP application.
-      </p>
-      <p>
-        Please continue to the certification page.
-      </p>
-      <Col
-        md={
+      <SupportedBrowserNotice />
+      <div
+        style={
           Object {
-            "offset": 1,
-            "span": 5,
+            "marginTop": "3em",
           }
         }
       >
-        <Button
-          active={false}
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-          variant="primary"
+        <h3
+          className="blue"
         >
-          Continue
-        </Button>
-      </Col>
+          Your certification is requested.
+        </h3>
+        <p>
+          <strong>
+            Old MacDonald
+          </strong>
+           on behalf of
+           
+          <strong>
+            MacDonald's Agriculture Ltd.
+          </strong>
+          , for facility
+           
+          <strong>
+            Farm
+          </strong>
+           has requested that you review, certify, and approve the information contained in this CIIP application.
+        </p>
+        <p>
+          Please continue to the certification page.
+        </p>
+        <Col
+          md={
+            Object {
+              "offset": 1,
+              "span": 5,
+            }
+          }
+        >
+          <Button
+            active={false}
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            variant="primary"
+          >
+            Continue
+          </Button>
+        </Col>
+      </div>
     </Col>
   </Row>
 </Relay(DefaultLayout)>

--- a/app/tests/unit/pages/__snapshots__/certifier-requests.test.tsx.snap
+++ b/app/tests/unit/pages/__snapshots__/certifier-requests.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`certifier requests list page It matches the last accepted Snapshot 1`] 
   }
   title="Certification Requests"
 >
+  <SupportedBrowserNotice />
   <SearchTableComponent
     defaultOrderByDisplay="Facility"
     defaultOrderByField="facility_name"

--- a/app/tests/unit/pages/__snapshots__/certify.test.tsx.snap
+++ b/app/tests/unit/pages/__snapshots__/certify.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`It matches the last accepted Snapshot 1`] = `
   }
   title="Submission Certification"
 >
+  <SupportedBrowserNotice />
   <Relay(ApplicationDetailsComponent)
     application={
       Object {
@@ -95,6 +96,7 @@ exports[`It renders ApplicationRecertificationContainer if hashMatches is false 
   }
   title="Submission Certification"
 >
+  <SupportedBrowserNotice />
   <Relay(ApplicationRecertification)
     certificationUrl={
       Object {

--- a/app/tests/unit/pages/__snapshots__/index.test.tsx.snap
+++ b/app/tests/unit/pages/__snapshots__/index.test.tsx.snap
@@ -12,22 +12,22 @@ exports[`landing It matches the last accepted Snapshot 1`] = `
       md={6}
     >
       <h3
-        className="jsx-348810478 blue"
+        className="jsx-260136842 blue"
       >
         What is the CleanBC Industrial Incentive Program?
       </h3>
       <p
-        className="jsx-348810478"
+        className="jsx-260136842"
       >
         The CleanBC Industrial Incentive Program (CIIP) is part of the CleanBC Program for Industry, which applies to large industrial operations that report their emissions under the Greenhouse Gas Industrial Reporting and Control Act (GGIRCA).
       </p>
       <p
-        className="jsx-348810478"
+        className="jsx-260136842"
       >
         The CIIP helps encourage cleaner industrial operations across the province by reducing carbon tax costs for facilities that can demonstrate they operate near world-leading emissions benchmarks.
       </p>
       <p
-        className="jsx-348810478"
+        className="jsx-260136842"
       >
         As the price of carbon rises, the CleanBC Program for Industry will support competitiveness and facilitate emission reductions using revenues from the carbon tax that industry pays above $30 per tonne carbon dioxide equivalent (tCO2e).
       </p>
@@ -49,7 +49,7 @@ exports[`landing It matches the last accepted Snapshot 1`] = `
       md={12}
     >
       <h4
-        className="jsx-348810478 blue"
+        className="jsx-260136842 blue"
       >
         How to Apply
       </h4>
@@ -58,19 +58,19 @@ exports[`landing It matches the last accepted Snapshot 1`] = `
       md={4}
     >
       <div
-        className="jsx-348810478 value-prop"
+        className="jsx-260136842 value-prop"
       >
         <img
-          className="jsx-348810478"
+          className="jsx-260136842"
           src="/static/icons/icon-register.svg"
         />
         <h5
-          className="jsx-348810478 blue"
+          className="jsx-260136842 blue"
         >
           1. Register as an Industrial Reporter
         </h5>
         <p
-          className="jsx-348810478"
+          className="jsx-260136842"
         >
           Before you can apply for the CIIP on behalf of an eligible operation, you must register with the Ministry of Environment and Climate Change Strategy.
         </p>
@@ -80,19 +80,19 @@ exports[`landing It matches the last accepted Snapshot 1`] = `
       md={4}
     >
       <div
-        className="jsx-348810478 value-prop"
+        className="jsx-260136842 value-prop"
       >
         <img
-          className="jsx-348810478"
+          className="jsx-260136842"
           src="/static/icons/icon-request.svg"
         />
         <h5
-          className="jsx-348810478 blue"
+          className="jsx-260136842 blue"
         >
           2. Request to apply for an Operation
         </h5>
         <p
-          className="jsx-348810478"
+          className="jsx-260136842"
         >
           Once you’ve registered you can request to apply on behalf one or multiple eligible Operations.
         </p>
@@ -102,19 +102,19 @@ exports[`landing It matches the last accepted Snapshot 1`] = `
       md={4}
     >
       <div
-        className="jsx-348810478 value-prop"
+        className="jsx-260136842 value-prop"
       >
         <img
-          className="jsx-348810478"
+          className="jsx-260136842"
           src="/static/icons/icon-apply.svg"
         />
         <h5
-          className="jsx-348810478 blue"
+          className="jsx-260136842 blue"
         >
           3. Apply on behalf of the Operation
         </h5>
         <p
-          className="jsx-348810478"
+          className="jsx-260136842"
         >
           The CIIP team will verify and approve your request and then you can apply for the CleanBC Industrial Incentive Program.
         </p>
@@ -122,7 +122,7 @@ exports[`landing It matches the last accepted Snapshot 1`] = `
     </Col>
   </Row>
   <div
-    className="jsx-348810478 row"
+    className="jsx-260136842 row"
     id="photo-row"
   >
     <Col
@@ -133,7 +133,7 @@ exports[`landing It matches the last accepted Snapshot 1`] = `
       }
     >
       <img
-        className="jsx-348810478 with-shadow img-fluid"
+        className="jsx-260136842 with-shadow img-fluid"
         id="photo"
         sizes=" (max-width: 575.98px) calc(100vw - 30px) (max-width: 767.98px) 510px, (min-width: 768px) 635px "
         src="/static/landing-photo-1020.jpg"
@@ -148,7 +148,7 @@ exports[`landing It matches the last accepted Snapshot 1`] = `
       }
     >
       <h3
-        className="jsx-348810478 blue"
+        className="jsx-260136842 blue"
       >
         Key Dates
       </h3>
@@ -158,23 +158,23 @@ exports[`landing It matches the last accepted Snapshot 1`] = `
         striped={true}
       >
         <thead
-          className="jsx-348810478"
+          className="jsx-260136842"
         >
           <tr
-            className="jsx-348810478"
+            className="jsx-260136842"
           >
             <th
-              className="jsx-348810478"
+              className="jsx-260136842"
             >
               Date
             </th>
             <th
-              className="jsx-348810478"
+              className="jsx-260136842"
             />
           </tr>
         </thead>
         <tbody
-          className="jsx-348810478"
+          className="jsx-260136842"
         >
           <tr
             key="j87kj39uhf8930"
@@ -234,7 +234,7 @@ exports[`landing It matches the last accepted Snapshot 1`] = `
           >
             Please email us at 
             <strong
-              className="jsx-348810478"
+              className="jsx-260136842"
             >
               GHGRegulator@gov.bc.ca
             </strong>
@@ -243,11 +243,11 @@ exports[`landing It matches the last accepted Snapshot 1`] = `
         </CardBody>
       </Card>
       <p
-        className="jsx-348810478"
+        className="jsx-260136842"
       >
         Further information on the CleanBC Industrial Incentive Program is available in this
         <a
-          className="jsx-348810478"
+          className="jsx-260136842"
           href="https://www2.gov.bc.ca/assets/gov/environment/climate-change/ind/cleanbc-program-for-industry/ciip_factsheet.pdf?bcgovtm=20200506_GCPE_AM_COVID_11_NOTIFICATION_BCGOVNEWS_BCGOV_EN_BC__NOTIFICATION&forcedownload=true"
           rel="noopener noreferrer"
           target="_blank"
@@ -260,9 +260,9 @@ exports[`landing It matches the last accepted Snapshot 1`] = `
     </Col>
   </div>
   <JSXStyle
-    id="348810478"
+    id="260136842"
   >
-    .value-prop.jsx-348810478{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;padding-right:30px;}.value-prop.jsx-348810478 img.jsx-348810478{max-width:100px;padding:30px 0;}.value-prop.jsx-348810478 h4.jsx-348810478{margin-bottom:20px;}li.jsx-348810478{list-style:none;}#photo.jsx-348810478{margin:53px 0;}@media (min-width:767.98px){#photo-row.jsx-348810478{margin-top:100px;}}
+    .value-prop{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;padding-right:30px;}.value-prop img{max-width:100px;padding:30px 0;}.value-prop h4{margin-bottom:20px;}li{list-style:none;}#photo{margin:53px 0;}@media (min-width:767.98px){#photo-row{margin-top:100px;}}@media screen and (min-width:992px){#page-content{padding-top:110px;}}
   </JSXStyle>
 </Relay(DefaultLayout)>
 `;

--- a/app/tests/unit/pages/__snapshots__/login-redirect.test.tsx.snap
+++ b/app/tests/unit/pages/__snapshots__/login-redirect.test.tsx.snap
@@ -12,13 +12,17 @@ exports[`Login redirect page It matches the last accepted Snapshot 1`] = `
       md={6}
     >
       <h3
-        className="blue"
+        className="jsx-3098287074 blue"
       >
         You need to be logged in to access this page.
       </h3>
-      <p>
+      <p
+        className="jsx-3098287074"
+      >
         Please log in or register in order to access this page.
-        <br />
+        <br
+          className="jsx-3098287074"
+        />
         You will be redirected to the requested page after doing so.
       </p>
     </Col>
@@ -26,5 +30,10 @@ exports[`Login redirect page It matches the last accepted Snapshot 1`] = `
       applicationDeadline="August 31, 2020"
     />
   </Row>
+  <JSXStyle
+    id="3098287074"
+  >
+    @media screen and (min-width:768px){#page-content{padding-top:110px;}}
+  </JSXStyle>
 </Relay(DefaultLayout)>
 `;

--- a/app/tests/unit/pages/__snapshots__/view-application.test.tsx.snap
+++ b/app/tests/unit/pages/__snapshots__/view-application.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`It matches the last accepted Snapshot 1`] = `
     <Col
       md={8}
     >
+      <SupportedBrowserNotice />
       <Relay(ApplicationDetailsComponent)
         application={
           Object {

--- a/app/tests/unit/pages/reporter/__snapshots__/application.test.tsx.snap
+++ b/app/tests/unit/pages/reporter/__snapshots__/application.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`It matches the last accepted Snapshot 1`] = `
     }
   }
 >
+  <SupportedBrowserNotice />
   <Relay(ApplicationWizard)
     query={
       Object {

--- a/app/tests/unit/pages/reporter/__snapshots__/new-application-disclaimer.test.tsx.snap
+++ b/app/tests/unit/pages/reporter/__snapshots__/new-application-disclaimer.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`Interstitial application legal disclaimer page It matches the last acce
   }
   title="Legal Disclaimer"
 >
+  <SupportedBrowserNotice />
   <Card
     body={false}
     className="mb-2"

--- a/app/tests/unit/pages/user/__snapshots__/profile.test.tsx.snap
+++ b/app/tests/unit/pages/user/__snapshots__/profile.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`user profile matches snapshot 1`] = `
   showSubheader={true}
   title="User Profile"
 >
+  <SupportedBrowserNotice />
   <Relay(UserProfile)
     user={null}
   />

--- a/app/tests/unit/pages/user/__snapshots__/profile.test.tsx.snap
+++ b/app/tests/unit/pages/user/__snapshots__/profile.test.tsx.snap
@@ -1,7 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`user profile matches snapshot 1`] = `
-<Relay(DefaultLayout)>
+<Relay(DefaultLayout)
+  showSubheader={true}
+  title="User Profile"
+>
   <Relay(UserProfile)
     user={null}
   />


### PR DESCRIPTION
Implements a short, dismissible blurb stating the supported browsers to use for the best user experience. This is implemented on the logged-in views for industry users only.

(Related, but incidental changes):
- Removes a no-longer-necessary 110px of whitespace padding the top of page content on viewports 992px and wider.
- Turns on on the subheader navigation and page title (like all other related pages) on the user profile page

[GGIRCS-1747](https://youtrack.button.is/issue/GGIRCS-1747)