### PR TITLE
chore: move release CI jobs in a separate workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -448,6 +448,8 @@ workflows:
           dockerfile: app/Dockerfile
       - pathfinder_lint:
           context: cas-pipeline
+  release:
+    jobs:
       - release_approval:
           type: approval
           filters:
@@ -461,7 +463,6 @@ workflows:
             branches:
               only:
                 - develop
-
 
   nightly:
     triggers:


### PR DESCRIPTION
This should make the CircleCI ui less confusing, and marking the test workflow as a `success` instead on `on hold`