### PR TITLE
fix: Hide gases button shouldn't overlap 'saving' indicator

### DIFF
--- a/app/containers/Forms/EmissionField.tsx
+++ b/app/containers/Forms/EmissionField.tsx
@@ -35,8 +35,6 @@ export const EmissionFieldComponent: React.FunctionComponent<FieldProps> = (
         {`
           .emission-toggle {
             text-align: right;
-            position: relative;
-            top: -52px;
           }
           .emission .zero-emission,
           .emission-form .zero-emission {

--- a/app/tests/integration/Forms/__snapshots__/Form.test.tsx.snap
+++ b/app/tests/integration/Forms/__snapshots__/Form.test.tsx.snap
@@ -1125,7 +1125,7 @@ exports[`Form should match the snapshot with the emission form 1`] = `
           />
         </div>
         <div
-          className="jsx-3846335375 show-zero-emissions"
+          className="jsx-57562496 show-zero-emissions"
         >
           <div
             className="emission-toggle col-md-12"


### PR DESCRIPTION
Fixes "Hide gases with no emissions" button from overlapping the form 'Saving' indicator.
[GGIRCS-1925](https://youtrack.button.is/issue/GGIRCS-1925)

### After:
<img width="1178" alt="Screen Shot 2020-09-14 at 11 36 49 AM" src="https://user-images.githubusercontent.com/5522075/93124757-f8e08f80-f67e-11ea-8a37-1a8a4d114a01.png">

### Before: 
<img width="1198" alt="93124549-a1422400-f67e-11ea-9e79-35c78a17eae4" src="https://user-images.githubusercontent.com/5522075/93124737-efefbe00-f67e-11ea-80ae-bccb18715d4f.png">

