### PR TITLE
Fix: hide override if there are no errors

### DIFF
--- a/app/components/Application/ApplicationOverrideJustification.tsx
+++ b/app/components/Application/ApplicationOverrideJustification.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import {createFragmentContainer, RelayProp} from 'react-relay';
 import {Accordion, Alert, Button, Form} from 'react-bootstrap';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
@@ -79,118 +79,121 @@ export const ApplicationOverrideJustificationComponent: React.FunctionComponent<
     setAccordionOpen(true);
   };
 
-  if (overrideJustification && !hasErrors) handleOverrideDelete();
+  useEffect(() => {
+    if (overrideJustification && !hasErrors) handleOverrideDelete();
+  });
 
-  if (hasErrors && overrideActive) {
-    return (
-      <>
-        <Alert variant="danger">
-          <strong>Error Validation Override Active</strong>
-        </Alert>
-        <Alert variant="secondary">
-          <p>
-            <strong>
-              You have chosen to override the errors present in your
-              application. This may cause a delay in processing your
-              application.
-            </strong>
-          </p>
-          <p>
-            <strong>Your Override Justification:</strong>
-          </p>
-          <p>{overrideJustification}</p>
-          <Button
-            style={{marginRight: '5px'}}
-            variant="secondary"
-            onClick={handleOverrideEdit}
-          >
-            Edit Justification
-          </Button>
-          <Button variant="danger" onClick={handleOverrideDelete}>
-            Delete Override
-          </Button>
-        </Alert>
-      </>
-    );
-  }
+  const errorsWithOverrideActive = (
+    <>
+      <Alert variant="danger">
+        <strong>Error Validation Override Active</strong>
+      </Alert>
+      <Alert variant="secondary">
+        <p>
+          <strong>
+            You have chosen to override the errors present in your application.
+            This may cause a delay in processing your application.
+          </strong>
+        </p>
+        <p>
+          <strong>Your Override Justification:</strong>
+        </p>
+        <p>{overrideJustification}</p>
+        <Button
+          style={{marginRight: '5px'}}
+          variant="secondary"
+          onClick={handleOverrideEdit}
+        >
+          Edit Justification
+        </Button>
+        <Button variant="danger" onClick={handleOverrideDelete}>
+          Delete Override
+        </Button>
+      </Alert>
+    </>
+  );
 
