### PR TITLE
Reporter-facing side of application review

### DIFF
--- a/app/components/Application/ApplicationDecision.tsx
+++ b/app/components/Application/ApplicationDecision.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import {Alert} from 'react-bootstrap';
+
+interface Props {
+  changesRequested: Boolean;
+  decision?: string;
+  reviewComments: string[];
+}
+
+const BS_ALERT = {
+  REJECTED: 'danger',
+  APPROVED: 'success'
+};
+
+const DECISION_TEXT = {
+  REJECTED:
+    'Thank you for applying to the CIIP. Unfortunately this submission did not meet program requirements and a payment cannot be granted.',
+  APPROVED:
+    'This application has been approved. Your incentive payment is being processed. No further action is required from you at this time.'
+};
+
+const ApplicationDecision: React.FunctionComponent<Props> = ({
+  changesRequested,
+  decision,
+  reviewComments,
+  children
+}) => {
+  const heading = changesRequested
+    ? 'Action Required'
+    : `Decision: ${decision[0].toUpperCase()}${decision
+        .toLowerCase()
+        .slice(1)}`;
+
+  // eslint-disable-next-line react/no-array-index-key
+  const items = reviewComments.map((c, i) => <li key={`comment-${i}`}>{c}</li>);
+
+  return (
+    <Alert variant={changesRequested ? 'danger' : BS_ALERT[decision]}>
+      <Alert.Heading>{heading}</Alert.Heading>
+      <p>
+        {changesRequested
+          ? 'Changes to your application have been requested. Please read these review notes and gather the relevant information before revising your application.'
+          : DECISION_TEXT[decision]}
+      </p>
+      {reviewComments.length > 0 && (
+        <>
+          <p className="h5">Reviewer Notes:</p>
+          <ul>{items}</ul>
+        </>
+      )}
+      {children}
+    </Alert>
+  );
+};
+
+export default ApplicationDecision;

