### PR TITLE
refactor: insert default review_steps in migration

### DIFF
--- a/schema/deploy/tables/review_step.sql
+++ b/schema/deploy/tables/review_step.sql
@@ -31,4 +31,8 @@ comment on column ggircs_portal.review_step.id is 'Primary key for review_step t
 comment on column ggircs_portal.review_step.step_name is 'Unique step_name to be included in during an application review';
 comment on column ggircs_portal.review_step.is_active is 'Boolean value indicates if the step is currently in use when reviewing an application';
 
+-- Create initial review step rows
+insert into ggircs_portal.review_step(step_name, is_active)
+  values ('legacy', false), ('administrative', true), ('technical', true);
+
 commit;


### PR DESCRIPTION
Adds an insert in the migration to create the default [legacy, administrative, technical] steps into the table