### PR TITLE
fix: read-only policies

### DIFF
--- a/helm/cas-ciip-portal/templates/cron-app-users.yaml
+++ b/helm/cas-ciip-portal/templates/cron-app-users.yaml
@@ -91,5 +91,5 @@ spec:
                     grant ciip_administrator,ciip_analyst,ciip_industry_user,ciip_guest to $(PORTAL_APP_USER);
                     grant usage on schema swrs to ciip_administrator, ciip_analyst, ciip_industry_user;
                     grant select on all tables in schema swrs to ciip_administrator, ciip_analyst, ciip_industry_user;
-                    select ggircs_portal_private.read_only_user_policies(\'$(PORTAL_READONLY_USER)\');
+                    select ggircs_portal_private.read_only_user_policies('$(PORTAL_READONLY_USER)');
                   EOF


### PR DESCRIPTION
- remove escape characters from bash function call