### PR TITLE
feat: status change confirmation

### DIFF
--- a/app/containers/Applications/ApplicationRevisionStatusContainer.tsx
+++ b/app/containers/Applications/ApplicationRevisionStatusContainer.tsx
@@ -101,59 +101,67 @@ export const ApplicationRevisionStatusComponent: React.FunctionComponent<Props> 
   } = props.applicationRevisionStatus.applicationRevisionByApplicationIdAndVersionNumber;
 
   return (
-    <Row>
-      <Col md={3}>
-        <h3>Application Status*: </h3>
-        <p>
-          * Status changes will be immediately confirmed by email notification
-        </p>
-      </Col>
-      {confirmStatusChangeModal}
-      {isCurrentVersion ? (
-        <Col md={2}>
-          <Dropdown style={{width: '100%'}}>
-            <Dropdown.Toggle
-              style={{width: '100%', textTransform: 'capitalize'}}
+    <>
+      <Row>
+        <Col md={3}>
+          <h3>Application Status*: </h3>
+        </Col>
+        {confirmStatusChangeModal}
+        {isCurrentVersion ? (
+          <Col md={2}>
+            <Dropdown style={{width: '100%'}}>
+              <Dropdown.Toggle
+                style={{width: '100%', textTransform: 'capitalize'}}
+                variant={
+                  statusBadgeColor[
+                    props.applicationRevisionStatus.applicationRevisionStatus
+                  ]
+                }
+                id="dropdown"
+              >
+                {props.applicationRevisionStatus.applicationRevisionStatus}
+              </Dropdown.Toggle>
+              <Dropdown.Menu style={{width: '100%'}}>
+                {Object.keys(statusBadgeColor)
+                  .filter(
+                    (status) =>
+                      !['DRAFT', currentRevisionStatus].includes(status)
+                  )
+                  .map((status) => (
+                    <DropdownMenuItemComponent
+                      key={status}
+                      itemEventKey={status}
+                      itemFunc={renderStatusConfirmationModal}
+                      itemTitle={status}
+                    />
+                  ))}
+              </Dropdown.Menu>
+            </Dropdown>
+          </Col>
+        ) : (
+          <Col md={2}>
+            <Button
+              disabled
               variant={
                 statusBadgeColor[
                   props.applicationRevisionStatus.applicationRevisionStatus
                 ]
               }
-              id="dropdown"
             >
               {props.applicationRevisionStatus.applicationRevisionStatus}
-            </Dropdown.Toggle>
-            <Dropdown.Menu style={{width: '100%'}}>
-              {Object.keys(statusBadgeColor)
-                .filter(
-                  (status) => !['DRAFT', currentRevisionStatus].includes(status)
-                )
-                .map((status) => (
-                  <DropdownMenuItemComponent
-                    key={status}
-                    itemEventKey={status}
-                    itemFunc={renderStatusConfirmationModal}
-                    itemTitle={status}
-                  />
-                ))}
-            </Dropdown.Menu>
-          </Dropdown>
+            </Button>
+          </Col>
+        )}
+      </Row>
+      <Row>
+        <Col md={12}>
+          <p>
+            * Status changes will be immediately confirmed by email
+            notification.
+          </p>
         </Col>
-      ) : (
-        <Col md={2}>
-          <Button
-            disabled
-            variant={
-              statusBadgeColor[
-                props.applicationRevisionStatus.applicationRevisionStatus
-              ]
-            }
-          >
-            {props.applicationRevisionStatus.applicationRevisionStatus}
-          </Button>
-        </Col>
-      )}
-    </Row>
+      </Row>
+    </>
   );
 };
 

--- a/app/cypress/integration/email.spec.js
+++ b/app/cypress/integration/email.spec.js
@@ -346,6 +346,7 @@ function makeApplicationDecision(decision) {
   cy.get('#dropdown').click();
   cy.wait(500);
   cy.contains(decision).click();
+  cy.get('.btn-success').click();
   cy.wait(500);
 }
 

--- a/app/tests/unit/containers/Applications/ApplicationStatusContainer.test.tsx
+++ b/app/tests/unit/containers/Applications/ApplicationStatusContainer.test.tsx
@@ -20,7 +20,7 @@ describe('ApplicationRevisionStatusItem', () => {
       />
     );
     expect(r.exists('Dropdown')).toBe(true);
-    expect(r.exists('Button')).toBe(false);
+    expect(r.find('DropdownToggle').text()).toBe('SUBMITTED');
     expect(r).toMatchSnapshot();
   });
 
