### PR TITLE
Update CIIP program website URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The materials published include:
 
 - [CleanBC Program for Industry](https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry)
 
-- [CleanBC Industrial Incentive Program](https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry/cleanbc-industrial-incentive-program)
+- [CleanBC Industrial Incentive Program](https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3)
 
 - [Fact Sheet](https://www2.gov.bc.ca/assets/gov/environment/climate-change/ind/cleanbc-program-for-industry/ciip_factsheet_190524_final.pdf?forcedownload=true)
 

--- a/app/components/LegalDisclaimerText.tsx
+++ b/app/components/LegalDisclaimerText.tsx
@@ -7,7 +7,7 @@ const LegalDisclaimerText: React.FunctionComponent = () => {
       <ol id="glossary">
         <li>
           (a) &quot;CIIP&quot; means the{' '}
-          <a href="https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry/cleanbc-industrial-incentive-program">
+          <a href="https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3">
             CleanBC Industrial Incentive Program;
           </a>
         </li>
@@ -59,7 +59,7 @@ const LegalDisclaimerText: React.FunctionComponent = () => {
           The Operator agrees to repay any incentive amounts erroneously paid or
           which, upon audit or review by the Province of British Columbia, are
           determined by the Province to be either inconsistent with{' '}
-          <a href="https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry/cleanbc-industrial-incentive-program">
+          <a href="https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3">
             CIIP Rules
           </a>{' '}
           or not supported by evidence related to fuel usage and tax paid, and

--- a/app/containers/Organisations/Organisations.tsx
+++ b/app/containers/Organisations/Organisations.tsx
@@ -172,7 +172,7 @@ export const OrganisationsComponent: React.FunctionComponent<Props> = (
                   <p>
                     Further information on the role of the Operator and
                     Certifying Official{' '}
-                    <Alert.Link href="https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry/cleanbc-industrial-incentive-program">
+                    <Alert.Link href="https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3">
                       can be found here
                     </Alert.Link>
                     .

--- a/app/pages/reporter/new-application-disclaimer.tsx
+++ b/app/pages/reporter/new-application-disclaimer.tsx
@@ -75,7 +75,7 @@ class NewApplicationDisclaimer extends Component<Props> {
               paid or which, upon audit or review by the Province of British
               Columbia, are determined by the Province to be either inconsistent
               with{' '}
-              <Card.Link href="https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry/cleanbc-industrial-incentive-program">
+              <Card.Link href="https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3">
                 CIIP Rules
               </Card.Link>{' '}
               or not supported by evidence related to fuel usage and tax paid,

--- a/app/server/emailTemplates/certificationRequest.js
+++ b/app/server/emailTemplates/certificationRequest.js
@@ -22,7 +22,7 @@ const createCertificationRequestMail = ({
           <h3>Your certification is requested.</h3>
           <p>
             <strong>${firstName} ${lastName}</strong> (${reporterEmail}), on behalf of <strong>${operatorName}</strong> for the <strong>${facilityName}</strong>
-            facility has requested that you review, certify and sign off on the data contained in this application for the <a href="https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry/cleanbc-industrial-incentive-program">CleanBC Industrial Incentive Program</a>.
+            facility has requested that you review, certify and sign off on the data contained in this application for the <a href="https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3">CleanBC Industrial Incentive Program</a>.
           </p>
           <p>As the Certifying Official, you must agree to the <a href="${createUrl(
             'resources/application-disclaimer'

--- a/app/tests/unit/components/__snapshots__/LegalDisclaimerText.test.tsx.snap
+++ b/app/tests/unit/components/__snapshots__/LegalDisclaimerText.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`LegalDisclaimerText Component should match the last snapshot 1`] = `
       (a) "CIIP" means the
        
       <a
-        href="https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry/cleanbc-industrial-incentive-program"
+        href="https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3"
       >
         CleanBC Industrial Incentive Program;
       </a>
@@ -65,7 +65,7 @@ exports[`LegalDisclaimerText Component should match the last snapshot 1`] = `
        
       <a
         className="jsx-3350969095"
-        href="https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry/cleanbc-industrial-incentive-program"
+        href="https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3"
       >
         CIIP Rules
       </a>

--- a/app/tests/unit/containers/Organisation/__snapshots__/Organisations.test.tsx.snap
+++ b/app/tests/unit/containers/Organisation/__snapshots__/Organisations.test.tsx.snap
@@ -172,7 +172,7 @@ exports[`Organisations should announce there are certification requests to view 
               Further information on the role of the Operator and Certifying Official
                
               <AlertLink
-                href="https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry/cleanbc-industrial-incentive-program"
+                href="https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3"
               >
                 can be found here
               </AlertLink>
@@ -336,7 +336,7 @@ exports[`Organisations should render no organisations if the user has not reques
               Further information on the role of the Operator and Certifying Official
                
               <AlertLink
-                href="https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry/cleanbc-industrial-incentive-program"
+                href="https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3"
               >
                 can be found here
               </AlertLink>
@@ -555,7 +555,7 @@ exports[`Organisations should render the user's requested organisations 1`] = `
               Further information on the role of the Operator and Certifying Official
                
               <AlertLink
-                href="https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry/cleanbc-industrial-incentive-program"
+                href="https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3"
               >
                 can be found here
               </AlertLink>

--- a/app/tests/unit/pages/reporter/__snapshots__/new-application-disclaimer.test.tsx.snap
+++ b/app/tests/unit/pages/reporter/__snapshots__/new-application-disclaimer.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`Interstitial application legal disclaimer page It matches the last acce
         The Operator agrees to repay any incentive amounts erroneously paid or which, upon audit or review by the Province of British Columbia, are determined by the Province to be either inconsistent with
          
         <CardLink
-          href="https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry/cleanbc-industrial-incentive-program"
+          href="https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3"
         >
           CIIP Rules
         </CardLink>

--- a/docs/reporting-guide.md
+++ b/docs/reporting-guide.md
@@ -7,7 +7,7 @@
 
 This document is for users of the [CIIP Reporting Application Portal](https://ciip.gov.bc.ca/ ) and summarizes information from a number of sources including:
 
-- [CleanBC Industrial Incentive Program webpage](https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry) (includes webinar slides, product-specific benchmarks and thresholds, and sector eligibility).
+- [CleanBC Industrial Incentive Program webpage](https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3) (includes webinar slides, product-specific benchmarks and thresholds, and sector eligibility).
 - [BC Government's Reporting Industrial Greenhouse Gas Emissions webpage](https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/reporting) (includes important dates, links to related information).
 - [BC Greenhouse Gas Industrial Reporting and Control Act, [Sbc 2014] Chapter 29](https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01) (includes definitions, compliance obligations, etc).
 
@@ -17,13 +17,13 @@ This document is for users of the [CIIP Reporting Application Portal](https://ci
 
 'CIIP' stands for the CleanBC Industrial Incentive Program which supports emissions reductions and industrial competitiveness by providing incentives for cleaner industrial operations that meet a world-leading low-carbon emissions benchmark. The level of incentive payment is based on the performance of each industrial operation.
 
-More information on the CIIP, including details on the items below, is available on the [CleanBC Industrial Incentive Program webpage](https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry) which we recommend you have handy in another browser tab/window.
+More information on the CIIP, including details on the items below, is available on the [CleanBC Industrial Incentive Program webpage](https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3) which we recommend you have handy in another browser tab/window.
 
 
 
 ## Who is eligible?
 
-The CleanBC Industrial Incentive Program is open to businesses that emit more than 10,000 tonnes of carbon dioxide equivalent (CO<sub>2</sub>e) per year and/or those that report under the Greenhouse Gas Industrial Reporting and Control Act that have taken all reasonable measures to comply with the requirements under the Act. Additionally the business does not operate in a sector listed as being ineligible in the Sector Eligibility table listed on the [CleanBC Industrial Incentive Program webpage](https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry).
+The CleanBC Industrial Incentive Program is open to businesses that emit more than 10,000 tonnes of carbon dioxide equivalent (CO<sub>2</sub>e) per year and/or those that report under the Greenhouse Gas Industrial Reporting and Control Act that have taken all reasonable measures to comply with the requirements under the Act. Additionally the business does not operate in a sector listed as being ineligible in the Sector Eligibility table listed on the [CleanBC Industrial Incentive Program webpage](https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3).
 
 
 
@@ -79,7 +79,7 @@ While you are in the system, it will save your live (as you type) form data cont
 
 Before you can apply for the CIIP on behalf of an eligible operation, you must [register with the Ministry of Environment and Climate Change Strategy](https://ciip.gov.bc.ca/register).
 
-For more information please see the [CleanBC Industrial Incentive Program webpage](https://www2.gov.bc.ca/gov/content/environment/climate-change/industry/cleanbc-program-for-industry).
+For more information please see the [CleanBC Industrial Incentive Program webpage](https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3).
 
 
 


### PR DESCRIPTION
Updates the CIIP program website URL to its (hopefully) [permanent content URL](https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3).

[GGIRCS-1874](https://youtrack.button.is/issue/GGIRCS-1874)