### PR TITLE
fix: reset offset when applying new search filters

### DIFF
--- a/app/components/FilterableComponents/FilterableTableHeaders.tsx
+++ b/app/components/FilterableComponents/FilterableTableHeaders.tsx
@@ -41,7 +41,8 @@ const FilterableTableHeaders: React.FunctionComponent<ISearchProps> = (
       pathname: router.pathname,
       query: {
         ...router.query,
-        relayVars: queryString
+        relayVars: queryString,
+        pageVars: JSON.stringify({offset: 0})
       }
     };
 


### PR DESCRIPTION
The offset value was not being reset, leaving the user on a non-existent page when the results got pared down via a filter.