--- a/app/components/Application/ApplicationDecision.tsx
+++ b/app/components/Application/ApplicationDecision.tsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import {Alert} from 'react-bootstrap';
+import {getUserFriendlyStatusLabel} from 'lib/text-transforms';
 
 interface Props {
-  changesRequested: Boolean;
-  decision?: string;
+  actionRequired: Boolean;
+  decision: string;
   reviewComments: string[];
 }
 
 const BS_ALERT = {
+  REQUESTED_CHANGES: 'warning',
   REJECTED: 'danger',
   APPROVED: 'success'
 };
 
 const DECISION_TEXT = {
+  REQUESTED_CHANGES: '',
   REJECTED:
     'Thank you for applying to the CIIP. Unfortunately this submission did not meet program requirements and a payment cannot be granted.',
   APPROVED:
@@ -20,30 +23,32 @@ const DECISION_TEXT = {
 };
 
 const ApplicationDecision: React.FunctionComponent<Props> = ({
-  changesRequested,
+  actionRequired,
   decision,
   reviewComments,
   children
 }) => {
-  const heading = changesRequested
+  const heading = actionRequired
     ? 'Action Required'
-    : `Decision: ${decision[0].toUpperCase()}${decision
-        .toLowerCase()
-        .slice(1)}`;
+    : decision === 'REQUESTED_CHANGES'
+    ? 'Changes Requested'
+    : `Decision: ${getUserFriendlyStatusLabel(decision)}`;
 
+  // Items will not be re-ordered after mounting, so using index is safe
   // eslint-disable-next-line react/no-array-index-key
   const items = reviewComments.map((c, i) => <li key={`comment-${i}`}>{c}</li>);
 
   return (
-    <Alert variant={changesRequested ? 'danger' : BS_ALERT[decision]}>
+    <Alert variant={actionRequired ? 'danger' : BS_ALERT[decision]}>
       <Alert.Heading>{heading}</Alert.Heading>
       <p>
-        {changesRequested
+        {actionRequired
           ? 'Changes to your application have been requested. Please read these review notes and gather the relevant information before revising your application.'
           : DECISION_TEXT[decision]}
       </p>
       {reviewComments.length > 0 && (
         <>
+          <hr />
           <p className="h5">Reviewer Notes:</p>
           <ul>{items}</ul>
         </>

--- a/app/components/Application/ApplicationDecision.tsx
+++ b/app/components/Application/ApplicationDecision.tsx
@@ -3,7 +3,7 @@ import {Alert} from 'react-bootstrap';
 import {getUserFriendlyStatusLabel} from 'lib/text-transforms';
 
 interface Props {
-  actionRequired: Boolean;
+  actionRequired: boolean;
   decision: string;
   reviewComments: string[];
 }
@@ -43,7 +43,7 @@ const ApplicationDecision: React.FunctionComponent<Props> = ({
       <Alert.Heading>{heading}</Alert.Heading>
       <p>
         {actionRequired
-          ? 'Changes to your application have been requested. Please read these review notes and gather the relevant information before revising your application.'
+          ? 'Changes to your application have been requested. Please read these review notes before revising and resubmitting your application.'
           : DECISION_TEXT[decision]}
       </p>
       {reviewComments.length > 0 && (

--- a/app/components/Forms/ApplicationFormNavbar.tsx
+++ b/app/components/Forms/ApplicationFormNavbar.tsx
@@ -31,18 +31,9 @@ const ApplicationFormNavbarComponent: React.FunctionComponent<Props> = (
                 }
               }}
             >
-              {node.hasUnresolvedComments ? (
-                <Nav.Link
-                  active={node.id === props.formResultId}
-                  style={{color: 'red'}}
-                >
-                  {node.formJsonByFormId.name} !{' '}
-                </Nav.Link>
-              ) : (
-                <Nav.Link active={node.id === props.formResultId}>
-                  {node.formJsonByFormId.name}{' '}
-                </Nav.Link>
-              )}
+              <Nav.Link active={node.id === props.formResultId}>
+                {node.formJsonByFormId.name}{' '}
+              </Nav.Link>
             </Link>
           </Nav.Item>
         ))}
@@ -110,7 +101,6 @@ export default createFragmentContainer(ApplicationFormNavbarComponent, {
         edges {
           node {
             id
-            hasUnresolvedComments
             formJsonByFormId {
               name
             }

--- a/app/containers/Applications/ApplicationWizardStep.tsx
+++ b/app/containers/Applications/ApplicationWizardStep.tsx
@@ -59,13 +59,23 @@ const ApplicationWizardStep: React.FunctionComponent<Props> = ({
     await storeResult(formData);
   };
 
-  if (confirmationPage)
-    return (
+  if (confirmationPage) {
+    const confirmation = (
       <ApplicationWizardConfirmation
         query={query}
         application={query.application}
       />
     );
+    if (review) {
+      return (
+        <Row>
+          <Col md={8}>{confirmation}</Col>
+          <Col md={4}>{review}</Col>
+        </Row>
+      );
+    }
+    return confirmation;
+  }
   if (!formResult) return null;
 
   if (!application) return null;

--- a/app/containers/Applications/ApplicationWizardStep.tsx
+++ b/app/containers/Applications/ApplicationWizardStep.tsx
@@ -2,13 +2,13 @@ import React, {useState} from 'react';
 import {graphql, createFragmentContainer, RelayProp} from 'react-relay';
 import {ApplicationWizardStep_query} from 'ApplicationWizardStep_query.graphql';
 import {Row, Col} from 'react-bootstrap';
-import ApplicationComments from 'containers/Applications/ApplicationCommentsContainer';
 import Form from 'containers/Forms/Form';
 import updateFormResultMutation from 'mutations/form/updateFormResultMutation';
 import ApplicationWizardConfirmation from './ApplicationWizardConfirmation';
 
 interface Props {
   query: ApplicationWizardStep_query;
+  review: React.ReactNode;
   onStepComplete: () => void;
   confirmationPage: boolean;
   relay: RelayProp;
@@ -20,6 +20,7 @@ interface Props {
  */
 const ApplicationWizardStep: React.FunctionComponent<Props> = ({
   query,
+  review,
   onStepComplete,
   confirmationPage,
   relay
@@ -78,13 +79,11 @@ const ApplicationWizardStep: React.FunctionComponent<Props> = ({
     />
   );
 
-  if (formResult.hasUnresolvedComments)
+  if (review)
     return (
       <Row>
         <Col md={8}>{form}</Col>
-        <Col md={4}>
-          <ApplicationComments formResult={formResult} review={false} />
-        </Col>
+        <Col md={4}>{review}</Col>
       </Row>
     );
   return form;
@@ -104,8 +103,6 @@ export default createFragmentContainer(ApplicationWizardStep, {
       formResult(id: $formResultId) {
         id
         formResult
-        hasUnresolvedComments
-        ...ApplicationCommentsContainer_formResult
       }
       application(id: $applicationId) {
         ...ApplicationWizardConfirmation_application

--- a/app/containers/Applications/ReviseApplicationButtonContainer.tsx
+++ b/app/containers/Applications/ReviseApplicationButtonContainer.tsx
@@ -1,7 +1,6 @@
 import React, {useState} from 'react';
 import {useRouter} from 'next/router';
-import Link from 'next/link';
-import {Button, Col} from 'react-bootstrap';
+import {Button} from 'react-bootstrap';
 import createApplicationRevisionMutation from 'mutations/application/createApplicationRevisionMutation';
 import {createFragmentContainer, graphql, RelayProp} from 'react-relay';
 import {ReviseApplicationButtonContainer_application} from 'ReviseApplicationButtonContainer_application.graphql';
@@ -16,45 +15,9 @@ export const ReviseApplicationButton: React.FunctionComponent<Props> = ({
   relay
 }) => {
   const router = useRouter();
-  const thisVersion = Number(router.query.version);
+
   const [latestSubmittedRevision] = useState(
     application.latestSubmittedRevision.versionNumber
-  );
-  const [latestDraftRevision] = useState(
-    application.latestDraftRevision.versionNumber
-  );
-  const newerSubmissionExists = latestSubmittedRevision > thisVersion;
-  const latestSubmissionURL = `/reporter/view-application?applicationId=${encodeURIComponent(
-    application.id
-  )}&version=${latestSubmittedRevision}`;
-  const viewLatestSubmissionButton = (
-    <>
-      <p style={{margin: '1rem 0'}}>
-        <strong>Note:</strong> There is a more recently submitted version of
-        this application.
-      </p>
-      <Link passHref href={latestSubmissionURL}>
-        <Button>View most recent submission</Button>
-      </Link>
-    </>
-  );
-
-  const newerDraftExists = latestDraftRevision > latestSubmittedRevision;
-  const newerDraftURL = `/reporter/application?applicationId=${encodeURIComponent(
-    application.id
-  )}&version=${latestDraftRevision}`;
-  const resumeLatestDraftButton = (
-    <>
-      <p style={{margin: '1rem 0'}}>
-        <strong>Note:</strong> This application has been revised in a more
-        recent draft.
-      </p>
-      <Link href={newerDraftURL}>
-        <a>
-          <Button>Resume latest draft</Button>
-        </a>
-      </Link>
-    </>
   );
 
   const handleClick = async () => {
@@ -69,7 +32,6 @@ export const ReviseApplicationButton: React.FunctionComponent<Props> = ({
       relay.environment,
       variables
     );
-    console.log(response);
 
     const newVersion =
       response.createApplicationRevisionMutationChain.applicationRevision
@@ -89,17 +51,9 @@ export const ReviseApplicationButton: React.FunctionComponent<Props> = ({
   };
 
   return (
-    <>
-      {newerSubmissionExists ? (
-        viewLatestSubmissionButton
-      ) : newerDraftExists ? (
-        resumeLatestDraftButton
-      ) : (
-        <Button variant="success" onClick={handleClick}>
-          Revise Application
-        </Button>
-      )}
-    </>
+    <Button variant="primary" onClick={handleClick}>
+      Revise Application
+    </Button>
   );
 };
 
@@ -108,9 +62,6 @@ export default createFragmentContainer(ReviseApplicationButton, {
     fragment ReviseApplicationButtonContainer_application on Application {
       id
       rowId
-      latestDraftRevision {
-        versionNumber
-      }
       latestSubmittedRevision {
         versionNumber
       }

--- a/app/containers/Applications/ReviseApplicationButtonContainer.tsx
+++ b/app/containers/Applications/ReviseApplicationButtonContainer.tsx
@@ -89,7 +89,7 @@ export const ReviseApplicationButton: React.FunctionComponent<Props> = ({
   };
 
   return (
-    <Col>
+    <>
       {newerSubmissionExists ? (
         viewLatestSubmissionButton
       ) : newerDraftExists ? (
@@ -99,7 +99,7 @@ export const ReviseApplicationButton: React.FunctionComponent<Props> = ({
           Revise Application
         </Button>
       )}
-    </Col>
+    </>
   );
 };
 

--- a/app/tests/unit/components/Application/ApplicationDecision.test.tsx
+++ b/app/tests/unit/components/Application/ApplicationDecision.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import ApplicationDecision from 'components/Application/ApplicationDecision';
+
+describe('ApplicationDecision', () => {
+  it('matches the last accepted snapshot (no reviewer comments; APPROVED)', () => {
+    const r = shallow(
+      <ApplicationDecision
+        reviewComments={[]}
+        decision="APPROVED"
+        actionRequired={false}
+      />
+    );
+
+    expect(r).toMatchSnapshot();
+  });
+
+  it('matches the last accepted snapshot (no reviewer comments; REJECTED)', () => {
+    const r = shallow(
+      <ApplicationDecision
+        reviewComments={[]}
+        decision="REJECTED"
+        actionRequired={false}
+      />
+    );
+
+    expect(r).toMatchSnapshot();
+  });
+
+  it('matches the last accepted snapshot (with reviewer comments; REJECTED)', () => {
+    const r = shallow(
+      <ApplicationDecision
+        reviewComments={[
+          'We cannot accept applications from facilities that are either not regulated under GGIRCA, or which paid no carbon tax in 2020.'
+        ]}
+        decision="REJECTED"
+        actionRequired={false}
+      />
+    );
+
+    expect(r).toMatchSnapshot();
+  });
+
+  it('matches the last accepted snapshot (with reviewer comments; REQUESTED_CHANGES)', () => {
+    const r = shallow(
+      <ApplicationDecision
+        reviewComments={[
+          'The operator name is slightly different from a previous match we have on file: should it be "Virtucon Limited" instead of "Virtucon Ltd"?',
+          'Another comment.'
+        ]}
+        decision="REQUESTED_CHANGES"
+        actionRequired
+      />
+    );
+
+    expect(r).toMatchSnapshot();
+  });
+});

--- a/app/tests/unit/components/Application/__snapshots__/ApplicationDecision.test.tsx.snap
+++ b/app/tests/unit/components/Application/__snapshots__/ApplicationDecision.test.tsx.snap
@@ -1,0 +1,148 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ApplicationDecision matches the last accepted snapshot (no reviewer comments; APPROVED) 1`] = `
+<Alert
+  closeLabel="Close alert"
+  show={true}
+  transition={
+    Object {
+      "$$typeof": Symbol(react.forward_ref),
+      "defaultProps": Object {
+        "appear": false,
+        "in": false,
+        "mountOnEnter": false,
+        "timeout": 300,
+        "unmountOnExit": false,
+      },
+      "displayName": "Fade",
+      "render": [Function],
+    }
+  }
+  variant="success"
+>
+  <AlertHeading>
+    Decision: Approved
+  </AlertHeading>
+  <p>
+    This application has been approved. Your incentive payment is being processed. No further action is required from you at this time.
+  </p>
+</Alert>
+`;
+
+exports[`ApplicationDecision matches the last accepted snapshot (no reviewer comments; REJECTED) 1`] = `
+<Alert
+  closeLabel="Close alert"
+  show={true}
+  transition={
+    Object {
+      "$$typeof": Symbol(react.forward_ref),
+      "defaultProps": Object {
+        "appear": false,
+        "in": false,
+        "mountOnEnter": false,
+        "timeout": 300,
+        "unmountOnExit": false,
+      },
+      "displayName": "Fade",
+      "render": [Function],
+    }
+  }
+  variant="danger"
+>
+  <AlertHeading>
+    Decision: Rejected
+  </AlertHeading>
+  <p>
+    Thank you for applying to the CIIP. Unfortunately this submission did not meet program requirements and a payment cannot be granted.
+  </p>
+</Alert>
+`;
+
+exports[`ApplicationDecision matches the last accepted snapshot (with reviewer comments; REJECTED) 1`] = `
+<Alert
+  closeLabel="Close alert"
+  show={true}
+  transition={
+    Object {
+      "$$typeof": Symbol(react.forward_ref),
+      "defaultProps": Object {
+        "appear": false,
+        "in": false,
+        "mountOnEnter": false,
+        "timeout": 300,
+        "unmountOnExit": false,
+      },
+      "displayName": "Fade",
+      "render": [Function],
+    }
+  }
+  variant="danger"
+>
+  <AlertHeading>
+    Decision: Rejected
+  </AlertHeading>
+  <p>
+    Thank you for applying to the CIIP. Unfortunately this submission did not meet program requirements and a payment cannot be granted.
+  </p>
+  <hr />
+  <p
+    className="h5"
+  >
+    Reviewer Notes:
+  </p>
+  <ul>
+    <li
+      key="comment-0"
+    >
+      We cannot accept applications from facilities that are either not regulated under GGIRCA, or which paid no carbon tax in 2020.
+    </li>
+  </ul>
+</Alert>
+`;
+
+exports[`ApplicationDecision matches the last accepted snapshot (with reviewer comments; REQUESTED_CHANGES) 1`] = `
+<Alert
+  closeLabel="Close alert"
+  show={true}
+  transition={
+    Object {
+      "$$typeof": Symbol(react.forward_ref),
+      "defaultProps": Object {
+        "appear": false,
+        "in": false,
+        "mountOnEnter": false,
+        "timeout": 300,
+        "unmountOnExit": false,
+      },
+      "displayName": "Fade",
+      "render": [Function],
+    }
+  }
+  variant="danger"
+>
+  <AlertHeading>
+    Action Required
+  </AlertHeading>
+  <p>
+    Changes to your application have been requested. Please read these review notes and gather the relevant information before revising your application.
+  </p>
+  <hr />
+  <p
+    className="h5"
+  >
+    Reviewer Notes:
+  </p>
+  <ul>
+    <li
+      key="comment-0"
+    >
+      The operator name is slightly different from a previous match we have on file: should it be "Virtucon Limited" instead of "Virtucon Ltd"?
+    </li>
+    <li
+      key="comment-1"
+    >
+      Another comment.
+    </li>
+  </ul>
+</Alert>
+`;

--- a/app/tests/unit/components/Application/__snapshots__/ApplicationDecision.test.tsx.snap
+++ b/app/tests/unit/components/Application/__snapshots__/ApplicationDecision.test.tsx.snap
@@ -124,7 +124,7 @@ exports[`ApplicationDecision matches the last accepted snapshot (with reviewer c
     Action Required
   </AlertHeading>
   <p>
-    Changes to your application have been requested. Please read these review notes and gather the relevant information before revising your application.
+    Changes to your application have been requested. Please read these review notes before revising and resubmitting your application.
   </p>
   <hr />
   <p

--- a/app/tests/unit/containers/Applications/ReviseApplicationButtonContainer.test.tsx
+++ b/app/tests/unit/containers/Applications/ReviseApplicationButtonContainer.test.tsx
@@ -16,9 +16,6 @@ describe('The ReviseApplicationButton', () => {
           ' $refType': 'ReviseApplicationButtonContainer_application',
           id: 'foo',
           rowId: 1,
-          latestDraftRevision: {
-            versionNumber: 1
-          },
           latestSubmittedRevision: {
             versionNumber: 1
           }
@@ -29,51 +26,5 @@ describe('The ReviseApplicationButton', () => {
     expect(r).toMatchSnapshot();
     expect(r.exists('Button')).toBe(true);
     expect(r.find('Button').text()).toBe('Revise Application');
-  });
-
-  it('should render a "View most recent submission" button when viewing an older submission (viewed version < last submitted version)', () => {
-    const r = shallow(
-      <ReviseApplicationButton
-        relay={null}
-        application={{
-          ' $refType': 'ReviseApplicationButtonContainer_application',
-          id: 'foo',
-          rowId: 1,
-          latestDraftRevision: {
-            versionNumber: 2
-          },
-          latestSubmittedRevision: {
-            versionNumber: 2
-          }
-        }}
-      />
-    );
-
-    expect(r).toMatchSnapshot();
-    expect(r.exists('Button')).toBe(true);
-    expect(r.find('Button').text()).toBe('View most recent submission');
-  });
-
-  it('should render a "Resume latest draft" button when a new draft exists (but has not yet been submitted)', () => {
-    const r = shallow(
-      <ReviseApplicationButton
-        relay={null}
-        application={{
-          ' $refType': 'ReviseApplicationButtonContainer_application',
-          id: 'foo',
-          rowId: 1,
-          latestDraftRevision: {
-            versionNumber: 2
-          },
-          latestSubmittedRevision: {
-            versionNumber: 1
-          }
-        }}
-      />
-    );
-
-    expect(r).toMatchSnapshot();
-    expect(r.exists('Button')).toBe(true);
-    expect(r.find('Button').text()).toBe('Resume latest draft');
   });
 });

--- a/app/tests/unit/containers/Applications/__snapshots__/ReviseApplicationButtonContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ReviseApplicationButtonContainer.test.tsx.snap
@@ -1,28 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`The ReviseApplicationButton should render a "Resume latest draft" button when a new draft exists (but has not yet been submitted) 1`] = `
-<Button
-  active={false}
-  disabled={false}
-  onClick={[Function]}
-  variant="primary"
->
-  Revise Application
-</Button>
-`;
-
 exports[`The ReviseApplicationButton should render a "Revise" button when the version being viewed === the latest draft version (there is not yet a newer draft) 1`] = `
-<Button
-  active={false}
-  disabled={false}
-  onClick={[Function]}
-  variant="primary"
->
-  Revise Application
-</Button>
-`;
-
-exports[`The ReviseApplicationButton should render a "View most recent submission" button when viewing an older submission (viewed version < last submitted version) 1`] = `
 <Button
   active={false}
   disabled={false}

--- a/app/tests/unit/containers/Applications/__snapshots__/ReviseApplicationButtonContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ReviseApplicationButtonContainer.test.tsx.snap
@@ -1,73 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`The ReviseApplicationButton should render a "Resume latest draft" button when a new draft exists (but has not yet been submitted) 1`] = `
-<Col>
-  <p
-    style={
-      Object {
-        "margin": "1rem 0",
-      }
-    }
-  >
-    <strong>
-      Note:
-    </strong>
-     This application has been revised in a more recent draft.
-  </p>
-  <Link
-    href="/reporter/application?applicationId=foo&version=2"
-  >
-    <a>
-      <Button
-        active={false}
-        disabled={false}
-        variant="primary"
-      >
-        Resume latest draft
-      </Button>
-    </a>
-  </Link>
-</Col>
+<Button
+  active={false}
+  disabled={false}
+  onClick={[Function]}
+  variant="primary"
+>
+  Revise Application
+</Button>
 `;
 
 exports[`The ReviseApplicationButton should render a "Revise" button when the version being viewed === the latest draft version (there is not yet a newer draft) 1`] = `
-<Col>
-  <Button
-    active={false}
-    disabled={false}
-    onClick={[Function]}
-    variant="success"
-  >
-    Revise Application
-  </Button>
-</Col>
+<Button
+  active={false}
+  disabled={false}
+  onClick={[Function]}
+  variant="primary"
+>
+  Revise Application
+</Button>
 `;
 
 exports[`The ReviseApplicationButton should render a "View most recent submission" button when viewing an older submission (viewed version < last submitted version) 1`] = `
-<Col>
-  <p
-    style={
-      Object {
-        "margin": "1rem 0",
-      }
-    }
-  >
-    <strong>
-      Note:
-    </strong>
-     There is a more recently submitted version of this application.
-  </p>
-  <Link
-    href="/reporter/view-application?applicationId=foo&version=2"
-    passHref={true}
-  >
-    <Button
-      active={false}
-      disabled={false}
-      variant="primary"
-    >
-      View most recent submission
-    </Button>
-  </Link>
-</Col>
+<Button
+  active={false}
+  disabled={false}
+  onClick={[Function]}
+  variant="primary"
+>
+  Revise Application
+</Button>
 `;

--- a/app/tests/unit/pages/__snapshots__/view-application.test.tsx.snap
+++ b/app/tests/unit/pages/__snapshots__/view-application.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`matches the last accepted Snapshot 1`] = `
+exports[`View submitted application page displays a "Resume latest draft" button when changes are requested, and there is already a newer draft (not submitted) 1`] = `
 <Relay(DefaultLayout)
   session={
     Object {
@@ -16,8 +16,43 @@ exports[`matches the last accepted Snapshot 1`] = `
     noGutters={false}
   >
     <Col
-      md={8}
+      md={12}
     >
+      <ApplicationDecision
+        actionRequired={true}
+        decision="REQUESTED_CHANGES"
+        reviewComments={
+          Array [
+            "This is a comment",
+          ]
+        }
+      >
+        <p
+          style={
+            Object {
+              "margin": "1rem 0",
+            }
+          }
+        >
+          <strong>
+            Note:
+          </strong>
+           This application has been revised in a more recent draft.
+        </p>
+        <Link
+          href="/reporter/application?applicationId=testing&version=2"
+        >
+          <a>
+            <Button
+              active={false}
+              disabled={false}
+              variant="primary"
+            >
+              Resume latest draft
+            </Button>
+          </a>
+        </Link>
+      </ApplicationDecision>
       <Relay(ApplicationDetailsComponent)
         application={
           Object {
@@ -26,7 +61,13 @@ exports[`matches the last accepted Snapshot 1`] = `
               "ReviseApplicationButtonContainer_application": true,
             },
             "applicationRevisionStatus": Object {
-              "applicationRevisionStatus": "SUBMITTED",
+              "applicationRevisionStatus": "REQUESTED_CHANGES",
+            },
+            "latestDraftRevision": Object {
+              "versionNumber": 2,
+            },
+            "latestSubmittedRevision": Object {
+              "versionNumber": 1,
             },
             "orderedFormResults": Object {
               "edges": Array [
@@ -36,6 +77,17 @@ exports[`matches the last accepted Snapshot 1`] = `
                       "ApplicationCommentsContainer_formResult": true,
                     },
                     "id": "abc",
+                  },
+                },
+              ],
+            },
+            "reviewCommentsByApplicationId": Object {
+              "edges": Array [
+                Object {
+                  "node": Object {
+                    "commentType": "GENERAL",
+                    "description": "This is a comment",
+                    "resolved": false,
                   },
                 },
               ],
@@ -54,7 +106,13 @@ exports[`matches the last accepted Snapshot 1`] = `
                 "ReviseApplicationButtonContainer_application": true,
               },
               "applicationRevisionStatus": Object {
-                "applicationRevisionStatus": "SUBMITTED",
+                "applicationRevisionStatus": "REQUESTED_CHANGES",
+              },
+              "latestDraftRevision": Object {
+                "versionNumber": 2,
+              },
+              "latestSubmittedRevision": Object {
+                "versionNumber": 1,
               },
               "orderedFormResults": Object {
                 "edges": Array [
@@ -64,6 +122,17 @@ exports[`matches the last accepted Snapshot 1`] = `
                         "ApplicationCommentsContainer_formResult": true,
                       },
                       "id": "abc",
+                    },
+                  },
+                ],
+              },
+              "reviewCommentsByApplicationId": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      "commentType": "GENERAL",
+                      "description": "This is a comment",
+                      "resolved": false,
                     },
                   },
                 ],
@@ -79,25 +148,954 @@ exports[`matches the last accepted Snapshot 1`] = `
         review={false}
       />
     </Col>
+  </Row>
+</Relay(DefaultLayout)>
+`;
+
+exports[`View submitted application page displays a "Revise" button when changes are requested, and there is no newer revision 1`] = `
+<Relay(DefaultLayout)
+  session={
+    Object {
+      " $fragmentRefs": Object {
+        "defaultLayout_session": true,
+      },
+    }
+  }
+  showSubheader={true}
+  title="Summary of your application"
+>
+  <Row
+    noGutters={false}
+  >
     <Col
-      md={4}
+      md={12}
     >
-      <Relay(ApplicationCommentsComponent)
-        formResult={
+      <ApplicationDecision
+        actionRequired={true}
+        decision="REQUESTED_CHANGES"
+        reviewComments={
+          Array [
+            "The operator name is slightly different from a previous match we have on file: should it be \\"Virtucon Limited\\" instead of \\"Virtucon Ltd\\"?",
+          ]
+        }
+      >
+        <Relay(ReviseApplicationButton)
+          application={
+            Object {
+              " $fragmentRefs": Object {
+                "ApplicationDetailsContainer_application": true,
+                "ReviseApplicationButtonContainer_application": true,
+              },
+              "applicationRevisionStatus": Object {
+                "applicationRevisionStatus": "REQUESTED_CHANGES",
+              },
+              "latestDraftRevision": Object {
+                "versionNumber": 1,
+              },
+              "latestSubmittedRevision": Object {
+                "versionNumber": 1,
+              },
+              "orderedFormResults": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      " $fragmentRefs": Object {
+                        "ApplicationCommentsContainer_formResult": true,
+                      },
+                      "id": "abc",
+                    },
+                  },
+                ],
+              },
+              "reviewCommentsByApplicationId": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      "commentType": "GENERAL",
+                      "description": "The operator name is slightly different from a previous match we have on file: should it be \\"Virtucon Limited\\" instead of \\"Virtucon Ltd\\"?",
+                      "resolved": false,
+                    },
+                  },
+                ],
+              },
+            }
+          }
+        />
+      </ApplicationDecision>
+      <Relay(ApplicationDetailsComponent)
+        application={
           Object {
             " $fragmentRefs": Object {
-              "ApplicationCommentsContainer_formResult": true,
+              "ApplicationDetailsContainer_application": true,
+              "ReviseApplicationButtonContainer_application": true,
             },
-            "id": "abc",
+            "applicationRevisionStatus": Object {
+              "applicationRevisionStatus": "REQUESTED_CHANGES",
+            },
+            "latestDraftRevision": Object {
+              "versionNumber": 1,
+            },
+            "latestSubmittedRevision": Object {
+              "versionNumber": 1,
+            },
+            "orderedFormResults": Object {
+              "edges": Array [
+                Object {
+                  "node": Object {
+                    " $fragmentRefs": Object {
+                      "ApplicationCommentsContainer_formResult": true,
+                    },
+                    "id": "abc",
+                  },
+                },
+              ],
+            },
+            "reviewCommentsByApplicationId": Object {
+              "edges": Array [
+                Object {
+                  "node": Object {
+                    "commentType": "GENERAL",
+                    "description": "The operator name is slightly different from a previous match we have on file: should it be \\"Virtucon Limited\\" instead of \\"Virtucon Ltd\\"?",
+                    "resolved": false,
+                  },
+                },
+              ],
+            },
           }
         }
-        key="abc"
+        liveValidate={false}
+        query={
+          Object {
+            " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_query": true,
+            },
+            "application": Object {
+              " $fragmentRefs": Object {
+                "ApplicationDetailsContainer_application": true,
+                "ReviseApplicationButtonContainer_application": true,
+              },
+              "applicationRevisionStatus": Object {
+                "applicationRevisionStatus": "REQUESTED_CHANGES",
+              },
+              "latestDraftRevision": Object {
+                "versionNumber": 1,
+              },
+              "latestSubmittedRevision": Object {
+                "versionNumber": 1,
+              },
+              "orderedFormResults": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      " $fragmentRefs": Object {
+                        "ApplicationCommentsContainer_formResult": true,
+                      },
+                      "id": "abc",
+                    },
+                  },
+                ],
+              },
+              "reviewCommentsByApplicationId": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      "commentType": "GENERAL",
+                      "description": "The operator name is slightly different from a previous match we have on file: should it be \\"Virtucon Limited\\" instead of \\"Virtucon Ltd\\"?",
+                      "resolved": false,
+                    },
+                  },
+                ],
+              },
+            },
+            "session": Object {
+              " $fragmentRefs": Object {
+                "defaultLayout_session": true,
+              },
+            },
+          }
+        }
         review={false}
       />
     </Col>
   </Row>
+</Relay(DefaultLayout)>
+`;
+
+exports[`View submitted application page does not show an application decision when unreviewed 1`] = `
+<Relay(DefaultLayout)
+  session={
+    Object {
+      " $fragmentRefs": Object {
+        "defaultLayout_session": true,
+      },
+    }
+  }
+  showSubheader={true}
+  title="Summary of your application"
+>
   <Row
     noGutters={false}
-  />
+  >
+    <Col
+      md={12}
+    >
+      <Relay(ApplicationDetailsComponent)
+        application={
+          Object {
+            " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_application": true,
+              "ReviseApplicationButtonContainer_application": true,
+            },
+            "applicationRevisionStatus": Object {
+              "applicationRevisionStatus": "SUBMITTED",
+            },
+            "latestDraftRevision": Object {
+              "versionNumber": 1,
+            },
+            "latestSubmittedRevision": Object {
+              "versionNumber": 1,
+            },
+            "orderedFormResults": Object {
+              "edges": Array [
+                Object {
+                  "node": Object {
+                    " $fragmentRefs": Object {
+                      "ApplicationCommentsContainer_formResult": true,
+                    },
+                    "id": "abc",
+                  },
+                },
+              ],
+            },
+            "reviewCommentsByApplicationId": Object {
+              "edges": Array [],
+            },
+          }
+        }
+        liveValidate={false}
+        query={
+          Object {
+            " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_query": true,
+            },
+            "application": Object {
+              " $fragmentRefs": Object {
+                "ApplicationDetailsContainer_application": true,
+                "ReviseApplicationButtonContainer_application": true,
+              },
+              "applicationRevisionStatus": Object {
+                "applicationRevisionStatus": "SUBMITTED",
+              },
+              "latestDraftRevision": Object {
+                "versionNumber": 1,
+              },
+              "latestSubmittedRevision": Object {
+                "versionNumber": 1,
+              },
+              "orderedFormResults": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      " $fragmentRefs": Object {
+                        "ApplicationCommentsContainer_formResult": true,
+                      },
+                      "id": "abc",
+                    },
+                  },
+                ],
+              },
+              "reviewCommentsByApplicationId": Object {
+                "edges": Array [],
+              },
+            },
+            "session": Object {
+              " $fragmentRefs": Object {
+                "defaultLayout_session": true,
+              },
+            },
+          }
+        }
+        review={false}
+      />
+    </Col>
+  </Row>
+</Relay(DefaultLayout)>
+`;
+
+exports[`View submitted application page should render a "View most recent submission" button when viewing an older submission (viewed version < last submitted version) 1`] = `
+<Relay(DefaultLayout)
+  session={
+    Object {
+      " $fragmentRefs": Object {
+        "defaultLayout_session": true,
+      },
+    }
+  }
+  showSubheader={true}
+  title="Summary of your application"
+>
+  <Row
+    noGutters={false}
+  >
+    <Col
+      md={12}
+    >
+      <Alert
+        closeLabel="Close alert"
+        show={true}
+        transition={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "defaultProps": Object {
+              "appear": false,
+              "in": false,
+              "mountOnEnter": false,
+              "timeout": 300,
+              "unmountOnExit": false,
+            },
+            "displayName": "Fade",
+            "render": [Function],
+          }
+        }
+        variant="secondary"
+      >
+        <p
+          style={
+            Object {
+              "margin": "1rem 0",
+            }
+          }
+        >
+          <strong>
+            Note:
+          </strong>
+           There is a more recently submitted version of this application.
+        </p>
+        <Link
+          href="/reporter/view-application?applicationId=testing&version=2"
+          passHref={true}
+        >
+          <Button
+            active={false}
+            disabled={false}
+            variant="primary"
+          >
+            View most recent submission
+          </Button>
+        </Link>
+      </Alert>
+      <ApplicationDecision
+        actionRequired={false}
+        decision="REQUESTED_CHANGES"
+        reviewComments={
+          Array [
+            "This is a comment",
+          ]
+        }
+      />
+      <Relay(ApplicationDetailsComponent)
+        application={
+          Object {
+            " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_application": true,
+              "ReviseApplicationButtonContainer_application": true,
+            },
+            "applicationRevisionStatus": Object {
+              "applicationRevisionStatus": "REQUESTED_CHANGES",
+            },
+            "latestDraftRevision": Object {
+              "versionNumber": 2,
+            },
+            "latestSubmittedRevision": Object {
+              "versionNumber": 2,
+            },
+            "orderedFormResults": Object {
+              "edges": Array [
+                Object {
+                  "node": Object {
+                    " $fragmentRefs": Object {
+                      "ApplicationCommentsContainer_formResult": true,
+                    },
+                    "id": "abc",
+                  },
+                },
+              ],
+            },
+            "reviewCommentsByApplicationId": Object {
+              "edges": Array [
+                Object {
+                  "node": Object {
+                    "commentType": "GENERAL",
+                    "description": "This is a comment",
+                    "resolved": false,
+                  },
+                },
+              ],
+            },
+          }
+        }
+        liveValidate={false}
+        query={
+          Object {
+            " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_query": true,
+            },
+            "application": Object {
+              " $fragmentRefs": Object {
+                "ApplicationDetailsContainer_application": true,
+                "ReviseApplicationButtonContainer_application": true,
+              },
+              "applicationRevisionStatus": Object {
+                "applicationRevisionStatus": "REQUESTED_CHANGES",
+              },
+              "latestDraftRevision": Object {
+                "versionNumber": 2,
+              },
+              "latestSubmittedRevision": Object {
+                "versionNumber": 2,
+              },
+              "orderedFormResults": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      " $fragmentRefs": Object {
+                        "ApplicationCommentsContainer_formResult": true,
+                      },
+                      "id": "abc",
+                    },
+                  },
+                ],
+              },
+              "reviewCommentsByApplicationId": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      "commentType": "GENERAL",
+                      "description": "This is a comment",
+                      "resolved": false,
+                    },
+                  },
+                ],
+              },
+            },
+            "session": Object {
+              " $fragmentRefs": Object {
+                "defaultLayout_session": true,
+              },
+            },
+          }
+        }
+        review={false}
+      />
+    </Col>
+  </Row>
+</Relay(DefaultLayout)>
+`;
+
+exports[`View submitted application page should render a "View most recent submission" button when viewing an older submission that has BOTH a newer submission, and at least two newer drafts 1`] = `
+<Relay(DefaultLayout)
+  session={
+    Object {
+      " $fragmentRefs": Object {
+        "defaultLayout_session": true,
+      },
+    }
+  }
+  showSubheader={true}
+  title="Summary of your application"
+>
+  <Row
+    noGutters={false}
+  >
+    <Col
+      md={12}
+    >
+      <Alert
+        closeLabel="Close alert"
+        show={true}
+        transition={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "defaultProps": Object {
+              "appear": false,
+              "in": false,
+              "mountOnEnter": false,
+              "timeout": 300,
+              "unmountOnExit": false,
+            },
+            "displayName": "Fade",
+            "render": [Function],
+          }
+        }
+        variant="secondary"
+      >
+        <p
+          style={
+            Object {
+              "margin": "1rem 0",
+            }
+          }
+        >
+          <strong>
+            Note:
+          </strong>
+           There is a more recently submitted version of this application.
+        </p>
+        <Link
+          href="/reporter/view-application?applicationId=testing&version=2"
+          passHref={true}
+        >
+          <Button
+            active={false}
+            disabled={false}
+            variant="primary"
+          >
+            View most recent submission
+          </Button>
+        </Link>
+      </Alert>
+      <ApplicationDecision
+        actionRequired={false}
+        decision="REQUESTED_CHANGES"
+        reviewComments={
+          Array [
+            "This is a comment",
+          ]
+        }
+      />
+      <Relay(ApplicationDetailsComponent)
+        application={
+          Object {
+            " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_application": true,
+              "ReviseApplicationButtonContainer_application": true,
+            },
+            "applicationRevisionStatus": Object {
+              "applicationRevisionStatus": "REQUESTED_CHANGES",
+            },
+            "latestDraftRevision": Object {
+              "versionNumber": 3,
+            },
+            "latestSubmittedRevision": Object {
+              "versionNumber": 2,
+            },
+            "orderedFormResults": Object {
+              "edges": Array [
+                Object {
+                  "node": Object {
+                    " $fragmentRefs": Object {
+                      "ApplicationCommentsContainer_formResult": true,
+                    },
+                    "id": "abc",
+                  },
+                },
+              ],
+            },
+            "reviewCommentsByApplicationId": Object {
+              "edges": Array [
+                Object {
+                  "node": Object {
+                    "commentType": "GENERAL",
+                    "description": "This is a comment",
+                    "resolved": false,
+                  },
+                },
+              ],
+            },
+          }
+        }
+        liveValidate={false}
+        query={
+          Object {
+            " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_query": true,
+            },
+            "application": Object {
+              " $fragmentRefs": Object {
+                "ApplicationDetailsContainer_application": true,
+                "ReviseApplicationButtonContainer_application": true,
+              },
+              "applicationRevisionStatus": Object {
+                "applicationRevisionStatus": "REQUESTED_CHANGES",
+              },
+              "latestDraftRevision": Object {
+                "versionNumber": 3,
+              },
+              "latestSubmittedRevision": Object {
+                "versionNumber": 2,
+              },
+              "orderedFormResults": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      " $fragmentRefs": Object {
+                        "ApplicationCommentsContainer_formResult": true,
+                      },
+                      "id": "abc",
+                    },
+                  },
+                ],
+              },
+              "reviewCommentsByApplicationId": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      "commentType": "GENERAL",
+                      "description": "This is a comment",
+                      "resolved": false,
+                    },
+                  },
+                ],
+              },
+            },
+            "session": Object {
+              " $fragmentRefs": Object {
+                "defaultLayout_session": true,
+              },
+            },
+          }
+        }
+        review={false}
+      />
+    </Col>
+  </Row>
+</Relay(DefaultLayout)>
+`;
+
+exports[`View submitted application page shows approval when reviewed and approved 1`] = `
+<Relay(DefaultLayout)
+  session={
+    Object {
+      " $fragmentRefs": Object {
+        "defaultLayout_session": true,
+      },
+    }
+  }
+  showSubheader={true}
+  title="Summary of your application"
+>
+  <Row
+    noGutters={false}
+  >
+    <Col
+      md={12}
+    >
+      <ApplicationDecision
+        actionRequired={false}
+        decision="APPROVED"
+        reviewComments={Array []}
+      />
+      <Relay(ApplicationDetailsComponent)
+        application={
+          Object {
+            " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_application": true,
+              "ReviseApplicationButtonContainer_application": true,
+            },
+            "applicationRevisionStatus": Object {
+              "applicationRevisionStatus": "APPROVED",
+            },
+            "latestDraftRevision": Object {
+              "versionNumber": 1,
+            },
+            "latestSubmittedRevision": Object {
+              "versionNumber": 1,
+            },
+            "orderedFormResults": Object {
+              "edges": Array [
+                Object {
+                  "node": Object {
+                    " $fragmentRefs": Object {
+                      "ApplicationCommentsContainer_formResult": true,
+                    },
+                    "id": "abc",
+                  },
+                },
+              ],
+            },
+            "reviewCommentsByApplicationId": Object {
+              "edges": Array [],
+            },
+          }
+        }
+        liveValidate={false}
+        query={
+          Object {
+            " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_query": true,
+            },
+            "application": Object {
+              " $fragmentRefs": Object {
+                "ApplicationDetailsContainer_application": true,
+                "ReviseApplicationButtonContainer_application": true,
+              },
+              "applicationRevisionStatus": Object {
+                "applicationRevisionStatus": "APPROVED",
+              },
+              "latestDraftRevision": Object {
+                "versionNumber": 1,
+              },
+              "latestSubmittedRevision": Object {
+                "versionNumber": 1,
+              },
+              "orderedFormResults": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      " $fragmentRefs": Object {
+                        "ApplicationCommentsContainer_formResult": true,
+                      },
+                      "id": "abc",
+                    },
+                  },
+                ],
+              },
+              "reviewCommentsByApplicationId": Object {
+                "edges": Array [],
+              },
+            },
+            "session": Object {
+              " $fragmentRefs": Object {
+                "defaultLayout_session": true,
+              },
+            },
+          }
+        }
+        review={false}
+      />
+    </Col>
+  </Row>
+</Relay(DefaultLayout)>
+`;
+
+exports[`View submitted application page shows rejection when reviewed and rejected 1`] = `
+<Relay(DefaultLayout)
+  session={
+    Object {
+      " $fragmentRefs": Object {
+        "defaultLayout_session": true,
+      },
+    }
+  }
+  showSubheader={true}
+  title="Summary of your application"
+>
+  <Row
+    noGutters={false}
+  >
+    <Col
+      md={12}
+    >
+      <ApplicationDecision
+        actionRequired={false}
+        decision="REJECTED"
+        reviewComments={Array []}
+      />
+      <Relay(ApplicationDetailsComponent)
+        application={
+          Object {
+            " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_application": true,
+              "ReviseApplicationButtonContainer_application": true,
+            },
+            "applicationRevisionStatus": Object {
+              "applicationRevisionStatus": "REJECTED",
+            },
+            "latestDraftRevision": Object {
+              "versionNumber": 1,
+            },
+            "latestSubmittedRevision": Object {
+              "versionNumber": 1,
+            },
+            "orderedFormResults": Object {
+              "edges": Array [
+                Object {
+                  "node": Object {
+                    " $fragmentRefs": Object {
+                      "ApplicationCommentsContainer_formResult": true,
+                    },
+                    "id": "abc",
+                  },
+                },
+              ],
+            },
+            "reviewCommentsByApplicationId": Object {
+              "edges": Array [],
+            },
+          }
+        }
+        liveValidate={false}
+        query={
+          Object {
+            " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_query": true,
+            },
+            "application": Object {
+              " $fragmentRefs": Object {
+                "ApplicationDetailsContainer_application": true,
+                "ReviseApplicationButtonContainer_application": true,
+              },
+              "applicationRevisionStatus": Object {
+                "applicationRevisionStatus": "REJECTED",
+              },
+              "latestDraftRevision": Object {
+                "versionNumber": 1,
+              },
+              "latestSubmittedRevision": Object {
+                "versionNumber": 1,
+              },
+              "orderedFormResults": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      " $fragmentRefs": Object {
+                        "ApplicationCommentsContainer_formResult": true,
+                      },
+                      "id": "abc",
+                    },
+                  },
+                ],
+              },
+              "reviewCommentsByApplicationId": Object {
+                "edges": Array [],
+              },
+            },
+            "session": Object {
+              " $fragmentRefs": Object {
+                "defaultLayout_session": true,
+              },
+            },
+          }
+        }
+        review={false}
+      />
+    </Col>
+  </Row>
+</Relay(DefaultLayout)>
+`;
+
+exports[`View submitted application page shows reviewer comments when reviewed and rejected 1`] = `
+<Relay(DefaultLayout)
+  session={
+    Object {
+      " $fragmentRefs": Object {
+        "defaultLayout_session": true,
+      },
+    }
+  }
+  showSubheader={true}
+  title="Summary of your application"
+>
+  <Row
+    noGutters={false}
+  >
+    <Col
+      md={12}
+    >
+      <ApplicationDecision
+        actionRequired={false}
+        decision="REJECTED"
+        reviewComments={
+          Array [
+            "We cannot accept applications from facilities that are either not regulated under GGIRCA, or which paid no carbon tax in 2020.",
+          ]
+        }
+      />
+      <Relay(ApplicationDetailsComponent)
+        application={
+          Object {
+            " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_application": true,
+              "ReviseApplicationButtonContainer_application": true,
+            },
+            "applicationRevisionStatus": Object {
+              "applicationRevisionStatus": "REJECTED",
+            },
+            "latestDraftRevision": Object {
+              "versionNumber": 1,
+            },
+            "latestSubmittedRevision": Object {
+              "versionNumber": 1,
+            },
+            "orderedFormResults": Object {
+              "edges": Array [
+                Object {
+                  "node": Object {
+                    " $fragmentRefs": Object {
+                      "ApplicationCommentsContainer_formResult": true,
+                    },
+                    "id": "abc",
+                  },
+                },
+              ],
+            },
+            "reviewCommentsByApplicationId": Object {
+              "edges": Array [
+                Object {
+                  "node": Object {
+                    "commentType": "GENERAL",
+                    "description": "We cannot accept applications from facilities that are either not regulated under GGIRCA, or which paid no carbon tax in 2020.",
+                    "resolved": false,
+                  },
+                },
+              ],
+            },
+          }
+        }
+        liveValidate={false}
+        query={
+          Object {
+            " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_query": true,
+            },
+            "application": Object {
+              " $fragmentRefs": Object {
+                "ApplicationDetailsContainer_application": true,
+                "ReviseApplicationButtonContainer_application": true,
+              },
+              "applicationRevisionStatus": Object {
+                "applicationRevisionStatus": "REJECTED",
+              },
+              "latestDraftRevision": Object {
+                "versionNumber": 1,
+              },
+              "latestSubmittedRevision": Object {
+                "versionNumber": 1,
+              },
+              "orderedFormResults": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      " $fragmentRefs": Object {
+                        "ApplicationCommentsContainer_formResult": true,
+                      },
+                      "id": "abc",
+                    },
+                  },
+                ],
+              },
+              "reviewCommentsByApplicationId": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      "commentType": "GENERAL",
+                      "description": "We cannot accept applications from facilities that are either not regulated under GGIRCA, or which paid no carbon tax in 2020.",
+                      "resolved": false,
+                    },
+                  },
+                ],
+              },
+            },
+            "session": Object {
+              " $fragmentRefs": Object {
+                "defaultLayout_session": true,
+              },
+            },
+          }
+        }
+        review={false}
+      />
+    </Col>
+  </Row>
 </Relay(DefaultLayout)>
 `;

--- a/app/tests/unit/pages/view-application.test.tsx
+++ b/app/tests/unit/pages/view-application.test.tsx
@@ -13,6 +13,12 @@ const query: viewApplicationQueryResponse['query'] = {
     }
   },
   application: {
+    latestDraftRevision: {
+      versionNumber: 1
+    },
+    latestSubmittedRevision: {
+      versionNumber: 1
+    },
     applicationRevisionStatus: {
       applicationRevisionStatus: 'SUBMITTED'
     },
@@ -31,19 +37,365 @@ const query: viewApplicationQueryResponse['query'] = {
           }
         }
       ]
+    },
+    reviewCommentsByApplicationId: {
+      edges: []
     }
   }
 };
 
-// It matches the last accepted Snapshot
-it('matches the last accepted Snapshot', () => {
-  const wrapper = shallow(<ViewApplication query={query} router={null} />);
-  expect(wrapper).toMatchSnapshot();
-});
+describe('View submitted application page', () => {
+  it('passes a query to the ApplicationDetailsComponent component', () => {
+    const r = shallow(
+      <ViewApplication
+        query={query}
+        router={{
+          query: {
+            applicationId: 'testing',
+            version: '1'
+          }
+        }}
+      />
+    );
+    expect(
+      r.find('Relay(ApplicationDetailsComponent)').first().prop('query')
+    ).toBe(query);
+  });
 
-it('passes a query to the ApplicationDetailsComponent component', () => {
-  const wrapper = shallow(<ViewApplication query={query} router={null} />);
-  expect(
-    wrapper.find('Relay(ApplicationDetailsComponent)').first().prop('query')
-  ).toBe(query);
+  it('does not show an application decision when unreviewed', () => {
+    const r = shallow(
+      <ViewApplication
+        query={{
+          ...query,
+          application: {
+            ...query.application
+          }
+        }}
+        router={{
+          query: {
+            applicationId: 'testing',
+            version: '1'
+          }
+        }}
+      />
+    );
+    expect(r.find('ApplicationDecision')).toBeEmpty();
+    expect(r).toMatchSnapshot();
+  });
+
+  it('shows approval when reviewed and approved', () => {
+    const decision = 'APPROVED';
+    const r = shallow(
+      <ViewApplication
+        query={{
+          ...query,
+          application: {
+            ...query.application,
+            latestDraftRevision: {
+              versionNumber: 1
+            },
+            latestSubmittedRevision: {
+              versionNumber: 1
+            },
+            applicationRevisionStatus: {
+              applicationRevisionStatus: decision
+            }
+          }
+        }}
+        router={{
+          query: {
+            applicationId: 'testing',
+            version: '1'
+          }
+        }}
+      />
+    );
+    expect(r.find('ApplicationDecision').first().prop('decision')).toBe(
+      decision
+    );
+    expect(
+      r.find('ApplicationDecision').first().prop('actionRequired')
+    ).toBeFalse();
+    expect(
+      r.find('ApplicationDecision').first().prop('reviewComments')
+    ).toBeEmpty();
+    expect(r).toMatchSnapshot();
+  });
+
+  it('shows rejection when reviewed and rejected', () => {
+    const decision = 'REJECTED';
+    const r = shallow(
+      <ViewApplication
+        query={{
+          ...query,
+          application: {
+            ...query.application,
+            latestDraftRevision: {
+              versionNumber: 1
+            },
+            latestSubmittedRevision: {
+              versionNumber: 1
+            },
+            applicationRevisionStatus: {
+              applicationRevisionStatus: decision
+            }
+          }
+        }}
+        router={{
+          query: {
+            applicationId: 'testing',
+            version: '1'
+          }
+        }}
+      />
+    );
+    expect(r.find('ApplicationDecision').first().prop('decision')).toBe(
+      decision
+    );
+    expect(
+      r.find('ApplicationDecision').first().prop('actionRequired')
+    ).toBeFalse();
+    expect(
+      r.find('ApplicationDecision').first().prop('reviewComments')
+    ).toBeEmpty();
+    expect(r).toMatchSnapshot();
+  });
+
+  it('shows reviewer comments when reviewed and rejected', () => {
+    const decision = 'REJECTED';
+    const comments = [
+      'We cannot accept applications from facilities that are either not regulated under GGIRCA, or which paid no carbon tax in 2020.'
+    ];
+    const r = shallow(
+      <ViewApplication
+        query={{
+          ...query,
+          application: {
+            ...query.application,
+            latestDraftRevision: {
+              versionNumber: 1
+            },
+            latestSubmittedRevision: {
+              versionNumber: 1
+            },
+            applicationRevisionStatus: {
+              applicationRevisionStatus: decision
+            },
+            reviewCommentsByApplicationId: {
+              edges: [
+                {
+                  node: {
+                    description: comments[0],
+                    resolved: false,
+                    commentType: 'GENERAL'
+                  }
+                }
+              ]
+            }
+          }
+        }}
+        router={{
+          query: {
+            applicationId: 'testing',
+            version: '1'
+          }
+        }}
+      />
+    );
+    expect(r.find('ApplicationDecision').first().prop('decision')).toBe(
+      decision
+    );
+    expect(
+      r.find('ApplicationDecision').first().prop('actionRequired')
+    ).toBeFalse();
+    expect(
+      r.find('ApplicationDecision').first().prop('reviewComments')
+    ).toBeArrayOfSize(1);
+    expect(
+      r.find('ApplicationDecision').first().prop('reviewComments')[0]
+    ).toBe(comments[0]);
+    expect(r).toMatchSnapshot();
+  });
+
+  it('displays a "Revise" button when changes are requested, and there is no newer revision', () => {
+    const decision = 'REQUESTED_CHANGES';
+    const comments = [
+      'The operator name is slightly different from a previous match we have on file: should it be "Virtucon Limited" instead of "Virtucon Ltd"?'
+    ];
+    const r = shallow(
+      <ViewApplication
+        query={{
+          ...query,
+          application: {
+            ...query.application,
+            latestDraftRevision: {
+              versionNumber: 1
+            },
+            latestSubmittedRevision: {
+              versionNumber: 1
+            },
+            applicationRevisionStatus: {
+              applicationRevisionStatus: decision
+            },
+            reviewCommentsByApplicationId: {
+              edges: [
+                {
+                  node: {
+                    description: comments[0],
+                    resolved: false,
+                    commentType: 'GENERAL'
+                  }
+                }
+              ]
+            }
+          }
+        }}
+        router={{
+          query: {
+            applicationId: 'testing',
+            version: '1'
+          }
+        }}
+      />
+    );
+    expect(r.find('ApplicationDecision').first().prop('decision')).toBe(
+      decision
+    );
+    expect(
+      r.find('ApplicationDecision').first().prop('actionRequired')
+    ).toBeTrue();
+    expect(
+      r.find('ApplicationDecision').first().prop('reviewComments')
+    ).toBeArrayOfSize(1);
+    expect(
+      r.find('ApplicationDecision').first().prop('reviewComments')[0]
+    ).toBe(comments[0]);
+    expect(r).toMatchSnapshot();
+  });
+
+  it('displays a "Resume latest draft" button when changes are requested, and there is already a newer draft (not submitted)', () => {
+    const r = shallow(
+      <ViewApplication
+        query={{
+          ...query,
+          application: {
+            ...query.application,
+            latestDraftRevision: {
+              versionNumber: 2
+            },
+            latestSubmittedRevision: {
+              versionNumber: 1
+            },
+            applicationRevisionStatus: {
+              applicationRevisionStatus: 'REQUESTED_CHANGES'
+            },
+            reviewCommentsByApplicationId: {
+              edges: [
+                {
+                  node: {
+                    description: 'This is a comment',
+                    resolved: false,
+                    commentType: 'GENERAL'
+                  }
+                }
+              ]
+            }
+          }
+        }}
+        router={{
+          query: {
+            applicationId: 'testing',
+            version: '1'
+          }
+        }}
+      />
+    );
+    expect(r.exists('Button')).toBe(true);
+    expect(r.find('Button').text()).toBe('Resume latest draft');
+    expect(r).toMatchSnapshot();
+  });
+
+  it('should render a "View most recent submission" button when viewing an older submission (viewed version < last submitted version)', () => {
+    const r = shallow(
+      <ViewApplication
+        query={{
+          ...query,
+          application: {
+            ...query.application,
+            latestDraftRevision: {
+              versionNumber: 2
+            },
+            latestSubmittedRevision: {
+              versionNumber: 2
+            },
+            applicationRevisionStatus: {
+              applicationRevisionStatus: 'REQUESTED_CHANGES'
+            },
+            reviewCommentsByApplicationId: {
+              edges: [
+                {
+                  node: {
+                    description: 'This is a comment',
+                    resolved: false,
+                    commentType: 'GENERAL'
+                  }
+                }
+              ]
+            }
+          }
+        }}
+        router={{
+          query: {
+            applicationId: 'testing',
+            version: '1'
+          }
+        }}
+      />
+    );
+    expect(r).toMatchSnapshot();
+    expect(r.exists('Button')).toBe(true);
+    expect(r.find('Button').text()).toBe('View most recent submission');
+  });
+
+  it('should render a "View most recent submission" button when viewing an older submission that has BOTH a newer submission, and at least two newer drafts', () => {
+    const r = shallow(
+      <ViewApplication
+        query={{
+          ...query,
+          application: {
+            ...query.application,
+            latestDraftRevision: {
+              versionNumber: 3
+            },
+            latestSubmittedRevision: {
+              versionNumber: 2
+            },
+            applicationRevisionStatus: {
+              applicationRevisionStatus: 'REQUESTED_CHANGES'
+            },
+            reviewCommentsByApplicationId: {
+              edges: [
+                {
+                  node: {
+                    description: 'This is a comment',
+                    resolved: false,
+                    commentType: 'GENERAL'
+                  }
+                }
+              ]
+            }
+          }
+        }}
+        router={{
+          query: {
+            applicationId: 'testing',
+            version: '1'
+          }
+        }}
+      />
+    );
+    expect(r).toMatchSnapshot();
+    expect(r.exists('Button')).toBe(true);
+    expect(r.find('Button').text()).toBe('View most recent submission');
+  });
 });


### PR DESCRIPTION
On `/reporter/view-application`:
- See [screenshots](https://youtrack.button.is/issue/GGIRCS-2297#focus=streamItem-4-4629.0-0) of all the possible decision/revision/submission states that an application can be in.
- Moves the 'View latest submission' and 'Resume latest draft' buttons into the main page for DOM reasons

On `/reporter/application`:
- Replaces ApplicationCommentsContainer with new revamped ApplicationDecision component (re-used from the above page) - see [screenshot](https://youtrack.button.is/issue/GGIRCS-2297#focus=streamItem-4-4692.0-0)

[GGIRCS-2297](https://youtrack.button.is/issue/GGIRCS-2297)