-  if (hasErrors) {
-    return (
-      <>
-        <Alert variant="danger">
-          <Accordion>
-            <div className="override-accordion">
-              Your application contains errors shown below that must be fixed
-              before submission. You may either correct these or alternatively,
-              override and provide justification. Your justification will be
-              reviewed by CAS and may cause a delay in processing your
-              application.
-              <Accordion.Toggle
-                as={Button}
-                variant="secondary"
-                eventKey="0"
-                onClick={() => setAccordionOpen(!accordionOpen)}
-              >
-                Override and Justify
-                <FontAwesomeIcon
-                  icon={faCaretDown}
-                  style={{marginLeft: '0.75em'}}
-                />
-              </Accordion.Toggle>
-            </div>
-            <Accordion.Collapse in={accordionOpen} eventKey="0">
-              <>
-                <Form>
-                  <h4>Override Form Validation</h4>
-                  <Form.Group controlId="overrideJustification">
-                    <Form.Label>Justification for incomplete form:</Form.Label>
-                    <Form.Control
-                      as="textarea"
-                      rows={4}
-                      value={overrideJustification || ''}
-                      onChange={handleOverrideChange}
-                    />
-                  </Form.Group>
-                  <Button variant="success" onClick={handleOverrideSave}>
-                    Save
-                  </Button>
-                  <Accordion.Toggle
-                    as={Button}
-                    eventKey="0"
-                    variant="light"
-                    style={{
-                      marginLeft: '1em',
-                      border: '1px solid currentColor'
-                    }}
-                    onClick={handleOverrideCancel}
-                  >
-                    Cancel
-                  </Accordion.Toggle>
-                </Form>
-                {!overrideJustification && (
-                  <p className="justification-text">{emptyError}</p>
-                )}
-              </>
-            </Accordion.Collapse>
-          </Accordion>
-        </Alert>
-        <style jsx>
-          {`
-            .override-accordion {
-              display: flex;
-              flex-wrap: wrap;
-              justify-content: flex-end;
-            }
-            .justification-text {
-              color: red;
-            }
-          `}
-        </style>
-      </>
-    );
-  }
+  const errorsWithoutOverrideActive = (
+    <>
+      <Alert variant="danger">
+        <Accordion>
+          <div className="override-accordion">
+            Your application contains errors shown below that must be fixed
+            before submission. You may either correct these or alternatively,
+            override and provide justification. Your justification will be
+            reviewed by CAS and may cause a delay in processing your
+            application.
+            <Accordion.Toggle
+              as={Button}
+              variant="secondary"
+              eventKey="0"
+              onClick={() => setAccordionOpen(!accordionOpen)}
+            >
+              Override and Justify
+              <FontAwesomeIcon
+                icon={faCaretDown}
+                style={{marginLeft: '0.75em'}}
+              />
+            </Accordion.Toggle>
+          </div>
+          <Accordion.Collapse in={accordionOpen} eventKey="0">
+            <>
+              <Form>
+                <h4>Override Form Validation</h4>
+                <Form.Group controlId="overrideJustification">
+                  <Form.Label>Justification for incomplete form:</Form.Label>
+                  <Form.Control
+                    as="textarea"
+                    rows={4}
+                    value={overrideJustification || ''}
+                    onChange={handleOverrideChange}
+                  />
+                </Form.Group>
+                <Button variant="success" onClick={handleOverrideSave}>
+                  Save
+                </Button>
+                <Accordion.Toggle
+                  as={Button}
+                  eventKey="0"
+                  variant="light"
+                  style={{
+                    marginLeft: '1em',
+                    border: '1px solid currentColor'
+                  }}
+                  onClick={handleOverrideCancel}
+                >
+                  Cancel
+                </Accordion.Toggle>
+              </Form>
+              {!overrideJustification && (
+                <p className="justification-text">{emptyError}</p>
+              )}
+            </>
+          </Accordion.Collapse>
+        </Accordion>
+      </Alert>
+      <style jsx>
+        {`
+          .override-accordion {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: flex-end;
+          }
+          .justification-text {
+            color: red;
+          }
+        `}
+      </style>
+    </>
+  );
 
-  return null;
+  const renderOverride = () => {
+    if (!hasErrors) return null;
+    if (hasErrors && overrideActive) return errorsWithOverrideActive;
+    return errorsWithoutOverrideActive;
+  };
+
+  return renderOverride();
 };
 
 export default createFragmentContainer(

--- a/app/components/Application/ApplicationOverrideJustification.tsx
+++ b/app/components/Application/ApplicationOverrideJustification.tsx
@@ -79,6 +79,8 @@ export const ApplicationOverrideJustificationComponent: React.FunctionComponent<
     setAccordionOpen(true);
   };
 
