### PR TITLE
Apply BCGov style guide to Add Org/Facility tables

### DIFF
--- a/app/components/AddOrganisationModal.tsx
+++ b/app/components/AddOrganisationModal.tsx
@@ -33,8 +33,7 @@ const AddOrganisationModal: React.FunctionComponent<Props> = (props) => {
 
   return (
     <>
-      <span style={{marginTop: '20px'}}>Operator not in the list?</span>
-      <br />
+      <p style={{marginTop: '20px'}}>Operator not in the list?</p>
       <Button
         variant="outline-primary"
         onClick={() => setModalVisible(!isModalVisible)}

--- a/app/containers/Facilities/AddFacility.tsx
+++ b/app/containers/Facilities/AddFacility.tsx
@@ -82,7 +82,13 @@ export const AddFacilityComponent: React.FunctionComponent<Props> = (props) => {
             </Dropdown.Menu>
           </Dropdown>
           {props.selectedFacility !== null && (
-            <Table style={{textAlign: 'center', marginTop: '10px'}}>
+            <Table
+              style={{
+                textAlign: 'center',
+                marginTop: '10px',
+                borderBottom: '1px solid rgb(0,0,0,0.1)'
+              }}
+            >
               <thead>
                 <tr>
                   <th>Operator Name</th>
@@ -103,7 +109,6 @@ export const AddFacilityComponent: React.FunctionComponent<Props> = (props) => {
               </tbody>
             </Table>
           )}
-          <hr />
           <AddFacilityModal query={query} onAddFacility={handleAddFacility} />
           <style jsx>
             {`
@@ -111,6 +116,11 @@ export const AddFacilityComponent: React.FunctionComponent<Props> = (props) => {
                 max-height: 250px;
                 overflow: hidden;
                 overflow-y: scroll;
+              }
+
+              thead {
+                background: #036;
+                color: #fff;
               }
             `}
           </style>

--- a/app/containers/Organisations/AddOrganisation.tsx
+++ b/app/containers/Organisations/AddOrganisation.tsx
@@ -69,7 +69,13 @@ export const AddOrganisationComponent: React.FunctionComponent<Props> = (
             </Dropdown.Menu>
           </Dropdown>
           {props.selectedOrg !== null && (
-            <Table style={{textAlign: 'center', marginTop: '10px'}}>
+            <Table
+              style={{
+                textAlign: 'center',
+                margin: '10px 0 2em 0',
+                borderBottom: '1px solid rgb(0,0,0,0.1)'
+              }}
+            >
               <thead>
                 <tr>
                   <th>Operator Name</th>
@@ -88,7 +94,6 @@ export const AddOrganisationComponent: React.FunctionComponent<Props> = (
               </tbody>
             </Table>
           )}
-          <hr />
           <AddOrganisationModal onAddOrganisation={handleAddOrganisation} />
           <style jsx>
             {`
@@ -96,6 +101,11 @@ export const AddOrganisationComponent: React.FunctionComponent<Props> = (
                 max-height: 250px;
                 overflow: hidden;
                 overflow-y: scroll;
+              }
+
+              thead {
+                background: #036;
+                color: #fff;
               }
             `}
           </style>

--- a/app/tests/unit/components/__snapshots__/AddOrganisationModal.test.tsx.snap
+++ b/app/tests/unit/components/__snapshots__/AddOrganisationModal.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`AddOrganisationFacility Component should match the last snapshot 1`] = `
 Array [
-  <span
+  <p
     style={
       Object {
         "marginTop": "20px",
@@ -10,8 +10,7 @@ Array [
     }
   >
     Operator not in the list?
-  </span>,
-  <br />,
+  </p>,
   <Button
     active={false}
     disabled={false}


### PR DESCRIPTION
Updates the `/analyst/add-facility` and `/analyst/add-organisation` tables in the analyst view to be in line with the BCGov style guide as specified in [GGIRCS-1619](https://youtrack.button.is/issue/GGIRCS-1619#focus=streamItem-4-3165.0-0) (table header color and vertical centering of row content). See YT card for screenshots.