### PR TITLE
Chore: updating tools-version to postgres 12.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,6 +195,11 @@ jobs:
       image: ubuntu-1604:201903-01
     working_directory: ~/cas-ciip-portal
     steps:
+      - run:
+          name: install libdbd-pg-perl
+          command: |
+            sudo apt-get update
+            sudo apt-get install libdbd-pg-perl
       - attach_workspace:
           at: ~/
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           command: |
             # @see https://github.com/pyenv/pyenv/wiki/Common-build-problems
             sudo apt-get update
-            sudo apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
+            sudo apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget libdbd-pg-perl
       - restore_cache:
           name: Restore asdf Tools Cache
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,6 +312,11 @@ jobs:
       image: ubuntu-1604:201903-01
     working_directory: ~/cas-ciip-portal
     steps:
+      - run:
+          name: install libdbd-pg-perl
+          command: |
+            sudo apt-get update
+            sudo apt-get install libdbd-pg-perl
       - attach_workspace:
           at: ~/
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,6 +342,11 @@ jobs:
       image: ubuntu-1604:201903-01
     working_directory: ~/cas-ciip-portal
     steps:
+      - run:
+          name: install libdbd-pg-perl
+          command: |
+            sudo apt-get update
+            sudo apt-get install libdbd-pg-perl
       - attach_workspace:
           at: ~/
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
       - run:
           name: Install tools via asdf
           command: |
-            [[ -d ~/.asdf ]] || git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.7.4
-            pushd ~/.asdf && git checkout v0.7.4 && popd
+            [[ -d ~/.asdf ]] || git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.8.0
+            pushd ~/.asdf && git checkout v0.8.0 && popd
             echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.bashrc
             echo -e '\nexport BASH_ENV="~/.asdf/asdf.sh"' >> ~/.bashrc
             source ~/.bashrc

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 nodejs 12.20.1
 yarn 1.22.0
-postgres 11.4
+postgres 12.6
 python 3.7.0

--- a/schema/test/unit/database_functions/upsert_policy_test.sql
+++ b/schema/test/unit/database_functions/upsert_policy_test.sql
@@ -71,9 +71,9 @@ select policies_are(
 
 select results_eq(
   $$
-    select qual from pg_policies where policyname = 'admin_delete'
+    select qual::boolean from pg_policies where policyname = 'admin_delete'
   $$,
-  ARRAY['true'::text],
+  ARRAY[true],
   'policy admin_delete using qualifier is TRUE'
 );
 
@@ -86,9 +86,9 @@ select lives_ok(
 
 select results_eq(
   $$
-    select qual from pg_policies where policyname = 'admin_delete'
+    select qual::boolean from pg_policies where policyname = 'admin_delete'
   $$,
-  ARRAY['false'::text],
+  ARRAY[false],
   'policy admin_delete using qualifier has been changed to FALSE'
 );
 
@@ -103,9 +103,9 @@ select qual, with_check from pg_policies where policyname = 'different_statement
 
 select row_eq(
   $$
-    select qual, with_check from pg_policies where policyname = 'different_statement_update'
+    select qual::boolean, with_check::boolean from pg_policies where policyname = 'different_statement_update'
   $$,
-  ROW('true'::text, 'false'::text),
+  ROW(true, false),
   'policy different_statement_update has different values for using qualifier and with_check'
 );
 

--- a/schema/test/unit/mutations/create_application_revision_mutation_chain_test.sql
+++ b/schema/test/unit/mutations/create_application_revision_mutation_chain_test.sql
@@ -118,7 +118,8 @@ select results_eq(
     select version_number from ggircs_portal.facility f
     join ggircs_portal.application a on f.id = a.facility_id
     join ggircs_portal.application_revision ar on a.id = ar.application_id
-    and f.facility_name = 'has swrs';
+    and f.facility_name = 'has swrs'
+    order by version_number;
   $$,
   ARRAY[0::integer, 1::integer],
   'If an application has a swrs report, two application revisions are created with version_number 0 for swrs and 1 for draft'


### PR DESCRIPTION
Updating postgres version in the asdf tools, for development and test environments only.
cas-postgres uses 12.2 on the patroni HA cluster