### PR TITLE
fix: don't drop ciip_portal user during revert

### DIFF
--- a/.bin/sqitch-check-immutable-files.sh
+++ b/.bin/sqitch-check-immutable-files.sh
@@ -4,8 +4,8 @@
 # usage: sqitch-immutable-files.sh schema_dir base_branch
 
 set -euo pipefail
-# gets the list of modified files via git diff, and removes the schema/(deploy|revert|verify) prefix, and the .sql suffix to match the sqitch plan change name
-modified_changes=$(git diff --name-only "${2}" -- "${1}"/deploy "${1}"/revert "${1}"/verify | sed -e "s/.*\/\(deploy\|verify\|revert\)\///g; s/@.*//g; s/\.sql$//g")
+# gets the list of modified files via git diff, and removes the schema/deploy prefix, and the .sql suffix to match the sqitch plan change name
+modified_changes=$(git diff --name-only "${2}" -- "${1}"/deploy | sed -e "s/.*\/\(deploy\)\///g; s/@.*//g; s/\.sql$//g")
 
 # finds the last tag in the sqitch plan in the base branch
 last_tag_on_base_branch=$(git show "${2}":"${1}"/sqitch.plan | tac | sed '/^@/q' | cut -d' ' -f1 )

--- a/schema/revert/database_functions/create_portal_app_user.sql
+++ b/schema/revert/database_functions/create_portal_app_user.sql
@@ -19,6 +19,4 @@ do $$
   end;
 $$;
 
-drop user ciip_portal;
-
 commit;


### PR DESCRIPTION
dropping the user during revert caused an issue during `make test` when both the local _dev and _test databases existed. The deploy does a `create if not exists...` anyway.