### PR TITLE
Add code of conduct from DevHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,4 @@ The materials published include:
 ## Contributors
 
 - [Developers](https://github.com/bcgov/cas-ciip-portal/graphs/contributors)
+- [Code of Conduct](docs/CODE_OF_CONDUCT.md)

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at Maral.Sotoudehnia@gov.bc.ca. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 CAS CIIP portal is accepting contributions via Github pull requests. (If you're new to GitHub, you might want to start with a [basic tutorial](https://help.github.com/en/github/getting-started-with-github/set-up-git) and check out a more detailed guide to [pull requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests)). Also, any changes made to markdown files must follow [markdown guidelines](https://guides.github.com/features/mastering-markdown/) and ideally written with a [markdown editor](https://stackedit.io/). This document outlines the contribution work flow, contact points for developers and other resources to make getting your contribution accepted.
 
+The [Code of Conduct](./CODE_OF_CONDUCT.md) describes the principles that govern our interactions as project contributors and maintainers.
+
 ## Certificate of Origin
 
 By contributing to this project you agree to the [Developer Certificate of Origin (DCO)](./DCO.md). This document was created by the Linux Kernel community and is a simple statement that you, as a contributor, have the legal right to make the contribution.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 
 - [Inventory and basic documentation of all views in the application](./all-views-inventory.md)
 - [Developer guide](./developer-guide.md)
+  * [Code of Conduct](./CODE_OF_CONDUCT.md)
   * [Setting up the development environment](./dev-environment-setup.md)
   * [Docs](./docs.md)
   * [Button stack](./stack.md)


### PR DESCRIPTION
No rush, but thought I'd put this up since it's a boilerplate job [from DevHub](https://developer.gov.bc.ca/Code-Management/Sample-Code-of-Conduct).

@Maralsotoudehnia let me know what would be an appropriate [email contact to direct abuse reports to](https://github.com/bcgov/cas-ciip-portal/compare/docs/code-of-conduct?expand=1#diff-bf5ab2816dd1ffeb0c1a2ce8d3077160R57-R58) - I filled in yours to start.

Note the [Scope section](https://github.com/bcgov/cas-ciip-portal/compare/docs/code-of-conduct?expand=1#diff-bf5ab2816dd1ffeb0c1a2ce8d3077160R46-R53) applies the code of conduct to several relevant mediums.