### PR TITLE
feat: health endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,6 +383,13 @@ jobs:
             source ~/.asdf/asdf.sh
             pushd app
             NO_MATHJAX=true yarn start AS_CYPRESS & yarn wait-on http://localhost:3004
+            status_code=$(curl --write-out %{http_code} --silent --output /dev/null http://localhost:3004/health)
+            if [[ "$status_code" -ne 200 ]] ; then
+              echo "healthcheck failed: database is not available or is in recovery mode"
+              exit 1
+            else
+              echo "healthcheck passed"
+            fi
             yarn test:e2e-snapshots
             popd
       - run:

--- a/app/server/index.js
+++ b/app/server/index.js
@@ -270,6 +270,17 @@ app.prepare().then(async () => {
 
   server.use('/print-pdf', await printPdf());
 
+  // Endpoint /health sends a 500 status if there is an error connecting to the database or if the database is in recovery mode (result.rowAsArray === true)
+  server.get('/health', ({res}) => {
+    pgPool.query('SELECT pg_is_in_recovery();', [], (err, result) => {
+      if (err || result.rowAsArray) {
+        res.sendStatus(500);
+      } else {
+        res.sendStatus(200);
+      }
+    });
+  });
+
   server.get('*', async (req, res) => {
     return handle(req, res);
   });

--- a/helm/cas-ciip-portal/templates/deploy.yaml
+++ b/helm/cas-ciip-portal/templates/deploy.yaml
@@ -80,7 +80,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /
+            path: /health
             port: {{ .Values.port }}
             scheme: HTTP{{ if not .Values.route.insecure }}S{{ end }}
           periodSeconds: 10


### PR DESCRIPTION
- add a /health endpoint that queries the database (and checks for recovery mode)
- use /health in deploy.yaml template as the readiness probe target path