+  if (overrideJustification && !hasErrors) handleOverrideDelete();
+
   if (hasErrors && overrideActive) {
     return (
       <>

--- a/app/components/Application/ApplicationOverrideJustification.tsx
+++ b/app/components/Application/ApplicationOverrideJustification.tsx
@@ -11,6 +11,7 @@ interface Props {
   applicationOverrideJustification: string;
   revisionId: string;
   relay: RelayProp;
+  hasErrors: boolean;
 }
 
 export const ApplicationOverrideJustificationComponent: React.FunctionComponent<Props> = ({
@@ -18,7 +19,8 @@ export const ApplicationOverrideJustificationComponent: React.FunctionComponent<
   setOverrideActive,
   applicationOverrideJustification,
   revisionId,
-  relay
+  relay,
+  hasErrors
 }) => {
   const [accordionOpen, setAccordionOpen] = useState(false);
   const [overrideJustification, setOverrideJustification] = useState(
@@ -77,7 +79,7 @@ export const ApplicationOverrideJustificationComponent: React.FunctionComponent<
     setAccordionOpen(true);
   };
 
-  if (overrideActive) {
+  if (hasErrors && overrideActive) {
     return (
       <>
         <Alert variant="danger">
@@ -110,79 +112,83 @@ export const ApplicationOverrideJustificationComponent: React.FunctionComponent<
     );
   }
 
-  return (
-    <>
-      <Alert variant="danger">
-        <Accordion>
-          <div className="override-accordion">
-            Your application contains errors shown below that must be fixed
-            before submission. You may either correct these or alternatively,
-            override and provide justification. Your justification will be
-            reviewed by CAS and may cause a delay in processing your
-            application.
-            <Accordion.Toggle
-              as={Button}
-              variant="secondary"
-              eventKey="0"
-              onClick={() => setAccordionOpen(!accordionOpen)}
-            >
-              Override and Justify
-              <FontAwesomeIcon
-                icon={faCaretDown}
-                style={{marginLeft: '0.75em'}}
-              />
-            </Accordion.Toggle>
-          </div>
-          <Accordion.Collapse in={accordionOpen} eventKey="0">
-            <>
-              <Form>
-                <h4>Override Form Validation</h4>
-                <Form.Group controlId="overrideJustification">
-                  <Form.Label>Justification for incomplete form:</Form.Label>
-                  <Form.Control
-                    as="textarea"
-                    rows={4}
-                    value={overrideJustification || ''}
-                    onChange={handleOverrideChange}
-                  />
-                </Form.Group>
-                <Button variant="success" onClick={handleOverrideSave}>
-                  Save
-                </Button>
-                <Accordion.Toggle
-                  as={Button}
-                  eventKey="0"
-                  variant="light"
-                  style={{
-                    marginLeft: '1em',
-                    border: '1px solid currentColor'
-                  }}
-                  onClick={handleOverrideCancel}
-                >
-                  Cancel
-                </Accordion.Toggle>
-              </Form>
-              {!overrideJustification && (
-                <p className="justification-text">{emptyError}</p>
-              )}
-            </>
-          </Accordion.Collapse>
-        </Accordion>
-      </Alert>
-      <style jsx>
-        {`
-          .override-accordion {
-            display: flex;
-            flex-wrap: wrap;
-            justify-content: flex-end;
-          }
-          .justification-text {
-            color: red;
-          }
-        `}
-      </style>
-    </>
-  );
+  if (hasErrors) {
+    return (
+      <>
+        <Alert variant="danger">
+          <Accordion>
+            <div className="override-accordion">
+              Your application contains errors shown below that must be fixed
+              before submission. You may either correct these or alternatively,
+              override and provide justification. Your justification will be
+              reviewed by CAS and may cause a delay in processing your
+              application.
+              <Accordion.Toggle
+                as={Button}
+                variant="secondary"
+                eventKey="0"
+                onClick={() => setAccordionOpen(!accordionOpen)}
+              >
+                Override and Justify
+                <FontAwesomeIcon
+                  icon={faCaretDown}
+                  style={{marginLeft: '0.75em'}}
+                />
+              </Accordion.Toggle>
+            </div>
+            <Accordion.Collapse in={accordionOpen} eventKey="0">
+              <>
+                <Form>
+                  <h4>Override Form Validation</h4>
+                  <Form.Group controlId="overrideJustification">
+                    <Form.Label>Justification for incomplete form:</Form.Label>
+                    <Form.Control
+                      as="textarea"
+                      rows={4}
+                      value={overrideJustification || ''}
+                      onChange={handleOverrideChange}
+                    />
+                  </Form.Group>
+                  <Button variant="success" onClick={handleOverrideSave}>
+                    Save
+                  </Button>
+                  <Accordion.Toggle
+                    as={Button}
+                    eventKey="0"
+                    variant="light"
+                    style={{
+                      marginLeft: '1em',
+                      border: '1px solid currentColor'
+                    }}
+                    onClick={handleOverrideCancel}
+                  >
+                    Cancel
+                  </Accordion.Toggle>
+                </Form>
+                {!overrideJustification && (
+                  <p className="justification-text">{emptyError}</p>
+                )}
+              </>
+            </Accordion.Collapse>
+          </Accordion>
+        </Alert>
+        <style jsx>
+          {`
+            .override-accordion {
+              display: flex;
+              flex-wrap: wrap;
+              justify-content: flex-end;
+            }
+            .justification-text {
+              color: red;
+            }
+          `}
+        </style>
+      </>
+    );
+  }
+
+  return null;
 };
 
 export default createFragmentContainer(

--- a/app/containers/Applications/ApplicationWizardConfirmation.tsx
+++ b/app/containers/Applications/ApplicationWizardConfirmation.tsx
@@ -313,6 +313,7 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
           props.application.latestDraftRevision.overrideJustification
         }
         revisionId={props.application.latestDraftRevision.id}
+        hasErrors={hasErrors}
       />
       <ApplicationDetailsContainer
         liveValidate

--- a/app/tests/unit/components/ApplicationOverrideJustification.test.tsx
+++ b/app/tests/unit/components/ApplicationOverrideJustification.test.tsx
@@ -6,6 +6,7 @@ describe('OverrideJustification', () => {
   it('Should allow the user to save a justification if one is not currently active', async () => {
     const r = shallow(
       <ApplicationOverrideJustificationComponent
+        hasErrors
         overrideActive={false}
         setOverrideActive={jest.fn()}
         applicationOverrideJustification={null}
@@ -21,6 +22,7 @@ describe('OverrideJustification', () => {
     const r = shallow(
       <ApplicationOverrideJustificationComponent
         overrideActive
+        hasErrors
         setOverrideActive={jest.fn()}
         applicationOverrideJustification="bad stuff"
         revisionId="abc"
@@ -37,6 +39,7 @@ describe('OverrideJustification', () => {
     const r = shallow(
       <ApplicationOverrideJustificationComponent
         overrideActive
+        hasErrors
         setOverrideActive={jest.fn()}
         applicationOverrideJustification="bad stuff"
         revisionId="abc"
@@ -44,5 +47,20 @@ describe('OverrideJustification', () => {
       />
     );
     expect(r.find('Alert').find('Button').at(1).text()).toBe('Delete Override');
+  });
+
+  it('Should not render the override justification box if the application has no errors', async () => {
+    const r = shallow(
+      <ApplicationOverrideJustificationComponent
+        overrideActive
+        hasErrors={false}
+        setOverrideActive={jest.fn()}
+        applicationOverrideJustification="bad stuff"
+        revisionId="abc"
+        relay={null}
+      />
+    );
+    expect(r.exists('Alert')).toBe(false);
+    expect(r.exists('AccordionCollapse')).toBe(false);
   });
 });

--- a/app/tests/unit/components/__snapshots__/ApplicationOverrideJustification.test.tsx.snap
+++ b/app/tests/unit/components/__snapshots__/ApplicationOverrideJustification.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`OverrideJustification Should allow the user to save a justification if 
   >
     <ForwardRef>
       <div
-        className="jsx-743129836 override-accordion"
+        className="jsx-2238773333 override-accordion"
       >
         Your application contains errors shown below that must be fixed before submission. You may either correct these or alternatively, override and provide justification. Your justification will be reviewed by CAS and may cause a delay in processing your application.
         <ForwardRef
@@ -175,7 +175,7 @@ exports[`OverrideJustification Should allow the user to save a justification if 
           inline={false}
         >
           <h4
-            className="jsx-743129836"
+            className="jsx-2238773333"
           >
             Override Form Validation
           </h4>
@@ -232,15 +232,15 @@ exports[`OverrideJustification Should allow the user to save a justification if 
           </ForwardRef>
         </Form>
         <p
-          className="jsx-743129836 justification-text"
+          className="jsx-2238773333 justification-text"
         />
       </AccordionCollapse>
     </ForwardRef>
   </Alert>
   <JSXStyle
-    id="743129836"
+    id="2238773333"
   >
-    .override-accordion.jsx-743129836{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-box-pack:end;-webkit-justify-content:flex-end;-ms-flex-pack:end;justify-content:flex-end;}.justification-text.jsx-743129836{color:red;}
+    .override-accordion.jsx-2238773333{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-box-pack:end;-webkit-justify-content:flex-end;-ms-flex-pack:end;justify-content:flex-end;}.justification-text.jsx-2238773333{color:red;}
   </JSXStyle>
 </Fragment>
 `;

--- a/app/tests/unit/components/__snapshots__/ApplicationOverrideJustification.test.tsx.snap
+++ b/app/tests/unit/components/__snapshots__/ApplicationOverrideJustification.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`OverrideJustification Should allow the user to save a justification if 
   >
     <ForwardRef>
       <div
-        className="jsx-2238773333 override-accordion"
+        className="jsx-905902600 override-accordion"
       >
         Your application contains errors shown below that must be fixed before submission. You may either correct these or alternatively, override and provide justification. Your justification will be reviewed by CAS and may cause a delay in processing your application.
         <ForwardRef
@@ -175,7 +175,7 @@ exports[`OverrideJustification Should allow the user to save a justification if 
           inline={false}
         >
           <h4
-            className="jsx-2238773333"
+            className="jsx-905902600"
           >
             Override Form Validation
           </h4>
@@ -232,15 +232,15 @@ exports[`OverrideJustification Should allow the user to save a justification if 
           </ForwardRef>
         </Form>
         <p
-          className="jsx-2238773333 justification-text"
+          className="jsx-905902600 justification-text"
         />
       </AccordionCollapse>
     </ForwardRef>
   </Alert>
   <JSXStyle
-    id="2238773333"
+    id="905902600"
   >
-    .override-accordion.jsx-2238773333{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-box-pack:end;-webkit-justify-content:flex-end;-ms-flex-pack:end;justify-content:flex-end;}.justification-text.jsx-2238773333{color:red;}
+    .override-accordion.jsx-905902600{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-box-pack:end;-webkit-justify-content:flex-end;-ms-flex-pack:end;justify-content:flex-end;}.justification-text.jsx-905902600{color:red;}
   </JSXStyle>
 </Fragment>
 `;

--- a/app/tests/unit/components/__snapshots__/ApplicationOverrideJustification.test.tsx.snap
+++ b/app/tests/unit/components/__snapshots__/ApplicationOverrideJustification.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`OverrideJustification Should allow the user to save a justification if 
   >
     <ForwardRef>
       <div
-        className="jsx-905902600 override-accordion"
+        className="jsx-743129836 override-accordion"
       >
         Your application contains errors shown below that must be fixed before submission. You may either correct these or alternatively, override and provide justification. Your justification will be reviewed by CAS and may cause a delay in processing your application.
         <ForwardRef
@@ -175,7 +175,7 @@ exports[`OverrideJustification Should allow the user to save a justification if 
           inline={false}
         >
           <h4
-            className="jsx-905902600"
+            className="jsx-743129836"
           >
             Override Form Validation
           </h4>
@@ -232,15 +232,15 @@ exports[`OverrideJustification Should allow the user to save a justification if 
           </ForwardRef>
         </Form>
         <p
-          className="jsx-905902600 justification-text"
+          className="jsx-743129836 justification-text"
         />
       </AccordionCollapse>
     </ForwardRef>
   </Alert>
   <JSXStyle
-    id="905902600"
+    id="743129836"
   >
-    .override-accordion.jsx-905902600{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-box-pack:end;-webkit-justify-content:flex-end;-ms-flex-pack:end;justify-content:flex-end;}.justification-text.jsx-905902600{color:red;}
+    .override-accordion.jsx-743129836{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-box-pack:end;-webkit-justify-content:flex-end;-ms-flex-pack:end;justify-content:flex-end;}.justification-text.jsx-743129836{color:red;}
   </JSXStyle>
 </Fragment>
 `;

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationWizardConfirmation.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationWizardConfirmation.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`The Confirmation Component match the snapshot 1`] = `
   />
   <Relay(ApplicationOverrideJustificationComponent)
     applicationOverrideJustification={null}
+    hasErrors={false}
     overrideActive={false}
     revisionId="abc"
     setOverrideActive={[Function]}
@@ -160,6 +161,7 @@ exports[`The Confirmation Component should render the override justification com
   />
   <Relay(ApplicationOverrideJustificationComponent)
     applicationOverrideJustification="I did a bad thing and I dont want to fix it"
+    hasErrors={false}
     overrideActive={true}
     revisionId="abc"
     setOverrideActive={[Function]}
@@ -303,6 +305,7 @@ exports[`The Confirmation Component should render the override justification com
   />
   <Relay(ApplicationOverrideJustificationComponent)
     applicationOverrideJustification={null}
+    hasErrors={false}
     overrideActive={false}
     revisionId="abc"
     setOverrideActive={[Function]}
@@ -446,6 +449,7 @@ exports[`The Confirmation Component should show a "data has changed" dialogue wh
   />
   <Relay(ApplicationOverrideJustificationComponent)
     applicationOverrideJustification={null}
+    hasErrors={false}
     overrideActive={false}
     revisionId="abc"
     setOverrideActive={[Function]}
@@ -614,6 +618,7 @@ exports[`The Confirmation Component should show a certifier has not yet signed m
   />
   <Relay(ApplicationOverrideJustificationComponent)
     applicationOverrideJustification={null}
+    hasErrors={false}
     overrideActive={false}
     revisionId="abc"
     setOverrideActive={[Function]}


### PR DESCRIPTION
- ApplicationOverrideJustification component returns null if there are no errors present in the application