### PR TITLE
fix: acme-challenge should be served even when using https

### DIFF
--- a/app/server/index.js
+++ b/app/server/index.js
@@ -108,12 +108,11 @@ app.prepare().then(async () => {
   // Enable serving ACME HTTP-01 challenge response written to disk by acme.sh
   // https://letsencrypt.org/docs/challenge-types/#http-01-challenge
   // https://github.com/acmesh-official/acme.sh
-  if (!secure) {
-    server.use(
-      '/.well-known',
-      express.static(path.resolve(__dirname, '../.well-known'))
-    );
-  }
+  server.use(
+    '/.well-known',
+    express.static(path.resolve(__dirname, '../.well-known'))
+  );
+
   server.use(bodyParser.json({limit: '50mb'}));
   server.use(cors());
 


### PR DESCRIPTION
The SSL issuer may ask to verify the domain when renewing a certificate