### PR TITLE
Add instruction text above digital signature pad

### DIFF
--- a/app/containers/Forms/CertificationSignature.tsx
+++ b/app/containers/Forms/CertificationSignature.tsx
@@ -74,6 +74,15 @@ export const CertificationSignature: React.FunctionComponent<Props> = ({
   return (
     <Container>
       <h3>Certifier Signature:</h3>
+      <p>
+        To create a digital signature, click, hold and drag your pointer within
+        the box to draw your signature. Use the Clear button below the signature
+        box to delete the signature and start again. Alternatively, you can
+        select &quot;Choose File&quot; to upload an existing signature image
+        file from your computer (.png, .jpg, .jpeg). When you&apos;re ready to
+        submit your certification, click &quot;Sign&quot; below the signature
+        box.
+      </p>
       <Row>
         <Col md={12}>
           <SignaturePad

--- a/app/cypress/integration/reporter-certifier-access.spec.js
+++ b/app/cypress/integration/reporter-certifier-access.spec.js
@@ -17,6 +17,9 @@ describe('When logged in as a certifier(reporter)', () => {
     const applicationId = window.btoa('["applications", 1]');
     cy.visit('localhost:3004/certifier/certification-redirect?rowId=testpage');
     cy.get('#page-content');
+    cy.get('.page-wrap').happoScreenshot({
+      component: 'Certification Redirect'
+    });
     cy.contains('Continue').click();
     cy.visit(
       `http://localhost:3004/certifier/certify?applicationId=${applicationId}&version=1`
@@ -32,9 +35,21 @@ describe('When logged in as a certifier(reporter)', () => {
     cy.contains('Legal Disclaimer');
     cy.contains('View').click();
     cy.url().should('include', '/certifier/certify');
+    cy.get('.page-wrap').happoScreenshot({
+      component: 'Certification Page'
+    });
     cy.visit('/reporter');
     cy.get('.alert-link').contains('View all certification requests.').click();
     cy.url().should('include', '/certifier/requests');
+    cy.get('.page-wrap').happoScreenshot({
+      component: 'Batch certification page',
+      variant: 'Nothing selected'
+    });
+    cy.get('input[type="checkbox"]').first().click();
+    cy.get('.page-wrap').happoScreenshot({
+      component: 'Batch certification page',
+      variant: 'Multiple certification requests selected'
+    });
   });
 
   it('should redirect the certifier to /certify if they access the edit view by URL', () => {

--- a/app/tests/unit/containers/Forms/__snapshots__/CertificationSignature.test.tsx.snap
+++ b/app/tests/unit/containers/Forms/__snapshots__/CertificationSignature.test.tsx.snap
@@ -9,6 +9,11 @@ exports[`The Confirmation Component matches the snapshot 1`] = `
   >
     Certifier Signature:
   </h3>
+  <p
+    className="jsx-2877110858"
+  >
+    To create a digital signature, click, hold and drag your pointer within the box to draw your signature. Use the Clear button below the signature box to delete the signature and start again. Alternatively, you can select "Choose File" to upload an existing signature image file from your computer (.png, .jpg, .jpeg). When you're ready to submit your certification, click "Sign" below the signature box.
+  </p>
   <Row
     noGutters={false}
   >


### PR DESCRIPTION
Adds instruction text above digital signature pad for certifiers to understand how to sign.

[GGIRCS-1830](https://youtrack.button.is/issue/GGIRCS-1830)