### PR TITLE
Fix: PDF fuel/emission category ID parsing

### DIFF
--- a/app/containers/Applications/ApplicationDetailsPdf.tsx
+++ b/app/containers/Applications/ApplicationDetailsPdf.tsx
@@ -66,7 +66,6 @@ const CUSTOM_FIELDS = {
   ),
   emissionGas: (props) => <PdfEmissionGasFieldTemplate {...props} />,
   fuel: (props) => {
-    console.log(props);
     return <PdfFuelFieldsTemplate query={props.formContext.query} {...props} />;
   },
   product: (props) => {

--- a/app/containers/Applications/ApplicationDetailsPdf.tsx
+++ b/app/containers/Applications/ApplicationDetailsPdf.tsx
@@ -14,6 +14,7 @@ import {createFragmentContainer, graphql} from 'react-relay';
 import {ApplicationDetailsPdf_application} from 'ApplicationDetailsPdf_application.graphql';
 import PdfEmissionGasFieldTemplate from 'containers/Pdf/PdfEmissionGasFieldTemplate';
 import PdfProductionFieldsTemplate from 'containers/Pdf/PdfProductionFieldsTemplate';
+import PdfFuelFieldsTemplate from 'containers/Pdf/PdfFuelFieldsTemplate';
 import PdfFieldTemplate from 'containers/Pdf/PdfFieldTemplate';
 import PdfArrayFieldTemplate from 'containers/Pdf/PdfArrayFieldTemplate';
 import PdfObjectFieldTemplate from 'containers/Pdf/PdfObjectFieldTemplate';
@@ -64,6 +65,10 @@ const CUSTOM_FIELDS = {
     </Text>
   ),
   emissionGas: (props) => <PdfEmissionGasFieldTemplate {...props} />,
+  fuel: (props) => {
+    console.log(props);
+    return <PdfFuelFieldsTemplate query={props.formContext.query} {...props} />;
+  },
   product: (props) => {
     return (
       <PdfProductionFieldsTemplate query={props.formContext.query} {...props} />
@@ -228,6 +233,22 @@ export default createFragmentContainer(ApplicationDetailsPdf, {
           node {
             rowId
             productName
+          }
+        }
+      }
+      allFuels(condition: {state: "active"}) {
+        edges {
+          node {
+            rowId
+            name
+          }
+        }
+      }
+      allEmissionCategories {
+        edges {
+          node {
+            rowId
+            displayName
           }
         }
       }

--- a/app/containers/Pdf/PdfFuelFieldsTemplate.tsx
+++ b/app/containers/Pdf/PdfFuelFieldsTemplate.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import {View, Text} from '@react-pdf/renderer';
+import {FieldProps} from 'react-jsonschema-form';
+import {ApplicationDetailsPdf_query} from 'ApplicationDetailsPdf_query.graphql';
+
+interface Props extends FieldProps {
+  query: ApplicationDetailsPdf_query;
+}
+
+export const PdfFuelFieldsTemplate: React.FunctionComponent<Props> = ({
+  formData,
+  query
+}) => {
+  return (
+    <View>
+      <Text style={{fontSize: 15, letterSpacing: 2}}>
+        {'\n'}Fuel:{'\n'}
+      </Text>
+      <Text>
+        Fuel Name:{' '}
+        {formData.fuelRowId
+          ? query.allFuels.edges.find(
+              ({node}) => node.rowId === formData.fuelRowId
+            ).node.name
+          : '[Not entered]'}
+        {'\n'}
+      </Text>
+      <Text>
+        Quantity: {formData.quantity ?? '[Not entered]'}
+        {'\n'}
+      </Text>
+      <Text>
+        Units: {formData.fuelUnits ?? '[Not entered]'}
+        {'\n'}
+      </Text>
+      <Text>
+        Emission Category:{' '}
+        {formData.emissionCategoryRowId
+          ? query.allEmissionCategories.edges.find(
+              ({node}) => node.rowId === formData.emissionCategoryRowId
+            ).node.displayName
+          : '[Not entered]'}
+        {'\n'}
+      </Text>
+    </View>
+  );
+};
+
+export default PdfFuelFieldsTemplate;

--- a/app/tests/unit/containers/Applications/ApplicationDetailsPdf.test.tsx
+++ b/app/tests/unit/containers/Applications/ApplicationDetailsPdf.test.tsx
@@ -16,7 +16,7 @@ describe('ApplicationDetailsPdf', () => {
     mockRandom([0.1, 0.2, 0.3, 0.4, 0.5]);
   });
 
-  it('should render application pdf donwload link', async () => {
+  it('should render application pdf download link', async () => {
     const renderer = shallow(
       <ApplicationDetailsPdf
         application={{
@@ -26,12 +26,7 @@ describe('ApplicationDetailsPdf', () => {
           },
           reportingYear: 2019,
           facilityByFacilityId: {
-            facilityName: 'Forest Floor',
-            facilityMailingAddress: 'Evergreen Street Northwest',
-            facilityCity: 'Oak Grove',
-            facilityCountry: 'Canada',
-            facilityProvince: 'British Columbia',
-            facilityPostalCode: 'V1C6T8'
+            facilityName: 'Forest Floor'
           },
           orderedFormResults: {
             edges: [
@@ -83,13 +78,45 @@ describe('ApplicationDetailsPdf', () => {
               {
                 node: {
                   rowId: 1,
-                  name: 'foo'
+                  productName: 'foo'
                 }
               },
               {
                 node: {
                   rowId: 2,
-                  name: 'simpleFoo'
+                  productName: 'simpleFoo'
+                }
+              }
+            ]
+          },
+          allFuels: {
+            edges: [
+              {
+                node: {
+                  rowId: 1,
+                  name: 'bar'
+                }
+              },
+              {
+                node: {
+                  rowId: 2,
+                  name: 'simpleBar'
+                }
+              }
+            ]
+          },
+          allEmissionCategories: {
+            edges: [
+              {
+                node: {
+                  rowId: 1,
+                  displayName: 'baz'
+                }
+              },
+              {
+                node: {
+                  rowId: 2,
+                  displayName: 'simpleBaz'
                 }
               }
             ]

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationDetailsPdf.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationDetailsPdf.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ApplicationDetailsPdf should render application pdf donwload link 1`] = `
+exports[`ApplicationDetailsPdf should render application pdf download link 1`] = `
 <PDFDownloadLink
   className="btn btn-primary"
   document={
@@ -157,6 +157,7 @@ exports[`ApplicationDetailsPdf should render application pdf donwload link 1`] =
                   "StringField": [Function],
                   "emissionGas": [Function],
                   "emissionSource": [Function],
+                  "fuel": [Function],
                   "product": [Function],
                 }
               }
@@ -164,17 +165,49 @@ exports[`ApplicationDetailsPdf should render application pdf donwload link 1`] =
                 Object {
                   "query": Object {
                     " $refType": "ApplicationDetailsPdf_query",
-                    "allProducts": Object {
+                    "allEmissionCategories": Object {
                       "edges": Array [
                         Object {
                           "node": Object {
-                            "name": "foo",
+                            "displayName": "baz",
                             "rowId": 1,
                           },
                         },
                         Object {
                           "node": Object {
-                            "name": "simpleFoo",
+                            "displayName": "simpleBaz",
+                            "rowId": 2,
+                          },
+                        },
+                      ],
+                    },
+                    "allFuels": Object {
+                      "edges": Array [
+                        Object {
+                          "node": Object {
+                            "name": "bar",
+                            "rowId": 1,
+                          },
+                        },
+                        Object {
+                          "node": Object {
+                            "name": "simpleBar",
+                            "rowId": 2,
+                          },
+                        },
+                      ],
+                    },
+                    "allProducts": Object {
+                      "edges": Array [
+                        Object {
+                          "node": Object {
+                            "productName": "foo",
+                            "rowId": 1,
+                          },
+                        },
+                        Object {
+                          "node": Object {
+                            "productName": "simpleFoo",
                             "rowId": 2,
                           },
                         },
@@ -500,6 +533,7 @@ exports[`ApplicationDetailsPdf should render application pdf donwload link 1`] =
                   "StringField": [Function],
                   "emissionGas": [Function],
                   "emissionSource": [Function],
+                  "fuel": [Function],
                   "product": [Function],
                 }
               }
@@ -507,17 +541,49 @@ exports[`ApplicationDetailsPdf should render application pdf donwload link 1`] =
                 Object {
                   "query": Object {
                     " $refType": "ApplicationDetailsPdf_query",
-                    "allProducts": Object {
+                    "allEmissionCategories": Object {
                       "edges": Array [
                         Object {
                           "node": Object {
-                            "name": "foo",
+                            "displayName": "baz",
                             "rowId": 1,
                           },
                         },
                         Object {
                           "node": Object {
-                            "name": "simpleFoo",
+                            "displayName": "simpleBaz",
+                            "rowId": 2,
+                          },
+                        },
+                      ],
+                    },
+                    "allFuels": Object {
+                      "edges": Array [
+                        Object {
+                          "node": Object {
+                            "name": "bar",
+                            "rowId": 1,
+                          },
+                        },
+                        Object {
+                          "node": Object {
+                            "name": "simpleBar",
+                            "rowId": 2,
+                          },
+                        },
+                      ],
+                    },
+                    "allProducts": Object {
+                      "edges": Array [
+                        Object {
+                          "node": Object {
+                            "productName": "foo",
+                            "rowId": 1,
+                          },
+                        },
+                        Object {
+                          "node": Object {
+                            "productName": "simpleFoo",
                             "rowId": 2,
                           },
                         },
@@ -758,6 +824,7 @@ exports[`ApplicationDetailsPdf should render application pdf donwload link 1`] =
                   "StringField": [Function],
                   "emissionGas": [Function],
                   "emissionSource": [Function],
+                  "fuel": [Function],
                   "product": [Function],
                 }
               }
@@ -765,17 +832,49 @@ exports[`ApplicationDetailsPdf should render application pdf donwload link 1`] =
                 Object {
                   "query": Object {
                     " $refType": "ApplicationDetailsPdf_query",
-                    "allProducts": Object {
+                    "allEmissionCategories": Object {
                       "edges": Array [
                         Object {
                           "node": Object {
-                            "name": "foo",
+                            "displayName": "baz",
                             "rowId": 1,
                           },
                         },
                         Object {
                           "node": Object {
-                            "name": "simpleFoo",
+                            "displayName": "simpleBaz",
+                            "rowId": 2,
+                          },
+                        },
+                      ],
+                    },
+                    "allFuels": Object {
+                      "edges": Array [
+                        Object {
+                          "node": Object {
+                            "name": "bar",
+                            "rowId": 1,
+                          },
+                        },
+                        Object {
+                          "node": Object {
+                            "name": "simpleBar",
+                            "rowId": 2,
+                          },
+                        },
+                      ],
+                    },
+                    "allProducts": Object {
+                      "edges": Array [
+                        Object {
+                          "node": Object {
+                            "productName": "foo",
+                            "rowId": 1,
+                          },
+                        },
+                        Object {
+                          "node": Object {
+                            "productName": "simpleFoo",
                             "rowId": 2,
                           },
                         },
@@ -933,6 +1032,7 @@ exports[`ApplicationDetailsPdf should render application pdf donwload link 1`] =
                   "StringField": [Function],
                   "emissionGas": [Function],
                   "emissionSource": [Function],
+                  "fuel": [Function],
                   "product": [Function],
                 }
               }
@@ -940,17 +1040,49 @@ exports[`ApplicationDetailsPdf should render application pdf donwload link 1`] =
                 Object {
                   "query": Object {
                     " $refType": "ApplicationDetailsPdf_query",
-                    "allProducts": Object {
+                    "allEmissionCategories": Object {
                       "edges": Array [
                         Object {
                           "node": Object {
-                            "name": "foo",
+                            "displayName": "baz",
                             "rowId": 1,
                           },
                         },
                         Object {
                           "node": Object {
-                            "name": "simpleFoo",
+                            "displayName": "simpleBaz",
+                            "rowId": 2,
+                          },
+                        },
+                      ],
+                    },
+                    "allFuels": Object {
+                      "edges": Array [
+                        Object {
+                          "node": Object {
+                            "name": "bar",
+                            "rowId": 1,
+                          },
+                        },
+                        Object {
+                          "node": Object {
+                            "name": "simpleBar",
+                            "rowId": 2,
+                          },
+                        },
+                      ],
+                    },
+                    "allProducts": Object {
+                      "edges": Array [
+                        Object {
+                          "node": Object {
+                            "productName": "foo",
+                            "rowId": 1,
+                          },
+                        },
+                        Object {
+                          "node": Object {
+                            "productName": "simpleFoo",
                             "rowId": 2,
                           },
                         },


### PR DESCRIPTION
Fixes issue where fuelRowId & emissionCategoryRowId were not being parsed from integer IDs to their corresponding named values in the PDF.