### PR TITLE
Allow editing of the last application close date, even if past

### DIFF
--- a/app/containers/Admin/ReportingYear/NewReportingYearFormDialog.tsx
+++ b/app/containers/Admin/ReportingYear/NewReportingYearFormDialog.tsx
@@ -15,7 +15,7 @@ interface Props {
   clearForm: () => void;
   createReportingYear: ({formData}) => void;
   existingYearKeys: number[];
-  validateExclusiveApplicationWindow: (
+  validateExclusiveDateRanges: (
     year: number,
     formData: object,
     errors: object
@@ -27,7 +27,7 @@ const NewReportingYearFormDialog: React.FunctionComponent<Props> = ({
   clearForm,
   createReportingYear,
   existingYearKeys,
-  validateExclusiveApplicationWindow
+  validateExclusiveDateRanges
 }) => {
   const handleSubmit = (e) => {
     const beginningOfDay = {hour: 0, minute: 0, second: 0, millisecond: 0};
@@ -85,7 +85,7 @@ const NewReportingYearFormDialog: React.FunctionComponent<Props> = ({
                   errors,
                   newReportingYearSchema.uiSchema
                 );
-                return validateExclusiveApplicationWindow(
+                return validateExclusiveDateRanges(
                   null,
                   formData,
                   errors

--- a/app/containers/Admin/ReportingYear/NewReportingYearFormDialog.tsx
+++ b/app/containers/Admin/ReportingYear/NewReportingYearFormDialog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Modal, Container, Button} from 'react-bootstrap';
 import globalFormStyles from '../../Forms/FormSharedStyles';
-import JsonSchemaForm from 'react-jsonschema-form';
+import JsonSchemaForm, {FormValidation} from 'react-jsonschema-form';
 import {JSONSchema6} from 'json-schema';
 import FormObjectFieldTemplate from 'containers/Forms/FormObjectFieldTemplate';
 import FormFieldTemplate from 'containers/Forms/FormFieldTemplate';
@@ -15,13 +15,19 @@ interface Props {
   clearForm: () => void;
   createReportingYear: ({formData}) => void;
   existingYearKeys: number[];
+  validateExclusiveApplicationWindow: (
+    year: number,
+    formData: object,
+    errors: object
+  ) => FormValidation;
 }
 
 const NewReportingYearFormDialog: React.FunctionComponent<Props> = ({
   show,
   clearForm,
   createReportingYear,
-  existingYearKeys
+  existingYearKeys,
+  validateExclusiveApplicationWindow
 }) => {
   const handleSubmit = (e) => {
     const beginningOfDay = {hour: 0, minute: 0, second: 0, millisecond: 0};
@@ -73,11 +79,16 @@ const NewReportingYearFormDialog: React.FunctionComponent<Props> = ({
               showErrorList={false}
               validate={(formData, errors) => {
                 validateUniqueKey(existingYearKeys, formData, errors);
-                return validateAllDates(
+                validateAllDates(
                   null,
                   formData,
                   errors,
                   newReportingYearSchema.uiSchema
+                );
+                return validateExclusiveApplicationWindow(
+                  null,
+                  formData,
+                  errors
                 );
               }}
               onSubmit={handleSubmit}

--- a/app/containers/Admin/ReportingYear/NewReportingYearFormDialog.tsx
+++ b/app/containers/Admin/ReportingYear/NewReportingYearFormDialog.tsx
@@ -85,11 +85,8 @@ const NewReportingYearFormDialog: React.FunctionComponent<Props> = ({
                   errors,
                   newReportingYearSchema.uiSchema
                 );
-                return validateExclusiveDateRanges(
-                  null,
-                  formData,
-                  errors
-                );
+                validateExclusiveDateRanges(null, formData, errors);
+                return errors;
               }}
               onSubmit={handleSubmit}
             >

--- a/app/containers/Admin/ReportingYear/ReportingYearFormDialog.tsx
+++ b/app/containers/Admin/ReportingYear/ReportingYearFormDialog.tsx
@@ -14,13 +14,11 @@ function transformUiSchema(json, formFields) {
   if (!formFields) return;
   const now = nowMoment();
 
-  Object.keys(json).forEach((field) => {
-    const d = defaultMoment(formFields[field]);
-    // Disable editing past dates, except for applicationCloseTime to enable them to extend it
-    // (interface is only displayed for the most recent period):
-    json[field]['ui:disabled'] =
-      field === 'applicationCloseTime' ? false : d.isBefore(now);
-  });
+  // Dates that are past should not be editable - with the exception of applicationCloseTime:
+  const swrsDeadline = defaultMoment(formFields.swrsDeadline);
+  json.swrsDeadline['ui:disabled'] = swrsDeadline.isBefore(now);
+  const applicationOpen = defaultMoment(formFields.applicationOpenTime);
+  json.applicationOpenTime['ui:disabled'] = applicationOpen.isBefore(now);
 
   return json;
 }

--- a/app/containers/Admin/ReportingYear/ReportingYearFormDialog.tsx
+++ b/app/containers/Admin/ReportingYear/ReportingYearFormDialog.tsx
@@ -16,7 +16,10 @@ function transformUiSchema(json, formFields) {
 
   Object.keys(json).forEach((field) => {
     const d = defaultMoment(formFields[field]);
-    json[field]['ui:disabled'] = d < now;
+    // Disable editing past dates, except for applicationCloseTime to enable them to extend it
+    // (interface is only displayed for the most recent period):
+    json[field]['ui:disabled'] =
+      field === 'applicationCloseTime' ? false : d.isBefore(now);
   });
 
   return json;
@@ -92,11 +95,7 @@ const ReportingYearFormDialog: React.FunctionComponent<Props> = ({
                   errors,
                   uiSchema
                 );
-                return validateExclusiveDateRanges(
-                  year,
-                  formData,
-                  errors
-                );
+                return validateExclusiveDateRanges(year, formData, errors);
               }}
               onSubmit={handleSubmit}
             >

--- a/app/containers/Admin/ReportingYear/ReportingYearFormDialog.tsx
+++ b/app/containers/Admin/ReportingYear/ReportingYearFormDialog.tsx
@@ -28,7 +28,7 @@ interface Props {
   formFields: object;
   clearForm: () => void;
   saveReportingYear: ({formData}) => void;
-  validateExclusiveApplicationWindow: (
+  validateExclusiveDateRanges: (
     year: number,
     formData: object,
     errors: object
@@ -41,7 +41,7 @@ const ReportingYearFormDialog: React.FunctionComponent<Props> = ({
   formFields,
   clearForm,
   saveReportingYear,
-  validateExclusiveApplicationWindow
+  validateExclusiveDateRanges
 }) => {
   const uiSchema = transformUiSchema(reportingYearSchema.uiSchema, formFields);
 
@@ -92,7 +92,7 @@ const ReportingYearFormDialog: React.FunctionComponent<Props> = ({
                   errors,
                   uiSchema
                 );
-                return validateExclusiveApplicationWindow(
+                return validateExclusiveDateRanges(
                   year,
                   formData,
                   errors

--- a/app/containers/Admin/ReportingYear/ReportingYearFormDialog.tsx
+++ b/app/containers/Admin/ReportingYear/ReportingYearFormDialog.tsx
@@ -93,7 +93,8 @@ const ReportingYearFormDialog: React.FunctionComponent<Props> = ({
                   errors,
                   uiSchema
                 );
-                return validateExclusiveDateRanges(year, formData, errors);
+                validateExclusiveDateRanges(year, formData, errors);
+                return errors;
               }}
               onSubmit={handleSubmit}
             >

--- a/app/containers/Admin/ReportingYear/ReportingYearFormDialog.tsx
+++ b/app/containers/Admin/ReportingYear/ReportingYearFormDialog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Modal, Container, Button} from 'react-bootstrap';
 import globalFormStyles from '../../Forms/FormSharedStyles';
-import JsonSchemaForm from 'react-jsonschema-form';
+import JsonSchemaForm, {FormValidation} from 'react-jsonschema-form';
 import {JSONSchema6} from 'json-schema';
 import FormObjectFieldTemplate from 'containers/Forms/FormObjectFieldTemplate';
 import FormFieldTemplate from 'containers/Forms/FormFieldTemplate';
@@ -28,6 +28,11 @@ interface Props {
   formFields: object;
   clearForm: () => void;
   saveReportingYear: ({formData}) => void;
+  validateExclusiveApplicationWindow: (
+    year: number,
+    formData: object,
+    errors: object
+  ) => FormValidation;
 }
 
 const ReportingYearFormDialog: React.FunctionComponent<Props> = ({
@@ -35,7 +40,8 @@ const ReportingYearFormDialog: React.FunctionComponent<Props> = ({
   year,
   formFields,
   clearForm,
-  saveReportingYear
+  saveReportingYear,
+  validateExclusiveApplicationWindow
 }) => {
   const uiSchema = transformUiSchema(reportingYearSchema.uiSchema, formFields);
 
@@ -45,14 +51,14 @@ const ReportingYearFormDialog: React.FunctionComponent<Props> = ({
     const formData = {
       ...e.formData,
       applicationOpenTime: ensureFullTimestamp(
-        e.formData.applicationOpenTime, beginningOfDay
+        e.formData.applicationOpenTime,
+        beginningOfDay
       ),
       applicationCloseTime: ensureFullTimestamp(
-        e.formData.applicationCloseTime, endOfDay
+        e.formData.applicationCloseTime,
+        endOfDay
       ),
-      swrsDeadline: ensureFullTimestamp(
-        e.formData.swrsDeadline, endOfDay
-      )
+      swrsDeadline: ensureFullTimestamp(e.formData.swrsDeadline, endOfDay)
     };
 
     if (e.errors.length === 0) {
@@ -79,14 +85,19 @@ const ReportingYearFormDialog: React.FunctionComponent<Props> = ({
               ObjectFieldTemplate={FormObjectFieldTemplate}
               widgets={{DatePickerWidget}}
               showErrorList={false}
-              validate={(formData, errors) =>
+              validate={(formData, errors) => {
                 validateApplicationDates(
                   formFields,
                   formData,
                   errors,
                   uiSchema
-                )
-              }
+                );
+                return validateExclusiveApplicationWindow(
+                  year,
+                  formData,
+                  errors
+                );
+              }}
               onSubmit={handleSubmit}
             >
               <Button type="submit" variant="primary">

--- a/app/containers/Admin/ReportingYear/ReportingYearTable.tsx
+++ b/app/containers/Admin/ReportingYear/ReportingYearTable.tsx
@@ -7,7 +7,7 @@ import createReportingYearMutation from 'mutations/reporting_year/createReportin
 import ReportingYearFormDialog from './ReportingYearFormDialog';
 import NewReportingYearFormDialog from './NewReportingYearFormDialog';
 import {nowMoment, defaultMoment, dateTimeFormat} from 'functions/formatDates';
-import {validateExclusiveApplicationWindow} from 'containers/Admin/ReportingYear/reportingYearValidation';
+import {validateExclusiveDateRanges} from 'containers/Admin/ReportingYear/reportingYearValidation';
 
 interface Props {
   relay: RelayProp;
@@ -39,9 +39,9 @@ export const ReportingYearTableComponent: React.FunctionComponent<Props> = (
     return edge.node.reportingYear;
   });
 
-  const applicationWindowValidator = useMemo(() => {
+  const exclusiveDateRangesValidator = useMemo(() => {
     return (year, formData, errors) => {
-      return validateExclusiveApplicationWindow(
+      return validateExclusiveDateRanges(
         year,
         props.query.allReportingYears.edges,
         formData,
@@ -130,7 +130,7 @@ export const ReportingYearTableComponent: React.FunctionComponent<Props> = (
         createReportingYear={createReportingYear}
         clearForm={clearForm}
         existingYearKeys={existingYearKeys}
-        validateExclusiveApplicationWindow={applicationWindowValidator}
+        validateExclusiveDateRanges={exclusiveDateRangesValidator}
       />
       <ReportingYearFormDialog
         show={dialogMode === 'edit'}
@@ -138,7 +138,7 @@ export const ReportingYearTableComponent: React.FunctionComponent<Props> = (
         formFields={editingYear}
         clearForm={clearForm}
         saveReportingYear={saveReportingYear}
-        validateExclusiveApplicationWindow={applicationWindowValidator}
+        validateExclusiveDateRanges={exclusiveDateRangesValidator}
       />
     </>
   );

--- a/app/containers/Admin/ReportingYear/ReportingYearTable.tsx
+++ b/app/containers/Admin/ReportingYear/ReportingYearTable.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useMemo} from 'react';
 import {Table, Button} from 'react-bootstrap';
 import {graphql, createFragmentContainer, RelayProp} from 'react-relay';
 import {ReportingYearTable_query} from '__generated__/ReportingYearTable_query.graphql';
@@ -7,6 +7,7 @@ import createReportingYearMutation from 'mutations/reporting_year/createReportin
 import ReportingYearFormDialog from './ReportingYearFormDialog';
 import NewReportingYearFormDialog from './NewReportingYearFormDialog';
 import {nowMoment, defaultMoment, dateTimeFormat} from 'functions/formatDates';
+import {validateExclusiveApplicationWindow} from 'containers/Admin/ReportingYear/reportingYearValidation';
 
 interface Props {
   relay: RelayProp;
@@ -37,6 +38,17 @@ export const ReportingYearTableComponent: React.FunctionComponent<Props> = (
   const existingYearKeys = query.allReportingYears.edges.map((edge) => {
     return edge.node.reportingYear;
   });
+
+  const applicationWindowValidator = useMemo(() => {
+    return (year, formData, errors) => {
+      return validateExclusiveApplicationWindow(
+        year,
+        props.query.allReportingYears.edges,
+        formData,
+        errors
+      );
+    };
+  }, [props.query.allReportingYears]);
 
   const clearForm = () => {
     setDialogMode(null);
@@ -118,6 +130,7 @@ export const ReportingYearTableComponent: React.FunctionComponent<Props> = (
         createReportingYear={createReportingYear}
         clearForm={clearForm}
         existingYearKeys={existingYearKeys}
+        validateExclusiveApplicationWindow={applicationWindowValidator}
       />
       <ReportingYearFormDialog
         show={dialogMode === 'edit'}
@@ -125,6 +138,7 @@ export const ReportingYearTableComponent: React.FunctionComponent<Props> = (
         formFields={editingYear}
         clearForm={clearForm}
         saveReportingYear={saveReportingYear}
+        validateExclusiveApplicationWindow={applicationWindowValidator}
       />
     </>
   );

--- a/app/containers/Admin/ReportingYear/ReportingYearTable.tsx
+++ b/app/containers/Admin/ReportingYear/ReportingYearTable.tsx
@@ -24,12 +24,9 @@ function getMostRecentlyClosedYear(query) {
     .sort((yearA, yearB) => {
       const yearACloseTime = defaultMoment(yearA.node.applicationCloseTime);
       const yearBCloseTime = defaultMoment(yearB.node.applicationCloseTime);
-
-      return yearACloseTime.isBefore(yearBCloseTime)
-        ? 1
-        : yearBCloseTime.isBefore(yearACloseTime)
-        ? -1
-        : 0;
+      let sortOrder = yearACloseTime === yearBCloseTime ? 0 : 1;
+      if (yearBCloseTime.isBefore(yearACloseTime)) sortOrder *= -1;
+      return sortOrder;
     });
   // Can edit only the most recently closed reporting period
   // (unless the next application window has already opened - prevents overlap):

--- a/app/containers/Admin/ReportingYear/ReportingYearTable.tsx
+++ b/app/containers/Admin/ReportingYear/ReportingYearTable.tsx
@@ -114,7 +114,7 @@ export const ReportingYearTableComponent: React.FunctionComponent<Props> = (
     <>
       <div style={{textAlign: 'right'}}>
         <Button
-          style={{marginTop: '-220px'}}
+          style={{marginTop: '-100px'}}
           onClick={() => setDialogMode('create')}
         >
           New Reporting Year

--- a/app/containers/Admin/ReportingYear/reportingYearValidation.ts
+++ b/app/containers/Admin/ReportingYear/reportingYearValidation.ts
@@ -82,7 +82,15 @@ function validateExclusiveDateRanges(
   return errors;
 }
 
-function validateApplicationDates(existingData, formData, errors, uiSchema) {
+function validateApplicationDates(
+  existingData,
+  formData,
+  errors,
+  uiSchema,
+  // only the validation for creating new reporting periods sets this to true
+  // (so closed application windows can be re-opened by editing the reporting period):
+  validateFutureApplicationClose = false
+) {
   const openDate = formData.applicationOpenTime
     ? defaultMoment(formData.applicationOpenTime)
     : undefined;
@@ -105,10 +113,12 @@ function validateApplicationDates(existingData, formData, errors, uiSchema) {
     errors.addError(`${ERRORS.PAST_DATE} Application open time`);
   }
 
+  const closeDateIsPast =
+    validateFutureApplicationClose && isPastDate(closeDate);
   if (
     Boolean(closeDate) &&
-    isPastDate(closeDate) &&
-    !uiSchema.applicationCloseTime['ui:disabled']
+    !uiSchema.applicationCloseTime['ui:disabled'] &&
+    closeDateIsPast
   ) {
     errors.addError(`${ERRORS.PAST_DATE} Application close time`);
   }
@@ -161,7 +171,7 @@ function validateReportingDates(formData, errors) {
 
 function validateAllDates(existingData, formData, errors, uiSchema) {
   return (
-    validateApplicationDates(existingData, formData, errors, uiSchema) &&
+    validateApplicationDates(existingData, formData, errors, uiSchema, true) &&
     validateReportingDates(formData, errors)
   );
 }

--- a/app/containers/Admin/ReportingYear/reportingYearValidation.ts
+++ b/app/containers/Admin/ReportingYear/reportingYearValidation.ts
@@ -57,27 +57,31 @@ function validateExclusiveDateRanges(
   },
   errors
 ) {
-  const doesApplicationWindowOverlap = doesRangeOverlap(
-    year,
-    existingYears,
-    applicationOpenTime,
-    applicationCloseTime,
-    'applicationOpenTime',
-    'applicationCloseTime'
-  );
-  const doesReportingPeriodOverlap = doesRangeOverlap(
-    year,
-    existingYears,
-    reportingPeriodStart,
-    reportingPeriodEnd,
-    'reportingPeriodStart',
-    'reportingPeriodEnd'
-  );
-  if (doesApplicationWindowOverlap) {
-    errors.addError(ERRORS.APPLICATION_WINDOW_OVERLAPS);
+  if  (applicationOpenTime && applicationCloseTime) {
+    const doesApplicationWindowOverlap = doesRangeOverlap(
+      year,
+      existingYears,
+      applicationOpenTime,
+      applicationCloseTime,
+      'applicationOpenTime',
+      'applicationCloseTime'
+    );
+    if (doesApplicationWindowOverlap) {
+      errors.addError(ERRORS.APPLICATION_WINDOW_OVERLAPS);
+    }
   }
-  if (doesReportingPeriodOverlap) {
-    errors.addError(ERRORS.REPORTING_PERIOD_OVERLAPS);
+  if (reportingPeriodStart && reportingPeriodEnd) {
+    const doesReportingPeriodOverlap = doesRangeOverlap(
+      year,
+      existingYears,
+      reportingPeriodStart,
+      reportingPeriodEnd,
+      'reportingPeriodStart',
+      'reportingPeriodEnd'
+    );
+    if (doesReportingPeriodOverlap) {
+      errors.addError(ERRORS.REPORTING_PERIOD_OVERLAPS);
+    }
   }
   return errors;
 }

--- a/app/containers/Admin/ReportingYear/reportingYearValidation.ts
+++ b/app/containers/Admin/ReportingYear/reportingYearValidation.ts
@@ -32,8 +32,7 @@ function doesRangeOverlap(
 ) {
   return existingYears.some((edge) => {
     // Allow the year currently being edited to overlap with itself:
-    if (edge.node.reportingYear === year) return false;
-
+    const sameAsYearEdited = edge.node.reportingYear === year;
     const begin = defaultMoment(edge.node[existingBeginDateName]);
     const end = defaultMoment(edge.node[existingEndDateName]);
     const beginDateFallsWithin =
@@ -42,7 +41,7 @@ function doesRangeOverlap(
     const endDateFallsWithin =
       defaultMoment(proposedEndDate).isSameOrAfter(begin) &&
       defaultMoment(proposedEndDate).isSameOrBefore(end);
-    return beginDateFallsWithin || endDateFallsWithin;
+      return !sameAsYearEdited && (beginDateFallsWithin || endDateFallsWithin);
   });
 }
 
@@ -130,6 +129,7 @@ function validateApplicationDates(
   if (
     Boolean(closeDate) &&
     Boolean(openDate) &&
+    !uiSchema.applicationCloseTime['ui:disabled'] &&
     closeDate.isSameOrBefore(openDate)
   ) {
     errors.addError(ERRORS.CLOSE_BEFORE_OPEN_DATE);
@@ -138,6 +138,7 @@ function validateApplicationDates(
   if (
     Boolean(closeDate) &&
     Boolean(reportingEnd) &&
+    !uiSchema.applicationCloseTime['ui:disabled'] &&
     closeDate.isBefore(reportingEnd)
   ) {
     errors.addError(ERRORS.CLOSE_BEFORE_REPORTING_END);
@@ -185,11 +186,16 @@ function validateUniqueKey(existingKeys, formData, errors) {
   if (existingKeys.includes(formData.reportingYear)) {
     errors.addError(ERRORS.NON_UNIQUE_KEY);
   }
+  return errors;
 }
 
 export {
   validateApplicationDates,
   validateAllDates,
   validateUniqueKey,
-  validateExclusiveDateRanges
+  validateExclusiveDateRanges,
+  // Note: The below exports are only used directly by unit tests:
+  ERRORS,
+  doesRangeOverlap,
+  validateReportingDates
 };

--- a/app/containers/Admin/ReportingYear/reportingYearValidation.ts
+++ b/app/containers/Admin/ReportingYear/reportingYearValidation.ts
@@ -116,12 +116,11 @@ function validateApplicationDates(
     errors.addError(`${ERRORS.PAST_DATE} Application open time`);
   }
 
-  const closeDateIsPast =
-    validateFutureApplicationClose && isPastDate(closeDate);
   if (
     Boolean(closeDate) &&
     !uiSchema.applicationCloseTime['ui:disabled'] &&
-    closeDateIsPast
+    validateFutureApplicationClose &&
+    isPastDate(closeDate)
   ) {
     errors.addError(`${ERRORS.PAST_DATE} Application close time`);
   }

--- a/app/tests/unit/containers/Admin/ReportingYear/reportingYearValidation.test.ts
+++ b/app/tests/unit/containers/Admin/ReportingYear/reportingYearValidation.test.ts
@@ -1,0 +1,582 @@
+import {
+  ERRORS,
+  doesRangeOverlap,
+  validateExclusiveDateRanges,
+  validateApplicationDates,
+  validateReportingDates,
+  validateUniqueKey
+} from 'containers/Admin/ReportingYear/reportingYearValidation';
+import moment from 'moment-timezone';
+
+const NOW = moment();
+const TODAY = `${NOW.year()}-${NOW.month() + 1}-${NOW.date()}T${NOW.hour()}:${
+  NOW.minute() + 10
+}:00-0${(-1 * NOW.utcOffset()) / 60}:00`;
+
+interface FakeJsonSchemaErrors {
+  __errors: [string?];
+}
+
+class FakeJsonSchemaErrors {
+  constructor() {
+    this.__errors = [];
+  }
+  addError(msg) {
+    this.__errors.push(msg);
+  }
+}
+
+const existingYears = [
+  {
+    node: {
+      reportingYear: 2019,
+      swrsDeadline: '2020-07-31T00:00:00-07:00',
+      reportingPeriodStart: '2019-01-01T00:00:00-08:00',
+      reportingPeriodEnd: '2019-12-31T23:59:59-08:00',
+      applicationOpenTime: '2020-07-03T00:00:00-07:00',
+      applicationCloseTime: '2020-08-31T23:59:59.999999-07:00'
+    }
+  },
+  {
+    node: {
+      reportingYear: 2020,
+      swrsDeadline: '2021-07-31T00:00:00-07:00',
+      reportingPeriodStart: '2020-01-01T00:00:00-08:00',
+      reportingPeriodEnd: '2020-12-31T23:59:59-08:00',
+      applicationOpenTime: '2021-07-03T00:00:00-07:00',
+      applicationCloseTime: '2021-08-31T23:59:59.999999-07:00'
+    }
+  },
+  {
+    node: {
+      reportingYear: 2021,
+      swrsDeadline: '2022-07-31T00:00:00-07:00',
+      reportingPeriodStart: '2021-01-01T00:00:00-08:00',
+      reportingPeriodEnd: '2021-12-31T23:59:59-08:00',
+      applicationOpenTime: '2022-07-03T00:00:00-07:00',
+      applicationCloseTime: '2022-08-31T23:59:59.999999-07:00'
+    }
+  }
+];
+
+describe('Reporting period admin validation functions: doesRangeOverlap', () => {
+  it("Should detect date range overlap with existing years' date ranges for the same field", () => {
+    const beginDateOverlapsAnother = doesRangeOverlap(
+      2020,
+      existingYears,
+      '2019-11-16T00:00:00-08:00',
+      '2020-12-31T23:59:59-08:00',
+      'reportingPeriodStart',
+      'reportingPeriodEnd'
+    );
+    const endDateOverlapsAnother = doesRangeOverlap(
+      2019,
+      existingYears,
+      '2019-01-01T00:00:00-08:00',
+      '2020-01-01T00:00:00-08:00',
+      'reportingPeriodStart',
+      'reportingPeriodEnd'
+    );
+    const bothDatesOverlapAnother = doesRangeOverlap(
+      2020,
+      existingYears,
+      '2019-12-31T23:59:59-08:00',
+      '2021-01-01T00:00:00-08:00',
+      'reportingPeriodStart',
+      'reportingPeriodEnd'
+    );
+    const neitherDateOverlaps = doesRangeOverlap(
+      2021,
+      existingYears,
+      '2022-01-01T00:00:00-08:00',
+      '2022-12-31T23:59:59-08:00',
+      'reportingPeriodStart',
+      'reportingPeriodEnd'
+    );
+    expect(beginDateOverlapsAnother).toBeTrue();
+    expect(endDateOverlapsAnother).toBeTrue();
+    expect(bothDatesOverlapAnother).toBeTrue();
+    expect(neitherDateOverlaps).toBeFalse();
+  });
+
+  it('Should not detect date range overlap with the existing date range for the same year (an existing date range may be edited post-creation)', () => {
+    const beginDateOverlapsSelf = doesRangeOverlap(
+      2019,
+      existingYears,
+      '2019-01-01T00:00:00-08:00',
+      '2025-01-01T00:00:00-08:00',
+      'reportingPeriodStart',
+      'reportingPeriodEnd'
+    );
+    const endDateOverlapsSelf = doesRangeOverlap(
+      2020,
+      existingYears,
+      '2018-12-31T23:59:59-08:00',
+      '2020-12-31T23:59:59-08:00',
+      'reportingPeriodStart',
+      'reportingPeriodEnd'
+    );
+    const bothDatesOverlapSelf = doesRangeOverlap(
+      2020,
+      existingYears,
+      '2020-01-01T23:59:59-08:00',
+      '2020-12-31T00:00:00-08:00',
+      'reportingPeriodStart',
+      'reportingPeriodEnd'
+    );
+
+    expect(beginDateOverlapsSelf).toBeFalse();
+    expect(endDateOverlapsSelf).toBeFalse();
+    expect(bothDatesOverlapSelf).toBeFalse();
+  });
+});
+
+describe('Reporting period admin validation functions: validateExclusiveDateRanges', () => {
+  let jsonSchemaErrors;
+
+  beforeEach(() => {
+    jsonSchemaErrors = new FakeJsonSchemaErrors();
+  });
+
+  it('Application window overlap with that of another existing year should add an error', () => {
+    const resultingErrors = validateExclusiveDateRanges(
+      2010,
+      existingYears,
+      {
+        applicationOpenTime: '2020-07-03T00:00:00-07:00',
+        applicationCloseTime: '2020-08-31T23:59:59.999999-07:00',
+        reportingPeriodStart: '2010-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2010-12-31T23:59:59-08:00'
+      },
+      jsonSchemaErrors
+    );
+    expect(resultingErrors.__errors).toContain(
+      ERRORS.APPLICATION_WINDOW_OVERLAPS
+    );
+  });
+  it('Application window that does not overlap with existing years should not add an error', () => {
+    const resultingErrors = validateExclusiveDateRanges(
+      2010,
+      existingYears,
+      {
+        applicationOpenTime: '2011-07-03T00:00:00-07:00',
+        applicationCloseTime: '2011-08-31T23:59:59.999999-07:00',
+        reportingPeriodStart: '2010-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2010-12-31T23:59:59-08:00'
+      },
+      jsonSchemaErrors
+    );
+    expect(resultingErrors.__errors).not.toContain(
+      ERRORS.APPLICATION_WINDOW_OVERLAPS
+    );
+  });
+  it('Reporting period overlap with that of another existing year should add an error', () => {
+    const resultingErrors = validateExclusiveDateRanges(
+      2030,
+      existingYears,
+      {
+        applicationOpenTime: '2031-07-03T00:00:00-07:00',
+        applicationCloseTime: '2031-08-31T23:59:59.999999-07:00',
+        reportingPeriodStart: '2020-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2020-12-31T23:59:59-08:00'
+      },
+      jsonSchemaErrors
+    );
+    expect(resultingErrors.__errors).toContain(
+      ERRORS.REPORTING_PERIOD_OVERLAPS
+    );
+  });
+  it('Reporting period that does not overlap with existing years should not add an error', () => {
+    const resultingErrors = validateExclusiveDateRanges(
+      2030,
+      existingYears,
+      {
+        applicationOpenTime: '2031-07-03T00:00:00-07:00',
+        applicationCloseTime: '2031-08-31T23:59:59.999999-07:00',
+        reportingPeriodStart: '2030-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2030-12-31T23:59:59-08:00'
+      },
+      jsonSchemaErrors
+    );
+    expect(resultingErrors.__errors).not.toContain(
+      ERRORS.REPORTING_PERIOD_OVERLAPS
+    );
+  });
+});
+
+describe('Reporting period admin validation functions: application open/close dates)', () => {
+  let jsonSchemaErrors;
+
+  beforeEach(() => {
+    jsonSchemaErrors = new FakeJsonSchemaErrors();
+  });
+
+  it('Past application open date should add an error', () => {
+    const resultingErrors = validateApplicationDates(
+      existingYears,
+      {
+        reportingPeriodStart: '2010-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2010-12-31T23:59:59-08:00',
+        applicationOpenTime: '2011-07-03T00:00:00-07:00',
+        applicationCloseTime: '2011-08-31T23:59:59.999999-07:00'
+      },
+      jsonSchemaErrors,
+      {
+        applicationOpenTime: {
+          'ui:disabled': false
+        },
+        applicationCloseTime: {
+          'ui:disabled': false
+        }
+      },
+      true
+    );
+    expect(resultingErrors.__errors).toContain(
+      `${ERRORS.PAST_DATE} Application open time`
+    );
+  });
+  it('Present or future application open date should not add an error', () => {
+    const resultingErrors1 = validateApplicationDates(
+      existingYears,
+      {
+        reportingPeriodStart: '2030-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2030-12-31T23:59:59-08:00',
+        applicationOpenTime: TODAY,
+        applicationCloseTime: '2031-08-31T23:59:59.999999-07:00'
+      },
+      jsonSchemaErrors,
+      {
+        applicationOpenTime: {
+          'ui:disabled': false
+        },
+        applicationCloseTime: {
+          'ui:disabled': false
+        }
+      },
+      true
+    );
+    expect(resultingErrors1.__errors).not.toContain(
+      `${ERRORS.PAST_DATE} Application open time`
+    );
+
+    const resultingErrors2 = validateApplicationDates(
+      existingYears,
+      {
+        reportingPeriodStart: '2030-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2030-12-31T23:59:59-08:00',
+        applicationOpenTime: '2031-07-03T00:00:00-07:00',
+        applicationCloseTime: '2031-08-31T23:59:59.999999-07:00'
+      },
+      jsonSchemaErrors,
+      {
+        applicationOpenTime: {
+          'ui:disabled': false
+        },
+        applicationCloseTime: {
+          'ui:disabled': false
+        }
+      },
+      true
+    );
+    expect(resultingErrors2.__errors).not.toContain(
+      `${ERRORS.PAST_DATE} Application open time`
+    );
+  });
+  it('Past application close date (when this validation is enabled) should add an error', () => {
+    const resultingErrors = validateApplicationDates(
+      existingYears,
+      {
+        reportingPeriodStart: '2010-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2010-12-31T23:59:59-08:00',
+        applicationOpenTime: '2011-07-03T00:00:00-07:00',
+        applicationCloseTime: '2011-08-31T23:59:59.999999-07:00'
+      },
+      jsonSchemaErrors,
+      {
+        applicationOpenTime: {
+          'ui:disabled': false
+        },
+        applicationCloseTime: {
+          'ui:disabled': false
+        }
+      },
+      true
+    );
+    expect(resultingErrors.__errors).toContain(
+      `${ERRORS.PAST_DATE} Application close time`
+    );
+  });
+  it('Present or future application close date (when this validation is enabled) should not add an error', () => {
+    const resultingErrors1 = validateApplicationDates(
+      existingYears,
+      {
+        reportingPeriodStart: '2010-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2010-12-31T23:59:59-08:00',
+        applicationOpenTime: TODAY,
+        applicationCloseTime: '2031-08-31T23:59:59.999999-07:00'
+      },
+      jsonSchemaErrors,
+      {
+        applicationOpenTime: {
+          'ui:disabled': false
+        },
+        applicationCloseTime: {
+          'ui:disabled': false
+        }
+      },
+      true
+    );
+    expect(resultingErrors1.__errors).not.toContain(
+      `${ERRORS.PAST_DATE} Application close time`
+    );
+
+    const resultingErrors2 = validateApplicationDates(
+      existingYears,
+      {
+        reportingPeriodStart: '2010-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2010-12-31T23:59:59-08:00',
+        applicationOpenTime: '2031-07-03T00:00:00-07:00',
+        applicationCloseTime: '2031-08-31T23:59:59.999999-07:00'
+      },
+      jsonSchemaErrors,
+      {
+        applicationOpenTime: {
+          'ui:disabled': false
+        },
+        applicationCloseTime: {
+          'ui:disabled': false
+        }
+      },
+      true
+    );
+    expect(resultingErrors2.__errors).not.toContain(
+      `${ERRORS.PAST_DATE} Application close time`
+    );
+  });
+  it('Past application close date (when this validation is disabled) should not add an error', () => {
+    const resultingErrors = validateApplicationDates(
+      existingYears,
+      {
+        reportingPeriodStart: '2010-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2010-12-31T23:59:59-08:00',
+        applicationOpenTime: '2011-07-03T00:00:00-07:00',
+        applicationCloseTime: '2011-08-31T23:59:59.999999-07:00'
+      },
+      jsonSchemaErrors,
+      {
+        applicationOpenTime: {
+          'ui:disabled': false
+        },
+        applicationCloseTime: {
+          'ui:disabled': false
+        }
+      },
+      false
+    );
+    expect(resultingErrors.__errors).not.toContain(
+      `${ERRORS.PAST_DATE} Application close time`
+    );
+  });
+  it('Application close date that occurs before the open date should add an error', () => {
+    const resultingErrors = validateApplicationDates(
+      existingYears,
+      {
+        reportingPeriodStart: '2030-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2030-12-31T23:59:59-08:00',
+        applicationOpenTime: '2031-07-03T00:00:00-07:00',
+        applicationCloseTime: '2031-04-01T23:59:59.999999-07:00'
+      },
+      jsonSchemaErrors,
+      {
+        applicationOpenTime: {
+          'ui:disabled': false
+        },
+        applicationCloseTime: {
+          'ui:disabled': false
+        }
+      },
+      true
+    );
+    expect(resultingErrors.__errors).toContain(ERRORS.CLOSE_BEFORE_OPEN_DATE);
+  });
+  it('Sequential application open and close dates should not add an error', () => {
+    const resultingErrors = validateApplicationDates(
+      existingYears,
+      {
+        reportingPeriodStart: '2030-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2030-12-31T23:59:59-08:00',
+        applicationOpenTime: '2031-04-03T00:00:00-07:00',
+        applicationCloseTime: '2031-07-01T23:59:59.999999-07:00'
+      },
+      jsonSchemaErrors,
+      {
+        applicationOpenTime: {
+          'ui:disabled': false
+        },
+        applicationCloseTime: {
+          'ui:disabled': false
+        }
+      },
+      true
+    );
+    expect(resultingErrors.__errors).not.toContain(
+      ERRORS.CLOSE_BEFORE_OPEN_DATE
+    );
+  });
+  it('Application close date that occurs before the end of the reporting period should add an error', () => {
+    const resultingErrors = validateApplicationDates(
+      existingYears,
+      {
+        reportingPeriodStart: '2030-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2030-12-31T23:59:59-08:00',
+        applicationOpenTime: '2030-07-03T00:00:00-07:00',
+        applicationCloseTime: '2030-08-01T23:59:59.999999-07:00'
+      },
+      jsonSchemaErrors,
+      {
+        applicationOpenTime: {
+          'ui:disabled': false
+        },
+        applicationCloseTime: {
+          'ui:disabled': false
+        }
+      },
+      true
+    );
+    expect(resultingErrors.__errors).toContain(
+      ERRORS.CLOSE_BEFORE_REPORTING_END
+    );
+  });
+  it('Application close date that occurs after the end of the reporting period should not add an error', () => {
+    const resultingErrors = validateApplicationDates(
+      existingYears,
+      {
+        reportingPeriodStart: '2030-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2030-12-31T23:59:59-08:00',
+        applicationOpenTime: '2031-07-03T00:00:00-07:00',
+        applicationCloseTime: '2031-08-01T23:59:59.999999-07:00'
+      },
+      jsonSchemaErrors,
+      {
+        applicationOpenTime: {
+          'ui:disabled': false
+        },
+        applicationCloseTime: {
+          'ui:disabled': false
+        }
+      },
+      true
+    );
+    expect(resultingErrors.__errors).not.toContain(
+      ERRORS.CLOSE_BEFORE_REPORTING_END
+    );
+  });
+  it('Application date validation should be skipped for disabled inputs (not add an error)', () => {
+    const resultingErrors = validateApplicationDates(
+      existingYears,
+      {
+        reportingPeriodStart: '2030-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2030-12-31T23:59:59-08:00',
+        applicationOpenTime: '2010-09-03T00:00:00-07:00',
+        applicationCloseTime: '2010-08-01T23:59:59.999999-07:00'
+      },
+      jsonSchemaErrors,
+      {
+        applicationOpenTime: {
+          'ui:disabled': true
+        },
+        applicationCloseTime: {
+          'ui:disabled': true
+        }
+      },
+      true
+    );
+    expect(resultingErrors.__errors).toBeEmpty();
+  });
+});
+
+describe('Reporting period admin validation functions: reporting period start/end dates)', () => {
+  let jsonSchemaErrors;
+
+  beforeEach(() => {
+    jsonSchemaErrors = new FakeJsonSchemaErrors();
+  });
+
+  it('Reporting period end that occurs before the reporting period start should add an error', () => {
+    const resultingErrors = validateReportingDates(
+      {
+        reportingYear: 2030,
+        reportingPeriodStart: '2030-12-31T23:59:59-08:00',
+        reportingPeriodEnd: '2030-01-01T00:00:00-08:00'
+      },
+      jsonSchemaErrors
+    );
+    expect(resultingErrors.__errors).toContain(ERRORS.END_BEFORE_START);
+  });
+
+  it('Sequential reporting period start before end should not add an error', () => {
+    const resultingErrors = validateReportingDates(
+      {
+        reportingYear: 2030,
+        reportingPeriodStart: '2030-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2030-12-31T23:59:59-08:00'
+      },
+      jsonSchemaErrors
+    );
+    expect(resultingErrors.__errors).not.toContain(ERRORS.END_BEFORE_START);
+  });
+
+  it('Reporting year that does not occur between the reporting period start and end should add an error', () => {
+    const resultingErrors = validateReportingDates(
+      {
+        reportingYear: 2031,
+        reportingPeriodStart: '2030-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2030-12-31T23:59:59-08:00'
+      },
+      jsonSchemaErrors
+    );
+    expect(resultingErrors.__errors).toContain(ERRORS.REPORTING_YEAR);
+  });
+
+  it('Reporting year that occurs between the reporting period start and end should not add an error', () => {
+    const resultingErrors = validateReportingDates(
+      {
+        reportingYear: 2030,
+        reportingPeriodStart: '2030-01-01T00:00:00-08:00',
+        reportingPeriodEnd: '2030-12-31T23:59:59-08:00'
+      },
+      jsonSchemaErrors
+    );
+    expect(resultingErrors.__errors).not.toContain(ERRORS.REPORTING_YEAR);
+  });
+});
+
+describe('Reporting period admin validation functions: reporting year key uniqueness', () => {
+  let jsonSchemaErrors;
+
+  beforeEach(() => {
+    jsonSchemaErrors = new FakeJsonSchemaErrors();
+  });
+
+  it('Entering a year that already exists for a new reporting period should add an error', () => {
+    const resultingErrors = validateUniqueKey(
+      [2019, 2020, 2021],
+      {
+        reportingYear: 2020
+      },
+      jsonSchemaErrors
+    );
+    expect(resultingErrors.__errors).toContain(ERRORS.NON_UNIQUE_KEY);
+  });
+
+  it('Entering a unique year for a new reporting period should not add an error', () => {
+    const resultingErrors = validateUniqueKey(
+      [2019, 2020, 2021],
+      {
+        reportingYear: 2030
+      },
+      jsonSchemaErrors
+    );
+    expect(resultingErrors.__errors).not.toContain(ERRORS.NON_UNIQUE_KEY);
+  });
+});

--- a/app/tests/unit/containers/ReportingYear/__snapshots__/ReportingYearFormDialog.test.tsx.snap
+++ b/app/tests/unit/containers/ReportingYear/__snapshots__/ReportingYearFormDialog.test.tsx.snap
@@ -71,7 +71,6 @@ exports[`ReportingYearFormDialog Should match last accepted snapshot: no inputs 
           uiSchema={
             Object {
               "applicationCloseTime": Object {
-                "ui:disabled": false,
                 "ui:widget": "DatePickerWidget",
               },
               "applicationOpenTime": Object {
@@ -694,7 +693,6 @@ exports[`ReportingYearFormDialog Should match last accepted snapshot: some past 
           uiSchema={
             Object {
               "applicationCloseTime": Object {
-                "ui:disabled": false,
                 "ui:widget": "DatePickerWidget",
               },
               "applicationOpenTime": Object {


### PR DESCRIPTION
- If there's currently an open application window, then no previous application window dates can be changed
  - prevents overlapping application windows, which the system cannot handle
- If there's **no** open application window, then the most recently closed application close date can be changed
- Adds validation to ensure when editing date ranges a) for the application window, and b) for the reporting years start/end that the proposed dates do not overlap with that of another reporting period.

[GGIRCS-2022](https://youtrack.button.is/issue/GGIRCS-2022)