### PR TITLE
feat: authenticate user when landing on index page if logged in KC

### DIFF
--- a/app/server/index.js
+++ b/app/server/index.js
@@ -393,6 +393,9 @@ app.prepare().then(() => {
 
   server.get('/register', ({res}) => res.redirect(302, kcRegistrationUrl));
 
+  // Automatically authenticate client when landing on index page if they are logged in Keycloak
+  server.get('/', keycloak.checkSso());
+
   server.get('*', async (req, res) => {
     return handle(req, res);
   });


### PR DESCRIPTION
This can be tested locally by:
1) logging out of CIIP
2) logging in the keycloak realm at https://sso-dev.pathfinder.gov.bc.ca/auth/admin/pisrwwhx/console/#/realms/pisrwwhx
3) open/refresh the CIIP index page, and you should be automatically logged in.

Prior to this feature, the user has to click on the login button.