@@ -41,7 +41,7 @@ describe('ApplicationRevisionStatusItem', () => {
       />
     );
     expect(r.exists('Dropdown')).toBe(false);
-    expect(r.find('Button').props().disabled).toBe(true);
+    expect(r.find('Button').at(2).props().disabled).toBe(true);
     expect(r).toMatchSnapshot();
   });
 });

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationStatusContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationStatusContainer.test.tsx.snap
@@ -8,9 +8,50 @@ exports[`ApplicationRevisionStatusItem should render the application status in a
     md={3}
   >
     <h3>
-      Application Status: 
+      Application Status*: 
     </h3>
+    <p>
+      * Status changes will be immediately confirmed by email notification
+    </p>
   </Col>
+  <Bootstrap(Modal)
+    onHide={[Function]}
+    show={false}
+  >
+    <ModalHeader
+      closeButton={false}
+      closeLabel="Close"
+    >
+      <ModalTitle>
+        Confirm Status Change
+      </ModalTitle>
+    </ModalHeader>
+    <ModalBody>
+      <p>
+        Changing this status will result in an email being sent to the reporter notifying them that their application status has been changed.
+      </p>
+    </ModalBody>
+    <ModalFooter>
+      <Button
+        active={false}
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+        variant="success"
+      >
+        Confirm
+      </Button>
+      <Button
+        active={false}
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+        variant="secondary"
+      >
+        Cancel
+      </Button>
+    </ModalFooter>
+  </Bootstrap(Modal)>
   <Col
     md={2}
   >
@@ -34,9 +75,50 @@ exports[`ApplicationRevisionStatusItem should render the application status in a
     md={3}
   >
     <h3>
-      Application Status: 
+      Application Status*: 
     </h3>
+    <p>
+      * Status changes will be immediately confirmed by email notification
+    </p>
   </Col>
+  <Bootstrap(Modal)
+    onHide={[Function]}
+    show={false}
+  >
+    <ModalHeader
+      closeButton={false}
+      closeLabel="Close"
+    >
+      <ModalTitle>
+        Confirm Status Change
+      </ModalTitle>
+    </ModalHeader>
+    <ModalBody>
+      <p>
+        Changing this status will result in an email being sent to the reporter notifying them that their application status has been changed.
+      </p>
+    </ModalBody>
+    <ModalFooter>
+      <Button
+        active={false}
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+        variant="success"
+      >
+        Confirm
+      </Button>
+      <Button
+        active={false}
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+        variant="secondary"
+      >
+        Cancel
+      </Button>
+    </ModalFooter>
+  </Bootstrap(Modal)>
   <Col
     md={2}
   >
@@ -69,18 +151,6 @@ exports[`ApplicationRevisionStatusItem should render the application status in a
           }
         }
       >
-        <DropdownMenuItemComponent
-          itemEventKey="DRAFT"
-          itemFunc={[Function]}
-          itemTitle="DRAFT"
-          key="DRAFT"
-        />
-        <DropdownMenuItemComponent
-          itemEventKey="SUBMITTED"
-          itemFunc={[Function]}
-          itemTitle="SUBMITTED"
-          key="SUBMITTED"
-        />
         <DropdownMenuItemComponent
           itemEventKey="REJECTED"
           itemFunc={[Function]}

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationStatusContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationStatusContainer.test.tsx.snap
@@ -1,176 +1,196 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ApplicationRevisionStatusItem should render the application status in a disabled button if isCurrentVersion is false 1`] = `
-<Row
-  noGutters={false}
->
-  <Col
-    md={3}
+<Fragment>
+  <Row
+    noGutters={false}
   >
-    <h3>
-      Application Status*: 
-    </h3>
-    <p>
-      * Status changes will be immediately confirmed by email notification
-    </p>
-  </Col>
-  <Bootstrap(Modal)
-    onHide={[Function]}
-    show={false}
-  >
-    <ModalHeader
-      closeButton={false}
-      closeLabel="Close"
+    <Col
+      md={3}
     >
-      <ModalTitle>
-        Confirm Status Change
-      </ModalTitle>
-    </ModalHeader>
-    <ModalBody>
-      <p>
-        Changing this status will result in an email being sent to the reporter notifying them that their application status has been changed.
-      </p>
-    </ModalBody>
-    <ModalFooter>
+      <h3>
+        Application Status*: 
+      </h3>
+    </Col>
+    <Bootstrap(Modal)
+      onHide={[Function]}
+      show={false}
+    >
+      <ModalHeader
+        closeButton={false}
+        closeLabel="Close"
+      >
+        <ModalTitle>
+          Confirm Status Change
+        </ModalTitle>
+      </ModalHeader>
+      <ModalBody>
+        <p>
+          Changing this status will result in an email being sent to the reporter notifying them that their application status has been changed.
+        </p>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          active={false}
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          variant="success"
+        >
+          Confirm
+        </Button>
+        <Button
+          active={false}
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          variant="secondary"
+        >
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Bootstrap(Modal)>
+    <Col
+      md={2}
+    >
       <Button
         active={false}
-        disabled={false}
-        onClick={[Function]}
+        disabled={true}
         type="button"
-        variant="success"
-      >
-        Confirm
-      </Button>
-      <Button
-        active={false}
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-        variant="secondary"
-      >
-        Cancel
-      </Button>
-    </ModalFooter>
-  </Bootstrap(Modal)>
-  <Col
-    md={2}
-  >
-    <Button
-      active={false}
-      disabled={true}
-      type="button"
-      variant="info"
-    >
-      SUBMITTED
-    </Button>
-  </Col>
-</Row>
-`;
-
-exports[`ApplicationRevisionStatusItem should render the application status in a dropdown if isCurrentVersion is true 1`] = `
-<Row
-  noGutters={false}
->
-  <Col
-    md={3}
-  >
-    <h3>
-      Application Status*: 
-    </h3>
-    <p>
-      * Status changes will be immediately confirmed by email notification
-    </p>
-  </Col>
-  <Bootstrap(Modal)
-    onHide={[Function]}
-    show={false}
-  >
-    <ModalHeader
-      closeButton={false}
-      closeLabel="Close"
-    >
-      <ModalTitle>
-        Confirm Status Change
-      </ModalTitle>
-    </ModalHeader>
-    <ModalBody>
-      <p>
-        Changing this status will result in an email being sent to the reporter notifying them that their application status has been changed.
-      </p>
-    </ModalBody>
-    <ModalFooter>
-      <Button
-        active={false}
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-        variant="success"
-      >
-        Confirm
-      </Button>
-      <Button
-        active={false}
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-        variant="secondary"
-      >
-        Cancel
-      </Button>
-    </ModalFooter>
-  </Bootstrap(Modal)>
-  <Col
-    md={2}
-  >
-    <Dropdown
-      navbar={false}
-      style={
-        Object {
-          "width": "100%",
-        }
-      }
-    >
-      <DropdownToggle
-        id="dropdown"
-        style={
-          Object {
-            "textTransform": "capitalize",
-            "width": "100%",
-          }
-        }
         variant="info"
       >
         SUBMITTED
-      </DropdownToggle>
-      <DropdownMenu
-        alignRight={false}
-        flip={true}
+      </Button>
+    </Col>
+  </Row>
+  <Row
+    noGutters={false}
+  >
+    <Col
+      md={12}
+    >
+      <p>
+        * Status changes will be immediately confirmed by email notification.
+      </p>
+    </Col>
+  </Row>
+</Fragment>
+`;
+
+exports[`ApplicationRevisionStatusItem should render the application status in a dropdown if isCurrentVersion is true 1`] = `
+<Fragment>
+  <Row
+    noGutters={false}
+  >
+    <Col
+      md={3}
+    >
+      <h3>
+        Application Status*: 
+      </h3>
+    </Col>
+    <Bootstrap(Modal)
+      onHide={[Function]}
+      show={false}
+    >
+      <ModalHeader
+        closeButton={false}
+        closeLabel="Close"
+      >
+        <ModalTitle>
+          Confirm Status Change
+        </ModalTitle>
+      </ModalHeader>
+      <ModalBody>
+        <p>
+          Changing this status will result in an email being sent to the reporter notifying them that their application status has been changed.
+        </p>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          active={false}
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          variant="success"
+        >
+          Confirm
+        </Button>
+        <Button
+          active={false}
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          variant="secondary"
+        >
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Bootstrap(Modal)>
+    <Col
+      md={2}
+    >
+      <Dropdown
+        navbar={false}
         style={
           Object {
             "width": "100%",
           }
         }
       >
-        <DropdownMenuItemComponent
-          itemEventKey="REJECTED"
-          itemFunc={[Function]}
-          itemTitle="REJECTED"
-          key="REJECTED"
-        />
-        <DropdownMenuItemComponent
-          itemEventKey="APPROVED"
-          itemFunc={[Function]}
-          itemTitle="APPROVED"
-          key="APPROVED"
-        />
-        <DropdownMenuItemComponent
-          itemEventKey="REQUESTED_CHANGES"
-          itemFunc={[Function]}
-          itemTitle="REQUESTED_CHANGES"
-          key="REQUESTED_CHANGES"
-        />
-      </DropdownMenu>
-    </Dropdown>
-  </Col>
-</Row>
+        <DropdownToggle
+          id="dropdown"
+          style={
+            Object {
+              "textTransform": "capitalize",
+              "width": "100%",
+            }
+          }
+          variant="info"
+        >
+          SUBMITTED
+        </DropdownToggle>
+        <DropdownMenu
+          alignRight={false}
+          flip={true}
+          style={
+            Object {
+              "width": "100%",
+            }
+          }
+        >
+          <DropdownMenuItemComponent
+            itemEventKey="REJECTED"
+            itemFunc={[Function]}
+            itemTitle="REJECTED"
+            key="REJECTED"
+          />
+          <DropdownMenuItemComponent
+            itemEventKey="APPROVED"
+            itemFunc={[Function]}
+            itemTitle="APPROVED"
+            key="APPROVED"
+          />
+          <DropdownMenuItemComponent
+            itemEventKey="REQUESTED_CHANGES"
+            itemFunc={[Function]}
+            itemTitle="REQUESTED_CHANGES"
+            key="REQUESTED_CHANGES"
+          />
+        </DropdownMenu>
+      </Dropdown>
+    </Col>
+  </Row>
+  <Row
+    noGutters={false}
+  >
+    <Col
+      md={12}
+    >
+      <p>
+        * Status changes will be immediately confirmed by email notification.
+      </p>
+    </Col>
+  </Row>
+</Fragment>
 `;


### PR DESCRIPTION
- adds a confirmation modal before applying change to application status
- adds some explanatory text under the Application Status dropdown