### PR TITLE
chore: remove acceptance step from ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,19 +257,6 @@ jobs:
           paths:
             - cas-ciip-portal # persist the build for e2e tests
 
-  acceptance:
-    machine:
-      image: ubuntu-1604:201903-01
-    working_directory: ~/cas-ciip-portal/app
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Cucumber Acceptance Test
-          command: |
-            source ~/.asdf/asdf.sh
-            yarn cucumber:pretty || true
-
   test-local-cluster:
     executor: redhat-openshift/machine-for-local-cluster
     steps:
@@ -441,9 +428,6 @@ workflows:
           requires:
             - tools
       - compile:
-          requires:
-            - tools
-      - acceptance:
           requires:
             - tools
       - e2e-snapshots:


### PR DESCRIPTION
- removes unused ci step