### PR TITLE
fix: keycloak access token is refreshed when needed

### DIFF
--- a/app/components/PageRedirectHandler.tsx
+++ b/app/components/PageRedirectHandler.tsx
@@ -86,6 +86,38 @@ const PageRedirectHandler: React.FunctionComponent<Props> = ({
     checkSessionAndGroups();
   }, [pageComponent, router, environment]);
 
+  useEffect(() => {
+    let timeoutId;
+
+    const checkSessionIdle = async () => {
+      const {isAccessProtected} = pageComponent;
+      if (isAccessProtected) {
+        const response = await fetch('/session-idle-remaining-time');
+        if (response.ok) {
+          const timeout = Number(await response.json());
+          if (timeout) {
+            timeoutId = setTimeout(checkSessionIdle, (timeout + 1) * 1000);
+          } else {
+            router.push({
+              pathname: '/login-redirect',
+              query: {
+                redirectTo: router.asPath,
+                sessionIdled: true
+              }
+            });
+          }
+        }
+      }
+    };
+
+    checkSessionIdle();
+
+    // Return cleanup function
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [router, pageComponent]);
+
   // eslint-disable-next-line react/jsx-no-useless-fragment
   if (shouldRender) return <>{children}</>;
 

--- a/app/pages/login-redirect.tsx
+++ b/app/pages/login-redirect.tsx
@@ -5,9 +5,11 @@ import {loginRedirectQueryResponse} from 'loginRedirectQuery.graphql';
 import {CiipPageComponentProps} from 'next-env';
 import DefaultLayout from 'layouts/default-layout';
 import RegistrationLoginButtons from 'containers/RegistrationLoginButtons';
+import {NextRouter} from 'next/router';
 
 interface Props extends CiipPageComponentProps {
   query: loginRedirectQueryResponse['query'];
+  router: NextRouter;
 }
 
 export default class LoginRedirect extends Component<Props> {
@@ -23,16 +25,17 @@ export default class LoginRedirect extends Component<Props> {
   `;
 
   render() {
-    const {query} = this.props;
+    const {query, router} = this.props;
     const {session} = query || {};
 
+    const headerText = router.query.sessionIdled
+      ? 'You were logged out due to inactivity.'
+      : 'You need to be logged in to access this page.';
     return (
       <DefaultLayout showSubheader={false} session={session}>
         <Row>
           <Col md={6}>
-            <h3 className="blue">
-              You need to be logged in to access this page.
-            </h3>
+            <h3 className="blue">{headerText}</h3>
             <p>
               Please log in or register in order to access this page.
               <br />

--- a/app/server/index.js
+++ b/app/server/index.js
@@ -229,7 +229,19 @@ app.prepare().then(() => {
     keycloak.middleware({
       logout: '/logout',
       admin: '/'
-    })
+    }),
+    async (req, res, next) => {
+      if (req.kauth && req.kauth.grant) {
+        try {
+          const grant = await keycloak.getGrant(req, res);
+          await keycloak.grantManager.ensureFreshness(grant);
+        } catch (error) {
+          return next(error);
+        }
+      }
+
+      next();
+    }
   );
 
   // Use consola for logging instead of default logger

--- a/app/server/index.js
+++ b/app/server/index.js
@@ -225,24 +225,44 @@ app.prepare().then(() => {
     next();
   });
 
+  // Retrieves keycloak grant for the session
   server.use(
     keycloak.middleware({
       logout: '/logout',
       admin: '/'
-    }),
-    async (req, res, next) => {
-      if (req.kauth && req.kauth.grant) {
-        try {
-          const grant = await keycloak.getGrant(req, res);
-          await keycloak.grantManager.ensureFreshness(grant);
-        } catch (error) {
-          return next(error);
-        }
-      }
-
-      next();
-    }
+    })
   );
+
+  // Returns the time, in seconds, before the refresh_token expires.
+  // This corresponds to the SSO idle timeout configured in keycloak.
+  server.get('/session-idle-remaining-time', async (req, res) => {
+    if (!req.kauth || !req.kauth.grant) {
+      return res.json(null);
+    }
+
+    console.log(req.kauth.grant);
+    const grant = await keycloak.getGrant(req, res);
+    return res.json(
+      Math.round(grant.refresh_token.content.exp - Date.now() / 1000)
+    );
+  });
+
+  // For any request (other than getting the remaining idle time), refresh the grant
+  // if needed. If the access token is expired (defaults to 5min in keycloak),
+  // the refresh token will be used to get a new access token, and the refresh token expiry will be updated.
+  server.use(async (req, res, next) => {
+    if (req.path === '/session-idle-remaining-time') return next();
+    if (req.kauth && req.kauth.grant) {
+      try {
+        const grant = await keycloak.getGrant(req, res);
+        await keycloak.grantManager.ensureFreshness(grant);
+      } catch (error) {
+        return next(error);
+      }
+    }
+
+    next();
+  });
 
   // Use consola for logging instead of default logger
   const pluginHook = makePluginHook([PostgraphileLogConsola]);

--- a/app/server/index.js
+++ b/app/server/index.js
@@ -240,7 +240,6 @@ app.prepare().then(() => {
       return res.json(null);
     }
 
-    console.log(req.kauth.grant);
     const grant = await keycloak.getGrant(req, res);
     return res.json(
       Math.round(grant.refresh_token.content.exp - Date.now() / 1000)

--- a/app/tests/unit/pages/__snapshots__/login-redirect.test.tsx.snap
+++ b/app/tests/unit/pages/__snapshots__/login-redirect.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Login redirect page It matches the last accepted Snapshot 1`] = `
+exports[`Login redirect page matches the last accepted Snapshot 1`] = `
 <Relay(DefaultLayout)
   session={null}
   showSubheader={false}

--- a/app/tests/unit/pages/login-redirect.test.tsx
+++ b/app/tests/unit/pages/login-redirect.test.tsx
@@ -9,18 +9,28 @@ const query: loginRedirectQueryResponse['query'] = {
 };
 
 describe('Login redirect page', () => {
-  it('It matches the last accepted Snapshot', () => {
-    const wrapper = shallow(<LoginRedirect query={query} />);
+  it('matches the last accepted Snapshot', () => {
+    const router: any = {query: {}};
+    const wrapper = shallow(<LoginRedirect query={query} router={router} />);
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('It passes the relay query response to the RegistrationLoginButtons component', () => {
-    const wrapper = shallow(<LoginRedirect query={query} />);
+  it('passes the relay query response to the RegistrationLoginButtons component', () => {
+    const router: any = {query: {}};
+    const wrapper = shallow(<LoginRedirect query={query} router={router} />);
     expect(
       wrapper
         .find('Relay(RegistrationLoginButtonsComponent)')
         .first()
         .prop('query')
     ).toBe(query);
+  });
+
+  it('tell the user when they were logged out due to inactivity', () => {
+    const router: any = {query: {sessionIdled: true}};
+    const wrapper = shallow(<LoginRedirect query={query} router={router} />);
+    expect(wrapper.find('h3').first().text()).toBe(
+      'You were logged out due to inactivity.'
+    );
   });
 });


### PR DESCRIPTION
In order to test this PR, you should reduce the `SSO Session Idle` setting in keycloak to 2/3 minutes, and the `Access token lifespan` to something smaller.
You should not encounter any issue as long as you keep interacting with the application (contrary to the current behavior where you get logged out either way).
If you wait for the time you set in the SSO Session Idle, you should get redirected to the `login-redirect` page, asking you to log in again