### PR TITLE
Fix: certifier redirected from edit view

### DIFF
--- a/app/containers/Applications/ApplicationWizard.tsx
+++ b/app/containers/Applications/ApplicationWizard.tsx
@@ -80,7 +80,6 @@ const ApplicationWizard = ({query}) => {
     }
   };
 
-  if (!application) return <>This is not the application you are looking for</>;
   return (
     <>
       <ApplicationFormNavbar

--- a/app/containers/Applications/ApplicationWizard.tsx
+++ b/app/containers/Applications/ApplicationWizard.tsx
@@ -27,6 +27,19 @@ const ApplicationWizard = ({query}) => {
   const {formResultId} = router.query;
   const confirmationPage = Boolean(router.query.confirmationPage);
   const orderedFormResults = application.orderedFormResults.edges;
+
+  // Redirect a certifier given a bad link to the certify page for the application
+  if (!application.currentUserCanEdit) {
+    router.push({
+      pathname: '/certifier/certify',
+      query: {
+        applicationId: application.id,
+        version: router.query.version
+      }
+    });
+    return null;
+  }
+
   if (!confirmationPage && !formResultId) {
     setRouterQueryParam(
       router,
@@ -96,6 +109,7 @@ export default createFragmentContainer(ApplicationWizard, {
       ) {
       application(id: $applicationId) {
         id
+        currentUserCanEdit
         orderedFormResults(versionNumberInput: $version) {
           edges {
             node {

--- a/app/cypress/integration/reporter-certifier-access.spec.js
+++ b/app/cypress/integration/reporter-certifier-access.spec.js
@@ -36,4 +36,14 @@ describe('When logged in as a certifier(reporter)', () => {
     cy.get('.alert-link').contains('View all certification requests.').click();
     cy.url().should('include', '/certifier/requests');
   });
+
+  it('should redirect the certifier to /certify if they access the edit view by URL', () => {
+    const applicationId = window.btoa('["applications", 1]');
+    const formResultId = window.btoa('[formResults, 1]');
+    cy.visit(
+      `http://localhost:3004/reporter/application?formResultId=${formResultId}&applicationId=${applicationId}&version=1`
+    );
+    cy.wait(500);
+    cy.url().should('include', '/certifier/certify');
+  });
 });

--- a/app/pages/certifier/certify.tsx
+++ b/app/pages/certifier/certify.tsx
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
 import {graphql} from 'react-relay';
+import {Alert} from 'react-bootstrap';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faExternalLinkAlt} from '@fortawesome/free-solid-svg-icons';
 import {certifyQueryResponse} from 'certifyQuery.graphql';
@@ -89,15 +90,22 @@ class Certify extends Component<Props> {
               liveValidate={false}
             />
             {LegalDisclaimer}
-            <CertificationSignature
-              certificationIdsToSign={[
-                query.application.latestDraftRevision.certificationUrl.id
-              ]}
-              submitted={
-                query.application.latestDraftRevision
-                  .certificationSignatureIsValid
-              }
-            />
+            {query.application.latestDraftRevision
+              .certificationSignatureIsValid ? (
+              <Alert variant="success">
+                <strong>Application has been certified</strong>
+              </Alert>
+            ) : (
+              <CertificationSignature
+                certificationIdsToSign={[
+                  query.application.latestDraftRevision.certificationUrl.id
+                ]}
+                submitted={
+                  query.application.latestDraftRevision
+                    .certificationSignatureIsValid
+                }
+              />
+            )}
           </>
         ) : (
           <ApplicationRecertificationContainer

--- a/app/pages/reporter/application.tsx
+++ b/app/pages/reporter/application.tsx
@@ -57,6 +57,12 @@ class Application extends Component<Props> {
     const {session} = query || {};
     const {application} = query || {};
 
+    // Route to 404 page if no application is present
+    if (!application) {
+      router.push({pathname: '/404'});
+      return null;
+    }
+
     if (!application?.latestDraftRevision?.legalDisclaimerAccepted) {
       router.push({
         pathname: '/reporter/new-application-disclaimer',

--- a/app/pages/reporter/application.tsx
+++ b/app/pages/reporter/application.tsx
@@ -25,6 +25,7 @@ class Application extends Component<Props> {
       query {
         application(id: $applicationId) {
           id
+          currentUserCanEdit
           latestDraftRevision {
             versionNumber
             legalDisclaimerAccepted

--- a/app/server/schema.graphql
+++ b/app/server/schema.graphql
@@ -63,6 +63,11 @@ type Application implements Node {
     orderBy: [CertificationUrlsOrderBy!] = [PRIMARY_KEY_ASC]
   ): CertificationUrlsConnection!
 
+  """
+  returns a boolean value based on whether the current user has edit permission on the application
+  """
+  currentUserCanEdit: Boolean
+
   """Reads a single `Facility` that is related to this `Application`."""
   facilityByFacilityId: Facility
 

--- a/app/server/schema.json
+++ b/app/server/schema.json
@@ -5796,6 +5796,18 @@
               "deprecationReason": null
             },
             {
+              "name": "currentUserCanEdit",
+              "description": "returns a boolean value based on whether the current user has edit permission on the application",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "facilityByFacilityId",
               "description": "Reads a single `Facility` that is related to this `Application`.",
               "args": [],

--- a/app/tests/unit/pages/__snapshots__/certify.test.tsx.snap
+++ b/app/tests/unit/pages/__snapshots__/certify.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`The certify page It matches the last accepted Snapshot 1`] = `
           "CertificationSignature_application": true,
         },
         "latestDraftRevision": Object {
+          "certificationSignatureIsValid": true,
           "certificationUrl": Object {
             " $fragmentRefs": Object {
               "ApplicationRecertificationContainer_certificationUrl": true,
@@ -50,6 +51,7 @@ exports[`The certify page It matches the last accepted Snapshot 1`] = `
             "CertificationSignature_application": true,
           },
           "latestDraftRevision": Object {
+            "certificationSignatureIsValid": true,
             "certificationUrl": Object {
               " $fragmentRefs": Object {
                 "ApplicationRecertificationContainer_certificationUrl": true,
@@ -74,13 +76,29 @@ exports[`The certify page It matches the last accepted Snapshot 1`] = `
     }
     review={false}
   />
-  <Relay(CertificationSignature)
-    certificationIdsToSign={
-      Array [
-        undefined,
-      ]
+  <Alert
+    closeLabel="Close alert"
+    show={true}
+    transition={
+      Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "defaultProps": Object {
+          "appear": false,
+          "in": false,
+          "mountOnEnter": false,
+          "timeout": 300,
+          "unmountOnExit": false,
+        },
+        "displayName": "Fade",
+        "render": [Function],
+      }
     }
-  />
+    variant="success"
+  >
+    <strong>
+      Application has been certified
+    </strong>
+  </Alert>
 </Relay(DefaultLayout)>
 `;
 

--- a/app/tests/unit/pages/certify.test.tsx
+++ b/app/tests/unit/pages/certify.test.tsx
@@ -19,6 +19,7 @@ describe('The certify page', () => {
     },
     application: {
       latestDraftRevision: {
+        certificationSignatureIsValid: true,
         certificationUrl: {
           certificationSignature: 'test',
           hashMatches: true,
@@ -46,6 +47,11 @@ describe('The certify page', () => {
     expect(
       wrapper.find('Relay(ApplicationDetailsComponent)').prop('application')
     ).toBe(query.application);
+  });
+
+  it('It renders an application certified message instead of the ApplicationSignature component if certification signature is valid', () => {
+    const wrapper = shallow(<Certify query={query} />);
+    expect(wrapper.find('Alert').text()).toBe('Application has been certified');
   });
 
   it('It renders ApplicationRecertificationContainer if hashMatches is false', () => {

--- a/schema/deploy/computed_columns/application_current_user_can_edit.sql
+++ b/schema/deploy/computed_columns/application_current_user_can_edit.sql
@@ -1,0 +1,27 @@
+-- Deploy ggircs-portal:computed_columns/application_current_user_can_edit to pg
+-- requires: tables/ciip_user_organisation
+-- requires: tables/application
+
+begin;
+
+  create or replace function ggircs_portal.application_current_user_can_edit(
+    app ggircs_portal.application
+  )
+  returns boolean
+  as
+  $body$
+    declare
+      return_value boolean;
+      current_user_id = (select id from ggircs_portal.ciip_user where uuid=(select sub from ggircs_portal.session));
+      org_id = (select organisation_id from app join ggircs_portal.facility f on app.facility_id = f.id);
+    begin
+      return (select exists(select * from ggircs_portal.ciip_user_organisation where user_id=current_user_id and organisation_id=org_id and status='approved'));
+    end;
+  $body$
+  language 'plpgsql' stable;
+
+  grant execute on function ggircs_portal.application_current_user_can_edit to ciip_administrator, ciip_analyst, ciip_industry_user;
+
+  comment on function ggircs_portal.application_current_user_can_edit is 'returns a boolean value based on whether the current user has edit permission on the application';
+
+commit;

--- a/schema/deploy/computed_columns/application_current_user_can_edit.sql
+++ b/schema/deploy/computed_columns/application_current_user_can_edit.sql
@@ -12,10 +12,15 @@ begin;
   $body$
     declare
       return_value boolean;
-      current_user_id = (select id from ggircs_portal.ciip_user where uuid=(select sub from ggircs_portal.session));
-      org_id = (select organisation_id from app join ggircs_portal.facility f on app.facility_id = f.id);
+      current_user_id int;
+      org_id int;
     begin
-      return (select exists(select * from ggircs_portal.ciip_user_organisation where user_id=current_user_id and organisation_id=org_id and status='approved'));
+      current_user_id:= (select id from ggircs_portal.ciip_user where uuid=(select sub from ggircs_portal.session()));
+      org_id:= (select organisation_id from ggircs_portal.application a join ggircs_portal.facility f on a.facility_id = f.id and a.id=app.id);
+      if (select exists(select * from ggircs_portal.ciip_user_organisation where user_id=current_user_id and organisation_id=org_id and status='approved')) then
+        return true;
+      end if;
+      return false;
     end;
   $body$
   language 'plpgsql' stable;

--- a/schema/revert/computed_columns/application_current_user_can_edit.sql
+++ b/schema/revert/computed_columns/application_current_user_can_edit.sql
@@ -1,0 +1,7 @@
+-- Revert ggircs-portal:computed_columns/application_current_user_can_edit from pg
+
+begin;
+
+drop function ggircs_portal.application_current_user_can_edit;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -165,3 +165,4 @@ trigger_functions/request_for_organisation_access [trigger_functions/request_for
 @v1.3.0 2020-07-29T20:54:44Z Matthieu Foucault <matthieu@button.is> # release v1.3.0
 tables/application_revision_001 [tables/application_revision] 2020-07-22T23:13:57Z Dylan Leard <dylan@button.is> # Migration: add override column to application_revision
 database_functions/read_only_user_policies [schema_ggircs_portal schema_ggircs_portal_private] 2020-07-30T18:10:31Z Dylan Leard <dylan@button.is> # function adds RLS policies for the read_only_user (metabase)
+computed_columns/application_current_user_can_edit [tables/ciip_user_organisation tables/application] 2020-07-30T23:55:55Z Dylan Leard <dylan@button.is> # computed column returns a boolean value: whether the current user has edit permission on the application

--- a/schema/verify/computed_columns/application_current_user_can_edit.sql
+++ b/schema/verify/computed_columns/application_current_user_can_edit.sql
@@ -1,0 +1,7 @@
+-- Verify ggircs-portal:computed_columns/application_current_user_can_edit on pg
+
+begin;
+
+select pg_get_functiondef('ggircs_portal.application_current_user_can_edit(ggircs_portal.application)'::regprocedure);
+
+rollback;


### PR DESCRIPTION
- redirects certifier to /certify if they attempt to access the edit view via a url
- replaces signature component with 'application certified' if it has been certified