### PR TITLE
PDF Download style tweaks

### DIFF
--- a/app/containers/Applications/ApplicationDetailsContainer.tsx
+++ b/app/containers/Applications/ApplicationDetailsContainer.tsx
@@ -163,7 +163,8 @@ export const ApplicationDetailsComponent: React.FunctionComponent<Props> = (
       </a>
       <style jsx global>{`
         @media print {
-          header,
+          header .header-right,
+          #navbar,
           footer {
             display: none !important;
           }

--- a/app/containers/Applications/ApplicationDetailsContainer.tsx
+++ b/app/containers/Applications/ApplicationDetailsContainer.tsx
@@ -156,6 +156,8 @@ export const ApplicationDetailsComponent: React.FunctionComponent<Props> = (
         className="btn btn-primary"
         href={`/print-pdf?url=${encodeURIComponent(router.asPath)}`}
         style={{marginBottom: '0.5em'}}
+        target="_blank"
+        rel="noopener noreferrer"
       >
         Download PDF
       </a>

--- a/app/containers/Applications/ApplicationWizardConfirmation.tsx
+++ b/app/containers/Applications/ApplicationWizardConfirmation.tsx
@@ -210,6 +210,7 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
     <Row>
       <Col md={6}>
         <input
+          className="print-hide"
           ref={copyArea}
           readOnly
           value={revision?.certificationUrl?.certifierUrl ?? url}
@@ -234,7 +235,7 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
                 Your request for certification has now been sent to your
                 certifier via email.
               </p>
-              <p>
+              <p className="print-hide">
                 You may copy the direct link to the certification page below.
               </p>
             </Card.Text>
@@ -245,7 +246,7 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
                 opted not to notify them by email, but your request will still
                 be visible via their dashboard.
               </p>
-              <p>
+              <p className="print-hide">
                 You may copy the direct link to the certification page below.
               </p>
             </Card.Text>
@@ -271,7 +272,9 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
             you indicated. You will be notified when they have certified the
             application, at which time it can be submitted.
           </p>
-          <p>You may copy the direct link to the certification page below.</p>
+          <p className="print-hide">
+            You may copy the direct link to the certification page below.
+          </p>
         </Card.Body>
         <Card.Footer>
           <span style={{color: 'green'}}>{copySuccess}</span> {copyUrl}
@@ -359,7 +362,7 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
       ) : (
         certificationMessage
       )}
-      <style jsx>
+      <style jsx global>
         {`
           .errors {
             margin-left: 20px;
@@ -367,6 +370,11 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
             background: #ce5c5c;
             color: white;
             font-size: 20px;
+          }
+          @media print {
+            .print-hide {
+              display: none !important;
+            }
           }
         `}
       </style>

--- a/app/containers/Applications/ApplicationWizardConfirmation.tsx
+++ b/app/containers/Applications/ApplicationWizardConfirmation.tsx
@@ -134,7 +134,7 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
   const generateCertification = (
     <>
       <br />
-      <Card>
+      <Card id="next-step">
         <Card.Header>Application Certification</Card.Header>
         <Card.Body>
           <Card.Text>
@@ -229,7 +229,7 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
 
   if (!revision.certificationUrl) {
     certificationMessage = url ? (
-      <Card className="text-center">
+      <Card id="next-step" className="text-center">
         <Card.Header>Ready for Certification</Card.Header>
         <Card.Body>
           {isChecked ? (
@@ -267,7 +267,7 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
     revision.certificationUrl.hashMatches
   ) {
     certificationMessage = (
-      <Card className="text-center">
+      <Card id="next-step" className="text-center">
         <Card.Header>Pending Certification</Card.Header>
         <Card.Body>
           <p>
@@ -287,7 +287,7 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
   } else {
     certificationMessage = (
       <>
-        <Card className="text-center">
+        <Card id="next-step" className="text-center">
           <Card.Header>Error</Card.Header>
           <Card.Body>
             <Card.Title>The data has changed</Card.Title>
@@ -345,7 +345,7 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
         </div>
       ) : revision.certificationSignatureIsValid ? (
         <>
-          <Card>
+          <Card id="next-step">
             <Card.Header>
               <h5>Before you submit</h5>
             </Card.Header>

--- a/app/containers/Applications/ApplicationWizardConfirmation.tsx
+++ b/app/containers/Applications/ApplicationWizardConfirmation.tsx
@@ -165,7 +165,10 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
             Once you have reviewed the application and ensured all the data is
             correct, the application has to be certified.
           </Card.Text>
-          <Form onSubmit={handleClickGenerateCertificationUrl}>
+          <Form
+            className="print-hide"
+            onSubmit={handleClickGenerateCertificationUrl}
+          >
             <Form.Row>
               <Form.Group as={Col} md="4" controlId="certifierEmail">
                 <Form.Label>Certifier Email Address:</Form.Label>

--- a/app/containers/Forms/CertificationSignature.tsx
+++ b/app/containers/Forms/CertificationSignature.tsx
@@ -78,7 +78,7 @@ export const CertificationSignature: React.FunctionComponent<Props> = ({
   };
 
   return (
-    <Container>
+    <Container id="signature-component">
       <h3>Certifier Signature:</h3>
       <p>
         To create a digital signature, click, hold and drag your pointer within
@@ -138,6 +138,11 @@ export const CertificationSignature: React.FunctionComponent<Props> = ({
             background: #eee;
             border-radius: 6px;
             margin-bottom: 60px;
+          }
+          @media print {
+            #signature-component {
+              display: none !important;
+            }
           }
         `}
       </style>

--- a/app/containers/Forms/CertificationSignature.tsx
+++ b/app/containers/Forms/CertificationSignature.tsx
@@ -143,6 +143,14 @@ export const CertificationSignature: React.FunctionComponent<Props> = ({
             #signature-component {
               display: none !important;
             }
+            .card-text a {
+              display: none !important;
+            }
+            .card-text::after {
+              content: '(full text available at: ${window.location
+                .protocol}//${window.location
+                .host}/resources/application-disclaimer)';
+            }
           }
         `}
       </style>

--- a/app/cypress/integration/override-justification.spec.js
+++ b/app/cypress/integration/override-justification.spec.js
@@ -125,10 +125,7 @@ describe('When an applicaiton does not have errors', () => {
       `/reporter/application?applicationId=${applicationId}&confirmationPage=true&version=1`
     );
     cy.url().should('include', '/reporter/application');
-    cy.get(':nth-child(10) > .card-header').should(
-      'contain',
-      'Application Certification'
-    );
+    cy.get('#next-step').contains('Application Certification');
     cy.get('.override-accordion > .btn').should('not.exist');
   });
 

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationDetailsContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationDetailsContainer.test.tsx.snap
@@ -60,11 +60,13 @@ exports[`ApplicationDetailsComponent should match the snapshot with the Applicat
   <a
     className="jsx-3086474478 btn btn-primary"
     href="/print-pdf?url=%2Fpath-to-application"
