### PR TITLE
refactor: apply default form result column

### DIFF
--- a/schema/deploy/mutations/create_application_revision_mutation_chain.sql
+++ b/schema/deploy/mutations/create_application_revision_mutation_chain.sql
@@ -48,11 +48,7 @@ begin
 
     else
       -- Populate initial version of application form results with data from swrs or empty results
-      if ((select fj.name from ggircs_portal.form_json as fj where temp_row.form_id = fj.id) in ('Production', 'fuel')) then
-        form_result='[{}]';
-      else
-        form_result = '{}';
-      end if;
+      form_result = (select default_form_result from ggircs_portal.form_json fj where temp_row.form_id = fj.id);
       if (select prepopulate_from_swrs from ggircs_portal.form_json where id = temp_row.form_id) then
         select form_result_init_function from ggircs_portal.form_json where id = temp_row.form_id into init_function;
         if (init_function is not null) then

--- a/schema/test/unit/mutations/create_application_mutation_chain_test.sql
+++ b/schema/test/unit/mutations/create_application_mutation_chain_test.sql
@@ -3,7 +3,7 @@ create extension if not exists pgtap;
 reset client_min_messages;
 
 begin;
-select plan(3);
+select plan(4);
 
 select has_function(
   'ggircs_portal', 'create_application_mutation_chain', array['integer'],
@@ -28,6 +28,12 @@ select ggircs_portal.create_application_mutation_chain((select id from ggircs_po
 select is(
   (select report_id from ggircs_portal.application where id = 1), 42::integer,
   'create_application_mutation_chain copies the report_id from the facility table to the application table'
+);
+
+select is(
+  (select form_result from ggircs_portal.form_result where application_id=1 and version_number=1 and form_id=1),
+  (select default_form_result from ggircs_portal.form_json where id=1),
+  'The initial empty form_result is derived from the form_json.default_form_result column'
 );
 
 -- Set the timestamp to a time where the application window is closed

--- a/schema/test/unit/mutations/create_application_revision_mutation_chain_test.sql
+++ b/schema/test/unit/mutations/create_application_revision_mutation_chain_test.sql
@@ -43,9 +43,10 @@ short_name,
 description,
 form_json,
 prepopulate_from_ciip,
-prepopulate_from_swrs
+prepopulate_from_swrs,
+default_form_result
 ) values
-('admin', 'admin-2018', 'admin', 'admin', '{}', false, false);
+('admin', 'admin-2018', 'admin', 'admin', '{}', false, false, '{}');
 
 insert into ggircs_portal.ciip_application_wizard(form_id, form_position, is_active)
 values ((select id from ggircs_portal.form_json order by id desc limit 1), 0, false);


### PR DESCRIPTION
create_application_revision_mutation_chain() was fragile, using 'slug' names to determine the shape of an initially empty form_result.
The empty result is now defined by the `default_form_result` column on the form_json table