### PR TITLE
fix: read-only-user policies

### DIFF
--- a/helm/cas-ciip-portal/templates/cron-app-users.yaml
+++ b/helm/cas-ciip-portal/templates/cron-app-users.yaml
@@ -91,5 +91,5 @@ spec:
                     grant ciip_administrator,ciip_analyst,ciip_industry_user,ciip_guest to $(PORTAL_APP_USER);
                     grant usage on schema swrs to ciip_administrator, ciip_analyst, ciip_industry_user;
                     grant select on all tables in schema swrs to ciip_administrator, ciip_analyst, ciip_industry_user;
-                    select ggircs_portal_private.read_only_user_policies($(PORTAL_READONLY_USER));
+                    select ggircs_portal_private.read_only_user_policies('$(PORTAL_READONLY_USER)');
                   EOF


### PR DESCRIPTION
The last line of cron-app-users was always failing (function call that creates the policies for the read-only user). The user parameter needed to be wrapped in quotes, otherwise it is treated as a column by psql.

This should fix the problem in metabase where nobody can see any ciip data.