+    rel="noopener noreferrer"
     style={
       Object {
         "marginBottom": "0.5em",
       }
     }
+    target="_blank"
   >
     Download PDF
   </a>

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationDetailsContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationDetailsContainer.test.tsx.snap
@@ -15,10 +15,10 @@ exports[`ApplicationDetailsComponent should match the snapshot with the Applicat
     />
   </Row>
   <br
-    className="jsx-3086474478"
+    className="jsx-2472284510"
   />
   <div
-    className="jsx-3086474478"
+    className="jsx-2472284510"
   >
     <Relay(ApplicationDetailsCardItemComponent)
       diffToResults={
@@ -58,7 +58,7 @@ exports[`ApplicationDetailsComponent should match the snapshot with the Applicat
     />
   </div>
   <a
-    className="jsx-3086474478 btn btn-primary"
+    className="jsx-2472284510 btn btn-primary"
     href="/print-pdf?url=%2Fpath-to-application"
     rel="noopener noreferrer"
     style={
@@ -71,9 +71,9 @@ exports[`ApplicationDetailsComponent should match the snapshot with the Applicat
     Download PDF
   </a>
   <JSXStyle
-    id="3086474478"
+    id="2472284510"
   >
-    @media print{header,footer{display:none !important;}}
+    @media print{header .header-right,#navbar,footer{display:none !important;}}
   </JSXStyle>
 </Fragment>
 `;

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationWizardConfirmation.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationWizardConfirmation.test.tsx.snap
@@ -3,12 +3,12 @@
 exports[`The Confirmation Component match the snapshot 1`] = `
 <Fragment>
   <h1
-    className="jsx-1753635690"
+    className="jsx-733094270"
   >
     Summary of your application:
   </h1>
   <p
-    className="jsx-1753635690"
+    className="jsx-733094270"
     style={
       Object {
         "fontSize": "1.25rem",
@@ -19,7 +19,7 @@ exports[`The Confirmation Component match the snapshot 1`] = `
     Please review the information you have provided before continuing.
   </p>
   <br
-    className="jsx-1753635690"
+    className="jsx-733094270"
   />
   <Relay(ApplicationOverrideJustificationComponent)
     applicationDetailsRendered={false}
@@ -62,7 +62,7 @@ exports[`The Confirmation Component match the snapshot 1`] = `
     setHasErrors={[Function]}
   />
   <br
-    className="jsx-1753635690"
+    className="jsx-733094270"
   />
   <br />
   <Card
@@ -160,9 +160,9 @@ exports[`The Confirmation Component match the snapshot 1`] = `
     <CardFooter />
   </Card>
   <JSXStyle
-    id="1753635690"
+    id="733094270"
   >
-    .errors.jsx-1753635690{margin-left:20px;padding:20px;background:#ce5c5c;color:white;font-size:20px;}
+    .errors{margin-left:20px;padding:20px;background:#ce5c5c;color:white;font-size:20px;}@media print{.print-hide{display:none !important;}}
   </JSXStyle>
 </Fragment>
 `;
@@ -170,12 +170,12 @@ exports[`The Confirmation Component match the snapshot 1`] = `
 exports[`The Confirmation Component should render the override justification component with the right props if an override is currently set 1`] = `
 <Fragment>
   <h1
-    className="jsx-1753635690"
+    className="jsx-733094270"
   >
     Summary of your application:
   </h1>
   <p
-    className="jsx-1753635690"
+    className="jsx-733094270"
     style={
       Object {
         "fontSize": "1.25rem",
@@ -186,7 +186,7 @@ exports[`The Confirmation Component should render the override justification com
     Please review the information you have provided before continuing.
   </p>
   <br
-    className="jsx-1753635690"
+    className="jsx-733094270"
   />
   <Relay(ApplicationOverrideJustificationComponent)
     applicationDetailsRendered={false}
@@ -229,7 +229,7 @@ exports[`The Confirmation Component should render the override justification com
     setHasErrors={[Function]}
   />
   <br
-    className="jsx-1753635690"
+    className="jsx-733094270"
   />
   <br />
   <Card
@@ -327,9 +327,9 @@ exports[`The Confirmation Component should render the override justification com
     <CardFooter />
   </Card>
   <JSXStyle
-    id="1753635690"
+    id="733094270"
   >
-    .errors.jsx-1753635690{margin-left:20px;padding:20px;background:#ce5c5c;color:white;font-size:20px;}
+    .errors{margin-left:20px;padding:20px;background:#ce5c5c;color:white;font-size:20px;}@media print{.print-hide{display:none !important;}}
   </JSXStyle>
 </Fragment>
 `;
@@ -337,12 +337,12 @@ exports[`The Confirmation Component should render the override justification com
 exports[`The Confirmation Component should render the override justification component with the right props if no override is currently set 1`] = `
 <Fragment>
   <h1
-    className="jsx-1753635690"
+    className="jsx-733094270"
   >
     Summary of your application:
   </h1>
   <p
-    className="jsx-1753635690"
+    className="jsx-733094270"
     style={
       Object {
         "fontSize": "1.25rem",
@@ -353,7 +353,7 @@ exports[`The Confirmation Component should render the override justification com
     Please review the information you have provided before continuing.
   </p>
   <br
-    className="jsx-1753635690"
+    className="jsx-733094270"
   />
   <Relay(ApplicationOverrideJustificationComponent)
     applicationDetailsRendered={false}
@@ -396,7 +396,7 @@ exports[`The Confirmation Component should render the override justification com
     setHasErrors={[Function]}
   />
   <br
-    className="jsx-1753635690"
+    className="jsx-733094270"
   />
   <br />
   <Card
@@ -494,9 +494,9 @@ exports[`The Confirmation Component should render the override justification com
     <CardFooter />
   </Card>
   <JSXStyle
-    id="1753635690"
+    id="733094270"
   >
-    .errors.jsx-1753635690{margin-left:20px;padding:20px;background:#ce5c5c;color:white;font-size:20px;}
+    .errors{margin-left:20px;padding:20px;background:#ce5c5c;color:white;font-size:20px;}@media print{.print-hide{display:none !important;}}
   </JSXStyle>
 </Fragment>
 `;
@@ -504,12 +504,12 @@ exports[`The Confirmation Component should render the override justification com
 exports[`The Confirmation Component should show a "data has changed" dialogue when hashMatches is false but a signature exists 1`] = `
 <Fragment>
   <h1
-    className="jsx-1753635690"
+    className="jsx-733094270"
   >
     Summary of your application:
   </h1>
   <p
-    className="jsx-1753635690"
+    className="jsx-733094270"
     style={
       Object {
         "fontSize": "1.25rem",
@@ -520,7 +520,7 @@ exports[`The Confirmation Component should show a "data has changed" dialogue wh
     Please review the information you have provided before continuing.
   </p>
   <br
-    className="jsx-1753635690"
+    className="jsx-733094270"
   />
   <Relay(ApplicationOverrideJustificationComponent)
     applicationDetailsRendered={false}
@@ -568,7 +568,7 @@ exports[`The Confirmation Component should show a "data has changed" dialogue wh
     setHasErrors={[Function]}
   />
   <br
-    className="jsx-1753635690"
+    className="jsx-733094270"
   />
   <Card
     body={false}
@@ -686,9 +686,9 @@ exports[`The Confirmation Component should show a "data has changed" dialogue wh
     <CardFooter />
   </Card>
   <JSXStyle
-    id="1753635690"
+    id="733094270"
   >
-    .errors.jsx-1753635690{margin-left:20px;padding:20px;background:#ce5c5c;color:white;font-size:20px;}
+    .errors{margin-left:20px;padding:20px;background:#ce5c5c;color:white;font-size:20px;}@media print{.print-hide{display:none !important;}}
   </JSXStyle>
 </Fragment>
 `;
@@ -696,12 +696,12 @@ exports[`The Confirmation Component should show a "data has changed" dialogue wh
 exports[`The Confirmation Component should show a certifier has not yet signed message when hashMatches is true but certificationSignature is null 1`] = `
 <Fragment>
   <h1
-    className="jsx-1753635690"
+    className="jsx-733094270"
   >
     Summary of your application:
   </h1>
   <p
-    className="jsx-1753635690"
+    className="jsx-733094270"
     style={
       Object {
         "fontSize": "1.25rem",
@@ -712,7 +712,7 @@ exports[`The Confirmation Component should show a certifier has not yet signed m
     Please review the information you have provided before continuing.
   </p>
   <br
-    className="jsx-1753635690"
+    className="jsx-733094270"
   />
   <Relay(ApplicationOverrideJustificationComponent)
     applicationDetailsRendered={false}
@@ -760,7 +760,7 @@ exports[`The Confirmation Component should show a certifier has not yet signed m
     setHasErrors={[Function]}
   />
   <br
-    className="jsx-1753635690"
+    className="jsx-733094270"
   />
   <Card
     body={false}
@@ -773,7 +773,9 @@ exports[`The Confirmation Component should show a certifier has not yet signed m
       <p>
         Your application is pending verification by the certifying official you indicated. You will be notified when they have certified the application, at which time it can be submitted.
       </p>
-      <p>
+      <p
+        className="print-hide"
+      >
         You may copy the direct link to the certification page below.
       </p>
     </CardBody>
@@ -793,6 +795,7 @@ exports[`The Confirmation Component should show a certifier has not yet signed m
           md={6}
         >
           <input
+            className="print-hide"
             readOnly={true}
             style={
               Object {
@@ -826,9 +829,9 @@ exports[`The Confirmation Component should show a certifier has not yet signed m
     </CardFooter>
   </Card>
   <JSXStyle
-    id="1753635690"
+    id="733094270"
   >
-    .errors.jsx-1753635690{margin-left:20px;padding:20px;background:#ce5c5c;color:white;font-size:20px;}
+    .errors{margin-left:20px;padding:20px;background:#ce5c5c;color:white;font-size:20px;}@media print{.print-hide{display:none !important;}}
   </JSXStyle>
 </Fragment>
 `;

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationWizardConfirmation.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationWizardConfirmation.test.tsx.snap
@@ -93,6 +93,7 @@ exports[`The Confirmation Component match the snapshot 1`] = `
         Once you have reviewed the application and ensured all the data is correct, the application has to be certified.
       </CardText>
       <Form
+        className="print-hide"
         inline={false}
         onSubmit={[Function]}
       >
@@ -260,6 +261,7 @@ exports[`The Confirmation Component should render the override justification com
         Once you have reviewed the application and ensured all the data is correct, the application has to be certified.
       </CardText>
       <Form
+        className="print-hide"
         inline={false}
         onSubmit={[Function]}
       >
@@ -427,6 +429,7 @@ exports[`The Confirmation Component should render the override justification com
         Once you have reviewed the application and ensured all the data is correct, the application has to be certified.
       </CardText>
       <Form
+        className="print-hide"
         inline={false}
         onSubmit={[Function]}
       >
@@ -619,6 +622,7 @@ exports[`The Confirmation Component should show a "data has changed" dialogue wh
         Once you have reviewed the application and ensured all the data is correct, the application has to be certified.
       </CardText>
       <Form
+        className="print-hide"
         inline={false}
         onSubmit={[Function]}
       >

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationWizardConfirmation.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationWizardConfirmation.test.tsx.snap
@@ -67,6 +67,7 @@ exports[`The Confirmation Component match the snapshot 1`] = `
   <br />
   <Card
     body={false}
+    id="next-step"
   >
     <CardHeader>
       Application Certification
@@ -235,6 +236,7 @@ exports[`The Confirmation Component should render the override justification com
   <br />
   <Card
     body={false}
+    id="next-step"
   >
     <CardHeader>
       Application Certification
@@ -403,6 +405,7 @@ exports[`The Confirmation Component should render the override justification com
   <br />
   <Card
     body={false}
+    id="next-step"
   >
     <CardHeader>
       Application Certification
@@ -576,6 +579,7 @@ exports[`The Confirmation Component should show a "data has changed" dialogue wh
   <Card
     body={false}
     className="text-center"
+    id="next-step"
   >
     <CardHeader>
       Error
@@ -596,6 +600,7 @@ exports[`The Confirmation Component should show a "data has changed" dialogue wh
   <br />
   <Card
     body={false}
+    id="next-step"
   >
     <CardHeader>
       Application Certification
@@ -769,6 +774,7 @@ exports[`The Confirmation Component should show a certifier has not yet signed m
   <Card
     body={false}
     className="text-center"
+    id="next-step"
   >
     <CardHeader>
       Pending Certification

--- a/app/tests/unit/containers/Forms/__snapshots__/CertificationSignature.test.tsx.snap
+++ b/app/tests/unit/containers/Forms/__snapshots__/CertificationSignature.test.tsx.snap
@@ -3,14 +3,15 @@
 exports[`The Confirmation Component matches the snapshot 1`] = `
 <Container
   fluid={false}
+  id="signature-component"
 >
   <h3
-    className="jsx-2877110858"
+    className="jsx-410618694"
   >
     Certifier Signature:
   </h3>
   <p
-    className="jsx-2877110858"
+    className="jsx-410618694"
   >
     To create a digital signature, click, hold and drag your pointer within the box to draw your signature. Use the Clear button below the signature box to delete the signature and start again. Alternatively, you can select "Choose File" to upload an existing signature image file from your computer (.png, .jpg, .jpeg). When you're ready to submit your certification, click "Sign" below the signature box.
   </p>
@@ -37,12 +38,12 @@ exports[`The Confirmation Component matches the snapshot 1`] = `
       md={6}
     >
       <label
-        className="jsx-2877110858"
+        className="jsx-410618694"
       >
         Upload an existing signature image:
         <input
           accept="image/*"
-          className="jsx-2877110858"
+          className="jsx-410618694"
           onChange={[Function]}
           type="file"
         />
@@ -82,9 +83,9 @@ exports[`The Confirmation Component matches the snapshot 1`] = `
     </Col>
   </Row>
   <JSXStyle
-    id="2877110858"
+    id="410618694"
   >
-    .signatureCanvas{border:1px solid #bbb;padding:30px;width:80%;background:#eee;border-radius:6px;margin-bottom:60px;}
+    .signatureCanvas{border:1px solid #bbb;padding:30px;width:80%;background:#eee;border-radius:6px;margin-bottom:60px;}@media print{#signature-component{display:none !important;}}
   </JSXStyle>
 </Container>
 `;

--- a/app/tests/unit/containers/Forms/__snapshots__/CertificationSignature.test.tsx.snap
+++ b/app/tests/unit/containers/Forms/__snapshots__/CertificationSignature.test.tsx.snap
@@ -6,12 +6,12 @@ exports[`The Confirmation Component matches the snapshot 1`] = `
   id="signature-component"
 >
   <h3
-    className="jsx-410618694"
+    className="jsx-1666427015"
   >
     Certifier Signature:
   </h3>
   <p
-    className="jsx-410618694"
+    className="jsx-1666427015"
   >
     To create a digital signature, click, hold and drag your pointer within the box to draw your signature. Use the Clear button below the signature box to delete the signature and start again. Alternatively, you can select "Choose File" to upload an existing signature image file from your computer (.png, .jpg, .jpeg). When you're ready to submit your certification, click "Sign" below the signature box.
   </p>
@@ -38,12 +38,12 @@ exports[`The Confirmation Component matches the snapshot 1`] = `
       md={6}
     >
       <label
-        className="jsx-410618694"
+        className="jsx-1666427015"
       >
         Upload an existing signature image:
         <input
           accept="image/*"
-          className="jsx-410618694"
+          className="jsx-1666427015"
           onChange={[Function]}
           type="file"
         />
@@ -83,9 +83,9 @@ exports[`The Confirmation Component matches the snapshot 1`] = `
     </Col>
   </Row>
   <JSXStyle
-    id="410618694"
+    id="1666427015"
   >
-    .signatureCanvas{border:1px solid #bbb;padding:30px;width:80%;background:#eee;border-radius:6px;margin-bottom:60px;}@media print{#signature-component{display:none !important;}}
+    .signatureCanvas{border:1px solid #bbb;padding:30px;width:80%;background:#eee;border-radius:6px;margin-bottom:60px;}@media print{#signature-component{display:none !important;}.card-text a{display:none !important;}.card-text::after{content:'(full text available at: http://localhost/resources/application-disclaimer)';}}
   </JSXStyle>
 </Container>
 `;


### PR DESCRIPTION
@matthieu-foucault I noticed a couple more tweaks I wanted to add to #1214 after it was merged:

- Shows the program title and logo from the site header in print (just not the navigation)
- Opens the PDF download in a new tab
- Hides the certification signature interface in print
  - not interactive on paper
  - if they have signed before printing, it won't be visible in the PDF anyway, which is confusing
- Replaces the non-interactive "expand" link to the full text disclaimer with the full URL of the link destination.

(web view):
<img width="896" alt="Screen Shot 2020-10-23 at 4 18 56 PM" src="https://user-images.githubusercontent.com/5522075/97061412-a16df300-154b-11eb-8d64-281f8d0a3395.png">

(print view):
<img width="657" alt="Screen Shot 2020-10-23 at 4 18 13 PM" src="https://user-images.githubusercontent.com/5522075/97061409-9dda6c00-154b-11eb-9bb4-9ecc01de3e3b.png">


[GGIRCS-2037](https://youtrack.button.is/issue/GGIRCS-2037)