### PR TITLE
Cypress helper method to use the mocks schema

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,6 +366,9 @@ jobs:
             pushd test_helper_schema
             SQITCH_TARGET="ciip_portal_dev" sqitch deploy
             popd
+            pushd mocks_schema
+            SQITCH_TARGET="ciip_portal_dev" sqitch deploy
+            popd
       - run:
           name: Create Mailhog server via docker image
           command: docker run -d -p 1025:1025 -p 8025:8025 mailhog/mailhog
@@ -375,6 +378,7 @@ jobs:
             SMTP_CONNECTION_STRING: smtp://@localhost:1025
             SENDER_EMAIL: BCCAS <example@cas.com>
             ADMIN_EMAIL: GHG Regulator <GHGRegulator@gov.bc.ca>
+            ENABLE_DB_MOCKS_COOKIES_ONLY: true # Allow cookies to be set by cypress
           command: |
             source ~/.asdf/asdf.sh
             pushd app
@@ -382,14 +386,7 @@ jobs:
             yarn test:e2e-snapshots
             popd
       - run:
-          name: deploy mocks schema
-          command: |
-            source ~/.bashrc
-            pushd mocks_schema
-            SQITCH_TARGET="ciip_portal_dev" sqitch deploy
-            popd
-      - run:
-          name: run end-to-en tests with mocks
+          name: run end-to-en tests with mocks environment variable set
           environment:
             ENABLE_DB_MOCKS: "true"
           command: |

--- a/app/.env.example
+++ b/app/.env.example
@@ -8,6 +8,7 @@ HOST=<host address>
 
 # true if we want the mocks database schema to be deployed, false otherwise
 ENABLE_DB_MOCKS=<true or false>
+ENABLE_DB_MOCKS_COOKIES_ONLY=<true or false>
 
 # The PostgreSQL role used by the application when run in development mode, with the NO_AUTH option enabled
 # defaults to postgres.

--- a/app/cypress/integration/accessibility/certifier-all-pages-accessibility.spec.js
+++ b/app/cypress/integration/accessibility/certifier-all-pages-accessibility.spec.js
@@ -8,6 +8,7 @@ describe('When logged in as a certifier(reporter)', () => {
       Cypress.env('TEST_CERTIFIER_USERNAME'),
       Cypress.env('TEST_CERTIFIER_PASSWORD')
     );
+    cy.useMockedTime(new Date(2020, 5, 10, 9, 0, 0, 0)); //May 10th at 9am
   });
 
   afterEach(() => {

--- a/app/cypress/integration/reporter-certifier-access.spec.js
+++ b/app/cypress/integration/reporter-certifier-access.spec.js
@@ -8,6 +8,7 @@ describe('When logged in as a certifier(reporter)', () => {
       Cypress.env('TEST_CERTIFIER_USERNAME'),
       Cypress.env('TEST_CERTIFIER_PASSWORD')
     );
+    cy.useMockedTime(new Date(2020, 5, 10, 9, 0, 0, 0)); //May 10th at 9am
   });
 
   afterEach(() => {

--- a/app/cypress/support/commands.js
+++ b/app/cypress/support/commands.js
@@ -45,6 +45,16 @@ EOF`)
   );
 });
 
+Cypress.Commands.add('useMockedTime', (dateTime) => {
+  cy.setCookie(
+    'mocks.mocked_timestamp',
+    Math.round(dateTime.getTime() / 1000).toString()
+  );
+});
+Cypress.Commands.add('clearMockedTime', () => {
+  cy.clearCookie('mocks.mocked_timestamp');
+});
+
 Cypress.Commands.add('deployProdData', () => {
   cy.exec('pushd ../ && ./.bin/deploy-data.sh -test && popd');
 });

--- a/app/server/helpers/databaseMockPgOptions.js
+++ b/app/server/helpers/databaseMockPgOptions.js
@@ -7,10 +7,14 @@ const generateForwardedCookieOptions = (cookies, fields) => {
   }, {});
 };
 
-// if the ENABLE_DB_MOCKS env variable is set,
+// if the ENABLE_DB_MOCKS or ENABLE_DB_MOCKS_COOKIES_ONLY env variable is set,
 // creates the settings object needed for postgres to use the mocks schema by default and the fields to retrieve from the cookies
 const generateDatabaseMockOptions = (cookies, fields) => {
-  if (process.env.ENABLE_DB_MOCKS !== 'true') return {};
+  if (
+    process.env.ENABLE_DB_MOCKS !== 'true' &&
+    process.env.ENABLE_DB_MOCKS_COOKIES_ONLY !== 'true'
+  )
+    return {};
 
   return {
     ...generateForwardedCookieOptions(cookies, fields),


### PR DESCRIPTION
This PR creates `cy.useMockedTime(date: Date)` and `cy.clearMockedTime()` helper commands to set and clear the mocked database time.

For this to work:
- `ENABLE_DB_MOCKS` or `ENABLE_DB_MOCKS_COOKIES_ONLY` environment variables need to be set
- the `mocks` schema needs to be deployed