### PR TITLE
"Revise Application" button should be "Resume Latest Draft" if one exists

### DIFF
--- a/app/containers/Applications/ReviseApplicationButtonContainer.tsx
+++ b/app/containers/Applications/ReviseApplicationButtonContainer.tsx
@@ -15,6 +15,14 @@ export const ReviseApplicationButton: React.FunctionComponent<Props> = ({
   relay
 }) => {
   const router = useRouter();
+  const newerDraftExists =
+    application.latestDraftRevision.versionNumber > application.latestSubmittedRevision.versionNumber;
+  const newerDraftURL = `/reporter/application?applicationId=${
+    encodeURIComponent(application.id)
+  }&version=${
+    application.latestDraftRevision.versionNumber
+  }`;
+
   const handleClick = async () => {
     const variables = {
       input: {
@@ -48,9 +56,20 @@ export const ReviseApplicationButton: React.FunctionComponent<Props> = ({
 
   return (
     <Col>
-      <Button variant="success" onClick={handleClick}>
-        Revise Application
-      </Button>
+      {newerDraftExists ?
+        <>
+          <p style={{margin: '1rem 0'}}>
+            <strong>Note:</strong> This application has been revised in a more recent draft:
+          </p>
+          <a href={newerDraftURL}>
+            <Button>Resume latest draft</Button>
+          </a>
+        </>
+        :
+        <Button variant="success" onClick={handleClick}>
+          Revise Application
+        </Button>
+      }
     </Col>
   );
 };
@@ -60,6 +79,9 @@ export default createFragmentContainer(ReviseApplicationButton, {
     fragment ReviseApplicationButtonContainer_application on Application {
       id
       rowId
+      latestDraftRevision {
+        versionNumber
+      }
       latestSubmittedRevision {
         versionNumber
       }

--- a/app/containers/Applications/ReviseApplicationButtonContainer.tsx
+++ b/app/containers/Applications/ReviseApplicationButtonContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {useRouter} from 'next/router';
 import Link from 'next/link';
 import {Button, Col} from 'react-bootstrap';
@@ -17,11 +17,16 @@ export const ReviseApplicationButton: React.FunctionComponent<Props> = ({
 }) => {
   const router = useRouter();
   const thisVersion = Number(router.query.version);
-  const newerSubmissionExists =
-    application.latestSubmittedRevision.versionNumber > thisVersion;
-  const latestSubmissionURL = `/reporter/view-application?applicationId=${
-    encodeURIComponent(application.id)
-  }&version=${application.latestSubmittedRevision.versionNumber}`;
+  const [latestSubmittedRevision] = useState(
+    application.latestSubmittedRevision.versionNumber
+  );
+  const [latestDraftRevision] = useState(
+    application.latestDraftRevision.versionNumber
+  );
+  const newerSubmissionExists = latestSubmittedRevision > thisVersion;
+  const latestSubmissionURL = `/reporter/view-application?applicationId=${encodeURIComponent(
+    application.id
+  )}&version=${latestSubmittedRevision}`;
   const viewLatestSubmissionButton = (
     <>
       <p style={{margin: '1rem 0'}}>
@@ -36,13 +41,10 @@ export const ReviseApplicationButton: React.FunctionComponent<Props> = ({
     </>
   );
 
-  const newerDraftExists =
-    application.latestDraftRevision.versionNumber > application.latestSubmittedRevision.versionNumber;
-  const newerDraftURL = `/reporter/application?applicationId=${
-    encodeURIComponent(application.id)
-  }&version=${
-    application.latestDraftRevision.versionNumber
-  }`;
+  const newerDraftExists = latestDraftRevision > latestSubmittedRevision;
+  const newerDraftURL = `/reporter/application?applicationId=${encodeURIComponent(
+    application.id
+  )}&version=${latestDraftRevision}`;
   const resumeLatestDraftButton = (
     <>
       <p style={{margin: '1rem 0'}}>
@@ -61,7 +63,7 @@ export const ReviseApplicationButton: React.FunctionComponent<Props> = ({
     const variables = {
       input: {
         applicationIdInput: application.rowId,
-        lastRevisionIdInput: application.latestSubmittedRevision.versionNumber
+        lastRevisionIdInput: latestSubmittedRevision
       }
     };
 

--- a/app/containers/Applications/ReviseApplicationButtonContainer.tsx
+++ b/app/containers/Applications/ReviseApplicationButtonContainer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {useRouter} from 'next/router';
+import Link from 'next/link';
 import {Button, Col} from 'react-bootstrap';
 import createApplicationRevisionMutation from 'mutations/application/createApplicationRevisionMutation';
 import {createFragmentContainer, graphql, RelayProp} from 'react-relay';
@@ -15,6 +16,26 @@ export const ReviseApplicationButton: React.FunctionComponent<Props> = ({
   relay
 }) => {
   const router = useRouter();
+  const thisVersion = Number(router.query.version);
+  const newerSubmissionExists =
+    application.latestSubmittedRevision.versionNumber > thisVersion;
+  const latestSubmissionURL = `/reporter/view-application?applicationId=${
+    encodeURIComponent(application.id)
+  }&version=${application.latestSubmittedRevision.versionNumber}`;
+  const viewLatestSubmissionButton = (
+    <>
+      <p style={{margin: '1rem 0'}}>
+        <strong>Note:</strong> There is a more recently submitted version of
+        this application.
+      </p>
+      <Link href={latestSubmissionURL}>
+        <a>
+          <Button>View most recent submission</Button>
+        </a>
+      </Link>
+    </>
+  );
+
   const newerDraftExists =
     application.latestDraftRevision.versionNumber > application.latestSubmittedRevision.versionNumber;
   const newerDraftURL = `/reporter/application?applicationId=${
@@ -22,6 +43,19 @@ export const ReviseApplicationButton: React.FunctionComponent<Props> = ({
   }&version=${
     application.latestDraftRevision.versionNumber
   }`;
+  const resumeLatestDraftButton = (
+    <>
+      <p style={{margin: '1rem 0'}}>
+        <strong>Note:</strong> This application has been revised in a more
+        recent draft.
+      </p>
+      <Link href={newerDraftURL}>
+        <a>
+          <Button>Resume latest draft</Button>
+        </a>
+      </Link>
+    </>
+  );
 
   const handleClick = async () => {
     const variables = {
@@ -56,20 +90,14 @@ export const ReviseApplicationButton: React.FunctionComponent<Props> = ({
 
   return (
     <Col>
-      {newerDraftExists ?
-        <>
-          <p style={{margin: '1rem 0'}}>
-            <strong>Note:</strong> This application has been revised in a more recent draft:
-          </p>
-          <a href={newerDraftURL}>
-            <Button>Resume latest draft</Button>
-          </a>
-        </>
-        :
+      {newerSubmissionExists ? viewLatestSubmissionButton :
+      newerDraftExists ? (
+        resumeLatestDraftButton
+      ) : (
         <Button variant="success" onClick={handleClick}>
           Revise Application
         </Button>
-      }
+      )}
     </Col>
   );
 };

--- a/app/tests/unit/containers/Applications/ReviseApplicationButtonContainer.test.tsx
+++ b/app/tests/unit/containers/Applications/ReviseApplicationButtonContainer.test.tsx
@@ -3,7 +3,12 @@ import {shallow} from 'enzyme';
 import {ReviseApplicationButton} from 'containers/Applications/ReviseApplicationButtonContainer';
 
 describe('The ReviseApplicationButton', () => {
-  it('should render an button', () => {
+  const useRouter = jest.spyOn(require('next/router'), 'useRouter');
+  useRouter.mockImplementation(() => {
+    return {query: {version: 1}};
+  });
+
+  it('should render a "Revise" button when the version being viewed === the latest draft version (there is not yet a newer draft)', () => {
     const r = shallow(
       <ReviseApplicationButton
         relay={null}
@@ -11,6 +16,9 @@ describe('The ReviseApplicationButton', () => {
           ' $refType': 'ReviseApplicationButtonContainer_application',
           id: 'foo',
           rowId: 1,
+          latestDraftRevision: {
+            versionNumber: 1
+          },
           latestSubmittedRevision: {
             versionNumber: 1
           }
@@ -21,5 +29,51 @@ describe('The ReviseApplicationButton', () => {
     expect(r).toMatchSnapshot();
     expect(r.exists('Button')).toBe(true);
     expect(r.find('Button').text()).toBe('Revise Application');
+  });
+
+  it('should render a "View most recent submission" button when viewing an older submission (viewed version < last submitted version)', () => {
+    const r = shallow(
+      <ReviseApplicationButton
+        relay={null}
+        application={{
+          ' $refType': 'ReviseApplicationButtonContainer_application',
+          id: 'foo',
+          rowId: 1,
+          latestDraftRevision: {
+            versionNumber: 2
+          },
+          latestSubmittedRevision: {
+            versionNumber: 2
+          }
+        }}
+      />
+    );
+
+    expect(r).toMatchSnapshot();
+    expect(r.exists('Button')).toBe(true);
+    expect(r.find('Button').text()).toBe('View most recent submission');
+  });
+
+  it('should render a "Resume latest draft" button when a new draft exists (but has not yet been submitted)', () => {
+    const r = shallow(
+      <ReviseApplicationButton
+        relay={null}
+        application={{
+          ' $refType': 'ReviseApplicationButtonContainer_application',
+          id: 'foo',
+          rowId: 1,
+          latestDraftRevision: {
+            versionNumber: 2
+          },
+          latestSubmittedRevision: {
+            versionNumber: 1
+          }
+        }}
+      />
+    );
+
+    expect(r).toMatchSnapshot();
+    expect(r.exists('Button')).toBe(true);
+    expect(r.find('Button').text()).toBe('Resume latest draft');
   });
 });

--- a/app/tests/unit/containers/Applications/__snapshots__/ReviseApplicationButtonContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ReviseApplicationButtonContainer.test.tsx.snap
@@ -1,6 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`The ReviseApplicationButton should render an button 1`] = `
+exports[`The ReviseApplicationButton should render a "Resume latest draft" button when a new draft exists (but has not yet been submitted) 1`] = `
+<Col>
+  <p
+    style={
+      Object {
+        "margin": "1rem 0",
+      }
+    }
+  >
+    <strong>
+      Note:
+    </strong>
+     This application has been revised in a more recent draft.
+  </p>
+  <Link
+    href="/reporter/application?applicationId=foo&version=2"
+  >
+    <a>
+      <Button
+        active={false}
+        disabled={false}
+        type="button"
+        variant="primary"
+      >
+        Resume latest draft
+      </Button>
+    </a>
+  </Link>
+</Col>
+`;
+
+exports[`The ReviseApplicationButton should render a "Revise" button when the version being viewed === the latest draft version (there is not yet a newer draft) 1`] = `
 <Col>
   <Button
     active={false}
@@ -11,5 +42,36 @@ exports[`The ReviseApplicationButton should render an button 1`] = `
   >
     Revise Application
   </Button>
+</Col>
+`;
+
+exports[`The ReviseApplicationButton should render a "View most recent submission" button when viewing an older submission (viewed version < last submitted version) 1`] = `
+<Col>
+  <p
+    style={
+      Object {
+        "margin": "1rem 0",
+      }
+    }
+  >
+    <strong>
+      Note:
+    </strong>
+     There is a more recently submitted version of this application.
+  </p>
+  <Link
+    href="/reporter/view-application?applicationId=foo&version=2"
+  >
+    <a>
+      <Button
+        active={false}
+        disabled={false}
+        type="button"
+        variant="primary"
+      >
+        View most recent submission
+      </Button>
+    </a>
+  </Link>
 </Col>
 `;


### PR DESCRIPTION
In viewing a submitted application (for example from an old email link requesting changes to the application) at `/reporter/view-application`, if a newer draft has already been created, the "Revise" button will instead show:

a) "Resume latest draft" if the latest draft's version number is greater than the latest submitted version
b) "View most recent submission" if they're viewing a really old version, where a new version has already been revised and submitted
  * even if this newer submission has had changes requested, they can first navigate to the newer submission to view analyst comments before clicking either "Revise" or "Resume latest draft" on that version.

There is no change in appearance or behavior for the case where the submitted revision is still the most recent revision.

[GGIRCS-2047](https://youtrack.button.is/issue/GGIRCS-2047)

<img width="818" alt="a) Resume latest draft" src="https://user-images.githubusercontent.com/5522075/100265520-3d9d6800-2f05-11eb-81a9-13efc19f4066.png">

<img width="771" alt="b) View most recent submission" src="https://user-images.githubusercontent.com/5522075/100967814-028ecc00-34e5-11eb-916a-2d542d675318.png">

