### PR TITLE
Add AS_PENDING and AS_CERTIFIER flags to docs

### DIFF
--- a/docs/dev-environment-setup.md
+++ b/docs/dev-environment-setup.md
@@ -175,6 +175,7 @@ AS_REPORTER
 AS_CERTIFIER
 AS_ANALYST
 AS_ADMIN
+AS_PENDING
 ```
 
 [Learn more here](./all-views-inventory.md) about the functionality available to each user type.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -96,8 +96,10 @@ The application requires users to be authenticated using keycloak. Authenticatio
 ### Additional Flags
 
 `AS_REPORTER`: Automatically log in as our test reporter
+`AS_CERTIFIER`: Automatically log in as our test certifier
 `AS_ANALYST`: Automatically log in as our test analyst
 `AS_ADMIN`: Automatically log in as our test admin
+`AS_PENDING`: Automatically log in as a pending analyst (pending approval via the Keycloak console to become an analyst)
 `NO_MAIL`: Ignore all outgoing mail functionality (can be run by itself, or along with any other auth flags ie `yarn dev NO_AUTH NO_MAIL`)
 
 


### PR DESCRIPTION
I was surprised to learn we had a new `AS_PENDING` dev flag, so noticed it needed to be added to the docs. `AS_CERTIFIER` was also missing, so added that as well.