### PR TITLE
Happo snapshots should frame entire page

### DIFF
--- a/app/cypress/integration/application-form-validation.spec.js
+++ b/app/cypress/integration/application-form-validation.spec.js
@@ -136,6 +136,7 @@ describe('When reviewing a submitted application as an analyst', () => {
     cy.contains('Continue').click();
     cy.get('#page-content h1').contains('Emission');
     cy.visit(summaryPageUrl);
+    cy.contains('Administration Data');
     cy.get('body').happoScreenshot({
       component: 'Admin Summary Card',
       variant: 'no errors'
@@ -154,6 +155,7 @@ describe('When reviewing a submitted application as an analyst', () => {
     ).contains('is a required property');
 
     cy.visit(summaryPageUrl);
+    cy.contains('Emission');
     cy.get('body').happoScreenshot({
       component: 'Emission Summary Card',
       variant: 'with errors'
@@ -167,6 +169,7 @@ describe('When reviewing a submitted application as an analyst', () => {
     cy.contains('Continue').click();
     cy.get('#page-content h1').contains('Fuel');
     cy.visit(summaryPageUrl);
+    cy.contains('Emission');
     cy.get('body').happoScreenshot({
       component: 'Emission Summary Card',
       variant: 'no errors'
@@ -187,6 +190,7 @@ describe('When reviewing a submitted application as an analyst', () => {
     );
 
     cy.visit(summaryPageUrl);
+    cy.contains('Fuel');
     cy.get('body').happoScreenshot({
       component: 'Fuel Summary Card',
       variant: 'with errors'
@@ -205,6 +209,7 @@ describe('When reviewing a submitted application as an analyst', () => {
     cy.contains('Continue').click();
     cy.get('#page-content h1').contains('Production');
     cy.visit(summaryPageUrl);
+    cy.contains('Fuel');
     cy.get('body').happoScreenshot({
       component: 'Fuel Summary Card',
       variant: 'no errors'
@@ -229,6 +234,7 @@ describe('When reviewing a submitted application as an analyst', () => {
     );
 
     cy.visit(summaryPageUrl);
+    cy.contains('Production');
     cy.get('body').happoScreenshot({
       component: 'Production Summary Card',
       variant: 'with errors'

--- a/app/cypress/integration/application-form-validation.spec.js
+++ b/app/cypress/integration/application-form-validation.spec.js
@@ -114,7 +114,8 @@ describe('When reviewing a submitted application as an analyst', () => {
       variant: 'open'
     });
     cy.get('#overrideJustification').clear().type('justification goes here');
-    cy.get('.btn-success').click();
+    cy.get('.btn-success').contains('Save').click();
+    cy.contains('You have chosen to override');
     cy.get('body').happoScreenshot({
       component: 'Override Justification',
       variant: 'override active'

--- a/app/cypress/integration/application-form-validation.spec.js
+++ b/app/cypress/integration/application-form-validation.spec.js
@@ -27,7 +27,7 @@ describe('When reviewing a submitted application as an analyst', () => {
   it('The application admin form shows validation errors', () => {
     cy.visit(adminFormUrl);
     cy.get('#page-content');
-    cy.get('form.rjsf').happoScreenshot({component: 'Administration Form'});
+    cy.get('body').happoScreenshot({component: 'Administration Form'});
 
     // Operator details
     cy.get('#root_operator_name').clear().type('John Smith');
@@ -98,24 +98,24 @@ describe('When reviewing a submitted application as an analyst', () => {
     );
     cy.get('.admin > .collapse').contains('Format should be A1A 1A1');
     cy.get('.admin > .collapse').contains('BCGHGID code should be numeric');
-    cy.get('.admin.summary-card').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Admin Summary Card',
       variant: 'with errors'
     });
 
     // Override Justification screenshots
-    cy.get('.fade').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Override Justification',
       variant: 'closed'
     });
     cy.get('.override-accordion > .btn').click();
-    cy.get('.fade').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Override Justification',
       variant: 'open'
     });
     cy.get('#overrideJustification').clear().type('justification goes here');
     cy.get('.btn-success').click();
-    cy.get('.alert-secondary').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Override Justification',
       variant: 'override active'
     });
@@ -136,7 +136,7 @@ describe('When reviewing a submitted application as an analyst', () => {
     cy.contains('Continue').click();
     cy.get('#page-content h1').contains('Emission');
     cy.visit(summaryPageUrl);
-    cy.get('.admin.summary-card').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Admin Summary Card',
       variant: 'no errors'
     });
@@ -154,7 +154,7 @@ describe('When reviewing a submitted application as an analyst', () => {
     ).contains('is a required property');
 
     cy.visit(summaryPageUrl);
-    cy.get('.emission.summary-card').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Emission Summary Card',
       variant: 'with errors'
     });
@@ -162,12 +162,12 @@ describe('When reviewing a submitted application as an analyst', () => {
 
     // Fix invalid data
     cy.get('#root_sourceTypes_0_gases_0_annualEmission').type('42');
-    cy.get('form.rjsf').happoScreenshot({component: 'Emissions form'});
+    cy.get('body').happoScreenshot({component: 'Emissions form'});
     cy.get('div.card-header').contains('Form input saved');
     cy.contains('Continue').click();
     cy.get('#page-content h1').contains('Fuel');
     cy.visit(summaryPageUrl);
-    cy.get('.emission.summary-card').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Emission Summary Card',
       variant: 'no errors'
     });
@@ -187,7 +187,7 @@ describe('When reviewing a submitted application as an analyst', () => {
     );
 
     cy.visit(summaryPageUrl);
-    cy.get('.fuel.summary-card').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Fuel Summary Card',
       variant: 'with errors'
     });
@@ -200,12 +200,12 @@ describe('When reviewing a submitted application as an analyst', () => {
     cy.get('#root_0_emissionCategoryRowId').select(
       'General Stationary Combustion'
     );
-    cy.get('form.rjsf').happoScreenshot({component: 'Fuels Form'});
+    cy.get('body').happoScreenshot({component: 'Fuels Form'});
     cy.get('div.card-header').contains('Form input saved');
     cy.contains('Continue').click();
     cy.get('#page-content h1').contains('Production');
     cy.visit(summaryPageUrl);
-    cy.get('.fuel.summary-card').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Fuel Summary Card',
       variant: 'no errors'
     });
@@ -229,7 +229,7 @@ describe('When reviewing a submitted application as an analyst', () => {
     );
 
     cy.visit(summaryPageUrl);
-    cy.get('.production.summary-card').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Production Summary Card',
       variant: 'with errors'
     });
@@ -241,13 +241,13 @@ describe('When reviewing a submitted application as an analyst', () => {
     cy.get('#root_0_productAmount').type('123');
     cy.get('#root_0_productEmissions').type('456');
 
-    cy.get('form.rjsf').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Products and Energy Form'
     });
     cy.get('div.card-header').contains('Form input saved');
     cy.contains('Continue').click();
     cy.get('#page-content h1').contains('Summary');
-    cy.get('.production.summary-card').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Production Summary Card',
       variant: 'no errors'
     });

--- a/app/cypress/integration/application-form-validation.spec.js
+++ b/app/cypress/integration/application-form-validation.spec.js
@@ -98,7 +98,7 @@ describe('When reviewing a submitted application as an analyst', () => {
     );
     cy.get('.admin > .collapse').contains('Format should be A1A 1A1');
     cy.get('.admin > .collapse').contains('BCGHGID code should be numeric');
-    cy.get('body').happoScreenshot({
+    cy.get('.admin.summary-card').happoScreenshot({
       component: 'Admin Summary Card',
       variant: 'with errors'
     });
@@ -137,7 +137,7 @@ describe('When reviewing a submitted application as an analyst', () => {
     cy.get('#page-content h1').contains('Emission');
     cy.visit(summaryPageUrl);
     cy.contains('Administration Data');
-    cy.get('body').happoScreenshot({
+    cy.get('.admin.summary-card').happoScreenshot({
       component: 'Admin Summary Card',
       variant: 'no errors'
     });
@@ -156,7 +156,7 @@ describe('When reviewing a submitted application as an analyst', () => {
 
     cy.visit(summaryPageUrl);
     cy.contains('Emission');
-    cy.get('body').happoScreenshot({
+    cy.get('.emission.summary-card').happoScreenshot({
       component: 'Emission Summary Card',
       variant: 'with errors'
     });
@@ -170,7 +170,7 @@ describe('When reviewing a submitted application as an analyst', () => {
     cy.get('#page-content h1').contains('Fuel');
     cy.visit(summaryPageUrl);
     cy.contains('Emission');
-    cy.get('body').happoScreenshot({
+    cy.get('.emission.summary-card').happoScreenshot({
       component: 'Emission Summary Card',
       variant: 'no errors'
     });
@@ -191,7 +191,7 @@ describe('When reviewing a submitted application as an analyst', () => {
 
     cy.visit(summaryPageUrl);
     cy.contains('Fuel');
-    cy.get('body').happoScreenshot({
+    cy.get('.fuel.summary-card').happoScreenshot({
       component: 'Fuel Summary Card',
       variant: 'with errors'
     });
@@ -210,7 +210,7 @@ describe('When reviewing a submitted application as an analyst', () => {
     cy.get('#page-content h1').contains('Production');
     cy.visit(summaryPageUrl);
     cy.contains('Fuel');
-    cy.get('body').happoScreenshot({
+    cy.get('.fuel.summary-card').happoScreenshot({
       component: 'Fuel Summary Card',
       variant: 'no errors'
     });
@@ -235,7 +235,7 @@ describe('When reviewing a submitted application as an analyst', () => {
 
     cy.visit(summaryPageUrl);
     cy.contains('Production');
-    cy.get('body').happoScreenshot({
+    cy.get('.production.summary-card').happoScreenshot({
       component: 'Production Summary Card',
       variant: 'with errors'
     });
@@ -253,7 +253,7 @@ describe('When reviewing a submitted application as an analyst', () => {
     cy.get('div.card-header').contains('Form input saved');
     cy.contains('Continue').click();
     cy.get('#page-content h1').contains('Summary');
-    cy.get('body').happoScreenshot({
+    cy.get('.production.summary-card').happoScreenshot({
       component: 'Production Summary Card',
       variant: 'no errors'
     });

--- a/app/cypress/integration/index.spec.js
+++ b/app/cypress/integration/index.spec.js
@@ -10,7 +10,7 @@ describe('The index page', () => {
     cy.get('#page-content').contains(
       'Already have an account? Click here to login.'
     );
-    cy.get('#page-content').happoScreenshot({component: 'Index Page'});
+    cy.get('body').happoScreenshot({component: 'Index Page'});
   });
 
   it('does not contain the mocked database field', () => {

--- a/app/cypress/integration/product-benchmark.spec.js
+++ b/app/cypress/integration/product-benchmark.spec.js
@@ -41,7 +41,7 @@ describe('The benchmark modal', () => {
     cy.get('#root_minimumIncentiveRatio').should('have.value', '0');
     cy.get('#root_maximumIncentiveRatio').should('have.value', '1');
     cy.get('.rjsf > .btn').contains('Save');
-    cy.get('.modal-body > .container').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Benchmark Modal'
     });
     cy.get('.close > [aria-hidden="true"]').click();
@@ -111,7 +111,7 @@ describe('The linking modal', () => {
     cy.get('.modal-body > .container')
       .contains('Product B')
       .should('not.exist');
-    cy.get('.modal-body > .container').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Link Product Modal'
     });
   });
@@ -160,7 +160,7 @@ describe('The Create Product modal', () => {
     cy.get(
       '#root_subtractGeneratedHeatEmissions > :nth-child(1) > label > :nth-child(1) > input'
     ).click();
-    cy.get('.card-body').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Create Product Modal'
     });
     cy.contains('Add Product').click();

--- a/app/cypress/integration/reporter-certifier-access.spec.js
+++ b/app/cypress/integration/reporter-certifier-access.spec.js
@@ -29,12 +29,14 @@ describe('When logged in as a certifier(reporter)', () => {
     cy.contains('Legal Disclaimer');
     cy.contains('View').click();
     cy.url().should('include', '/certifier/certify');
+    cy.contains('Certifier Signature');
     cy.get('body').happoScreenshot({
       component: 'Certification Page'
     });
     cy.visit('/reporter');
     cy.get('.alert-link').contains('View all certification requests.').click();
     cy.url().should('include', '/certifier/requests');
+    cy.contains('View');
     cy.get('body').happoScreenshot({
       component: 'Batch certification page',
       variant: 'Nothing selected'

--- a/app/cypress/integration/reporter-certifier-access.spec.js
+++ b/app/cypress/integration/reporter-certifier-access.spec.js
@@ -11,7 +11,7 @@ describe('When logged in as a certifier(reporter)', () => {
     const applicationId = window.btoa('["applications", 1]');
     cy.visit('localhost:3004/certifier/certification-redirect?rowId=testpage');
     cy.get('#page-content');
-    cy.get('.page-wrap').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Certification Redirect'
     });
     cy.contains('Continue').click();
@@ -29,18 +29,18 @@ describe('When logged in as a certifier(reporter)', () => {
     cy.contains('Legal Disclaimer');
     cy.contains('View').click();
     cy.url().should('include', '/certifier/certify');
-    cy.get('.page-wrap').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Certification Page'
     });
     cy.visit('/reporter');
     cy.get('.alert-link').contains('View all certification requests.').click();
     cy.url().should('include', '/certifier/requests');
-    cy.get('.page-wrap').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Batch certification page',
       variant: 'Nothing selected'
     });
     cy.get('input[type="checkbox"]').first().click();
-    cy.get('.page-wrap').happoScreenshot({
+    cy.get('body').happoScreenshot({
       component: 'Batch certification page',
       variant: 'Multiple certification requests selected'
     });

--- a/app/layouts/default-layout.tsx
+++ b/app/layouts/default-layout.tsx
@@ -71,12 +71,6 @@ const DefaultLayout: React.FunctionComponent<Props> = ({
       <Footer />
       <style jsx global>
         {`
-          html,
-          body,
-          #__next,
-          .page-wrap {
-            height: 100%;
-          }
           a {
             color: #0053b3;
           }

--- a/app/tests/unit/layout/__snapshots__/default-layout.test.tsx.snap
+++ b/app/tests/unit/layout/__snapshots__/default-layout.test.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`The DefaultLayout component matches the last accepted Snapshot 1`] = `
 <div
-  className="jsx-3730414943 page-wrap"
+  className="jsx-1249468136 page-wrap"
 >
   <HeaderLayout
     isLoggedIn={false}
     isRegistered={false}
   />
   <main
-    className="jsx-3730414943"
+    className="jsx-1249468136"
   >
     <Container
       className="content narrow"
@@ -19,9 +19,9 @@ exports[`The DefaultLayout component matches the last accepted Snapshot 1`] = `
   </main>
   <Footer />
   <JSXStyle
-    id="3730414943"
+    id="1249468136"
   >
-    html,body,#__next,.page-wrap{height:100%;}a{color:#0053b3;}.btn-link{color:#0053b3;}.page-wrap{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;}.content{padding-top:50px;-webkit-flex:1 0 auto;-ms-flex:1 0 auto;flex:1 0 auto;}.footer{-webkit-flex-shrink:0;-ms-flex-negative:0;flex-shrink:0;}h1{font-size:30px;display:inline-block;}.page-title{background:#f5f5f5;border-bottom:1px solid #ccc;padding:40px 0 20px;}.page-title h1{font-size:25px;font-weight:400;}h3{margin-bottom:20px;font-weight:500;}.blue{color:#036;}p{line-height:25px;}.ciip-card{border:1px solid #036;padding:15px;border-radius:0;box-shadow:1px 8px 13px -5px #00336694;}button.full-width{width:100%;}.btn-primary{background:#036;border-color:#036;}.with-shadow{box-shadow:1px 8px 13px -5px #00336694;}.accordion .card-body{font-size:15px;}.container.wide{max-width:1600px;}@media screen and (min-width:992px){#page-content{padding-top:110px;}}.btn-outline-primary{color:#0053b3;border-color:#0053b3;}.badge-success,.btn-success{background-color:#24883e;}
+    a{color:#0053b3;}.btn-link{color:#0053b3;}.page-wrap{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;}.content{padding-top:50px;-webkit-flex:1 0 auto;-ms-flex:1 0 auto;flex:1 0 auto;}.footer{-webkit-flex-shrink:0;-ms-flex-negative:0;flex-shrink:0;}h1{font-size:30px;display:inline-block;}.page-title{background:#f5f5f5;border-bottom:1px solid #ccc;padding:40px 0 20px;}.page-title h1{font-size:25px;font-weight:400;}h3{margin-bottom:20px;font-weight:500;}.blue{color:#036;}p{line-height:25px;}.ciip-card{border:1px solid #036;padding:15px;border-radius:0;box-shadow:1px 8px 13px -5px #00336694;}button.full-width{width:100%;}.btn-primary{background:#036;border-color:#036;}.with-shadow{box-shadow:1px 8px 13px -5px #00336694;}.accordion .card-body{font-size:15px;}.container.wide{max-width:1600px;}@media screen and (min-width:992px){#page-content{padding-top:110px;}}.btn-outline-primary{color:#0053b3;border-color:#0053b3;}.badge-success,.btn-success{background-color:#24883e;}
   </JSXStyle>
 </div>
 `;


### PR DESCRIPTION
- Updates the sitewide default layout such that the `html` and `body` tags encompass their entire content
- Updates Happo screenshots in Cypress tests to snapshot content of the `body` tag instead of a subset
[GGIRCS-1984](https://youtrack.button.is/issue/GGIRCS-1984)
- Cleans up the reporter-certifier-access-spec, which was getting disorganized and a bit nonsensical
  - broke cases out into individual tests