### PR TITLE
fix: Require certifier email before submitting for certification

### DIFF
--- a/app/containers/Applications/ApplicationWizardConfirmation.tsx
+++ b/app/containers/Applications/ApplicationWizardConfirmation.tsx
@@ -27,15 +27,43 @@ interface Target extends EventTarget {
   };
 }
 
+function debounce(fn, wait, immediate?) {
+  let timeout;
+  return function (...args) {
+    const later = () => {
+      timeout = null;
+      if (!immediate) fn.apply(this, args);
+    };
+
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+    if (immediate && !timeout) fn.apply(this, args);
+  };
+}
+
 export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Props> = (
   props
 ) => {
+  const [
+    enableSubmitForCertification,
+    setEnableSubmitForCertification
+  ] = useState(false);
   const [copySuccess, setCopySuccess] = useState('');
   const [url, setUrl] = useState<string>();
   const [isChecked, toggleChecked] = useState(true);
   const [hasErrors, setHasErrors] = useState(false);
   const copyArea = useRef(null);
   const revision = props.application.latestDraftRevision;
+
+  const checkEnableSubmitForCertification = (e) => {
+    const isEmail = Boolean(e.target.value.match(/.+@.+\..+/i));
+
+    if (isEmail) {
+      debounce(() => setEnableSubmitForCertification(true), 200)();
+    } else {
+      debounce(() => setEnableSubmitForCertification(false), 200)();
+    }
+  };
 
   const copyToClipboard = () => {
     copyArea.current.select();
@@ -136,6 +164,8 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
                   name="email"
                   type="email"
                   placeholder="Certifier Email"
+                  onKeyDown={checkEnableSubmitForCertification}
+                  onChange={checkEnableSubmitForCertification}
                 />
               </Form.Group>
             </Form.Row>
@@ -149,7 +179,11 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
                 onChange={() => toggleChecked(!isChecked)}
               />
             </Form.Group>
-            <Button variant="info" type="submit">
+            <Button
+              variant="info"
+              type="submit"
+              disabled={!enableSubmitForCertification}
+            >
               Submit for Certification
             </Button>
           </Form>

--- a/app/cypress/integration/form-errors-prevent-submit.spec.js
+++ b/app/cypress/integration/form-errors-prevent-submit.spec.js
@@ -19,6 +19,6 @@ describe('When logged in as a reporter', () => {
     );
     cy.url().should('include', '/reporter/application');
     cy.get('.errors').contains('Your Application contains errors');
-    cy.get('Send to Certifier').should('not.exist');
+    cy.get('Submit for Certification').should('not.exist');
   });
 });

--- a/app/cypress/integration/reporter-access-all-pages.spec.js
+++ b/app/cypress/integration/reporter-access-all-pages.spec.js
@@ -29,6 +29,7 @@ describe('When logged in as a reporter', () => {
       `/reporter/application?applicationId=${applicationId}&confirmationPage=true&version=1`
     );
     cy.url().should('include', '/reporter/application');
+    cy.get('#certifierEmail').type('certifier@certi.fy');
     cy.get('.btn').contains('Submit for Certification').click();
     cy.wait(500); // Wait for half second (otherwise cypress gets the input before the value has been set)
     cy.get('input').invoke('val').should('contain', 'localhost');

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationWizardConfirmation.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationWizardConfirmation.test.tsx.snap
@@ -93,6 +93,8 @@ exports[`The Confirmation Component match the snapshot 1`] = `
           >
             <FormControl
               name="email"
+              onChange={[Function]}
+              onKeyDown={[Function]}
               placeholder="Certifier Email"
               type="email"
             />
@@ -115,7 +117,7 @@ exports[`The Confirmation Component match the snapshot 1`] = `
         </FormGroup>
         <Button
           active={false}
-          disabled={false}
+          disabled={true}
           type="submit"
           variant="info"
         >
@@ -249,6 +251,8 @@ exports[`The Confirmation Component should show a "data has changed" dialogue wh
           >
             <FormControl
               name="email"
+              onChange={[Function]}
+              onKeyDown={[Function]}
               placeholder="Certifier Email"
               type="email"
             />
@@ -271,7 +275,7 @@ exports[`The Confirmation Component should show a "data has changed" dialogue wh
         </FormGroup>
         <Button
           active={false}
-          disabled={false}
+          disabled={true}
           type="submit"
           variant="info"
         >


### PR DESCRIPTION
Requires an email to be input before 'Submit for Certification' can be clicked.
- button is disabled by default
- typing an email enables the button

[GGIRCS-1831](https://youtrack.button.is/issue/GGIRCS-1831)