### PR TITLE
fix: update rls to only hide 'internal' comments from industry user role

### DIFF
--- a/schema/deploy/policies/review_comment_policies.sql
+++ b/schema/deploy/policies/review_comment_policies.sql
@@ -43,7 +43,7 @@ perform ggircs_portal_private.upsert_policy('ciip_analyst_update_review_comment'
 -- statement for select using & insert with check
 industry_user_statement := $$
                              application_id in (select ggircs_portal_private.get_valid_review_comments())
-                             and comment_type='requested change'
+                             and comment_type!='internal'
                            $$;
 
 -- ciip_industry_user RLS

--- a/schema/deploy/policies/review_comment_policies@v1.1.0.sql
+++ b/schema/deploy/policies/review_comment_policies@v1.1.0.sql
@@ -43,7 +43,7 @@ perform ggircs_portal_private.upsert_policy('ciip_analyst_update_review_comment'
 -- statement for select using & insert with check
 industry_user_statement := $$
                              application_id in (select ggircs_portal_private.get_valid_review_comments())
-                             and comment_type='requested change'
+                             and comment_type!='internal'
                            $$;
 
 -- ciip_industry_user RLS

--- a/schema/deploy/policies/review_comment_policies@v1.1.0.sql
+++ b/schema/deploy/policies/review_comment_policies@v1.1.0.sql
@@ -43,7 +43,7 @@ perform ggircs_portal_private.upsert_policy('ciip_analyst_update_review_comment'
 -- statement for select using & insert with check
 industry_user_statement := $$
                              application_id in (select ggircs_portal_private.get_valid_review_comments())
-                             and comment_type!='internal'
+                             and comment_type='requested change'
                            $$;
 
 -- ciip_industry_user RLS

--- a/schema/revert/policies/review_comment_policies@v1.1.0.sql
+++ b/schema/revert/policies/review_comment_policies@v1.1.0.sql
@@ -1,0 +1,18 @@
+-- Revert ggircs-portal:policies/review_comment_policies from pg
+
+begin;
+
+drop policy ciip_administrator_select_review_comment on ggircs_portal.review_comment;
+drop policy ciip_administrator_insert_review_comment on ggircs_portal.review_comment;
+drop policy ciip_administrator_update_review_comment on ggircs_portal.review_comment;
+
+drop policy ciip_analyst_select_review_comment on ggircs_portal.review_comment;
+drop policy ciip_analyst_update_review_comment on ggircs_portal.review_comment;
+drop policy ciip_analyst_insert_review_comment on ggircs_portal.review_comment;
+
+drop policy ciip_industry_user_select_review_comment on ggircs_portal.review_comment;
+
+drop function ggircs_portal_private.get_valid_review_comments;
+drop function ggircs_portal_private.analyst_owns_comment;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -166,3 +166,4 @@ trigger_functions/request_for_organisation_access [trigger_functions/request_for
 tables/application_revision_001 [tables/application_revision] 2020-07-22T23:13:57Z Dylan Leard <dylan@button.is> # Migration: add override column to application_revision
 database_functions/read_only_user_policies [schema_ggircs_portal schema_ggircs_portal_private] 2020-07-30T18:10:31Z Dylan Leard <dylan@button.is> # function adds RLS policies for the read_only_user (metabase)
 computed_columns/application_current_user_can_edit [tables/ciip_user_organisation tables/application] 2020-07-30T23:55:55Z Dylan Leard <dylan@button.is> # computed column returns a boolean value: whether the current user has edit permission on the application
+policies/review_comment_policies [policies/review_comment_policies@v1.1.0] 2020-07-31T22:54:37Z Dylan Leard <dylan@button.is> # migration fixes the industry_user_statement for rls

--- a/schema/verify/policies/review_comment_policies@v1.1.0.sql
+++ b/schema/verify/policies/review_comment_policies@v1.1.0.sql
@@ -1,0 +1,21 @@
+-- Verify ggircs-portal:policies/review_comment_policies on pg
+
+begin;
+
+select pg_get_functiondef('ggircs_portal_private.get_valid_review_comments()'::regprocedure);
+select pg_get_functiondef('ggircs_portal_private.analyst_owns_comment()'::regprocedure);
+
+-- ciip_administrator Policies
+select ggircs_portal_private.verify_policy('select', 'ciip_administrator_select_review_comment', 'review_comment', 'ciip_administrator');
+select ggircs_portal_private.verify_policy('insert', 'ciip_administrator_insert_review_comment', 'review_comment', 'ciip_administrator');
+select ggircs_portal_private.verify_policy('update', 'ciip_administrator_update_review_comment', 'review_comment', 'ciip_administrator');
+
+-- ciip_analyst Policies
+select ggircs_portal_private.verify_policy('select', 'ciip_analyst_select_review_comment', 'review_comment', 'ciip_analyst');
+select ggircs_portal_private.verify_policy('insert', 'ciip_analyst_insert_review_comment', 'review_comment', 'ciip_analyst');
+select ggircs_portal_private.verify_policy('update', 'ciip_analyst_update_review_comment', 'review_comment', 'ciip_analyst');
+
+-- ciip_industry_user Policies
+select ggircs_portal_private.verify_policy('select', 'ciip_industry_user_select_review_comment', 'review_comment', 'ciip_industry_user');
+
+rollback;


### PR DESCRIPTION
- updates policy file for review_comments table