### PR TITLE
fix: upgrade nodejs to 12.20.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-nodejs 12.16.1
+nodejs 12.20.1
 yarn 1.22.0
 postgres 11.4
 python 3.7.0

--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint --ext .js,.jsx,.ts,.tsx ."
   },
   "engines": {
-    "node": "12.16.1",
+    "node": "12.20.1",
     "yarn": "1.22.0"
   },
   "author": "",


### PR DESCRIPTION
Fixes high-severity CVE-2020-8265