### PR TITLE
fix: Status indicators should appear as a pill badge

### DIFF
--- a/app/containers/Applications/ApplicationRevisionStatusContainer.tsx
+++ b/app/containers/Applications/ApplicationRevisionStatusContainer.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import {Row, Col, Dropdown, Button, Modal} from 'react-bootstrap';
+import {Row, Col, Dropdown, Button, Badge, Modal} from 'react-bootstrap';
 import {graphql, createFragmentContainer, RelayProp} from 'react-relay';
 import DropdownMenuItemComponent from 'components/DropdownMenuItemComponent';
 import createApplicationRevisionStatusMutation from 'mutations/application/createApplicationRevisionStatusMutation';
@@ -111,7 +111,9 @@ export const ApplicationRevisionStatusComponent: React.FunctionComponent<Props> 
           <Col md={2}>
             <Dropdown style={{width: '100%'}}>
               <Dropdown.Toggle
-                style={{width: '100%', textTransform: 'capitalize'}}
+                pill
+                as={Badge}
+                style={{padding: '0.6em 1em', fontSize: '1em'}}
                 variant={
                   statusBadgeColor[
                     props.applicationRevisionStatus.applicationRevisionStatus

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationStatusContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationStatusContainer.test.tsx.snap
@@ -139,11 +139,22 @@ exports[`ApplicationRevisionStatusItem should render the application status in a
         }
       >
         <DropdownToggle
+          as={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "defaultProps": Object {
+                "pill": false,
+              },
+              "displayName": "Badge",
+              "render": [Function],
+            }
+          }
           id="dropdown"
+          pill={true}
           style={
             Object {
-              "textTransform": "capitalize",
-              "width": "100%",
+              "fontSize": "1em",
+              "padding": "0.6em 1em",
             }
           }
           variant="info"


### PR DESCRIPTION
Transforms status indicator / dropdown selector on analyst application review into a 'pill' badge, as opposed to a rectangular dropdown button.
<img width="613" alt="Screen Shot 2020-09-14 at 1 00 21 PM" src="https://user-images.githubusercontent.com/5522075/93368561-ff980f80-f802-11ea-8162-8c558bcc3151.png">

[GGIRCS-1624](https://youtrack.button.is/issue/GGIRCS-1624)