### PR TITLE
Fix/y18n npm advisory

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -148,7 +148,7 @@
     "**/node-fetch": "^2.6.1",
     "next/resolve-url-loader/adjust-sourcemap-loader/object-path": "0.11.5",
     "**/axios": "^0.21.1",
-    "**/y18n": "5.0.5"
+    "**/y18n": "4.0.1"
   },
   "jest": {
     "testMatch": [

--- a/app/package.json
+++ b/app/package.json
@@ -147,7 +147,8 @@
     "**/@types/relay-runtime": "^9.1.6",
     "**/node-fetch": "^2.6.1",
     "next/resolve-url-loader/adjust-sourcemap-loader/object-path": "0.11.5",
-    "**/axios": "^0.21.1"
+    "**/axios": "^0.21.1",
+    "**/y18n": "5.0.5"
   },
   "jest": {
     "testMatch": [

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -15103,10 +15103,10 @@ xtend@^4.0.0, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-y18n@5.0.5, y18n@^4.0.0:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
-  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
+y18n@4.0.1, y18n@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
+  integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
 
 yallist@^2.1.2:
   version "2.1.2"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -15103,10 +15103,10 @@ xtend@^4.0.0, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-y18n@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+y18n@5.0.5, y18n@^4.0.0:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
+  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
 
 yallist@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
Resolve y18n subdependency to v4.0.1
latest is 5.0.5 but because the parent dependencies (jest, graphile-worker) use "^4.0.0" using 5.0.5 causes an incompatibility warning.
4.0.1 is unaffected by the vulnerability