### PR TITLE
test: mock_open_window accepts a year to mock as open

### DIFF
--- a/test_helper_schema/deploy/mock_open_window.sql
+++ b/test_helper_schema/deploy/mock_open_window.sql
@@ -3,40 +3,43 @@
 
 begin;
 
-create or replace function test_helper.mock_open_window()
+create or replace function test_helper.mock_open_window(opened_reporting_year int default 2019)
 returns void as
 $function$
+begin
 
-  -- Mock the opened_reporting_year() function to always return the row for 2019 (mocked below to always be open)
-  create or replace function ggircs_portal.opened_reporting_year()
+  -- Mock the opened_reporting_year() function to always return the row for the input year (mocked below to always be open)
+  execute 'create or replace function ggircs_portal.opened_reporting_year()
   returns ggircs_portal.reporting_year as
   $$
-    select *
-    from ggircs_portal.reporting_year
-    where reporting_year = 2019
-  $$ language sql stable;
+      select *
+      from ggircs_portal.reporting_year
+      where reporting_year=' || opened_reporting_year::text || '
+  $$ language sql stable;';
+
 
   /**
-    Mocking the open/close date for applications to now() +/- interval '1 day' can cause conflicts as these dates cannot overlap with other rows.
-    This update statement fixes the overlap issue if it exists.
+    We "park" the application open and close times 100 years back to avoid conflicts with now()
+    Using the reporting year itself as source makes sure we don't generate overlapping ranges in
+    the past if this function gets executed multiple times
   **/
   update ggircs_portal.reporting_year
   set
-  application_open_time = '2010-01-01 00:00:00.000000-07',
-  application_close_time= '2010-12-12 00:00:00.000000-07'
+  application_open_time = ((reporting_year - 100) || '-01-01 00:00:00.000000-07')::timestamptz,
+  application_close_time= ((reporting_year - 100) || '-12-12 00:00:00.000000-07')::timestamptz
   where
   now() - interval '1 day' between application_open_time and application_close_time
   or
   now() + interval '1 day' between application_open_time and application_close_time;
 
-  -- Upserts a row for the 2019 year where current date is always open
+  -- Upserts a row for the year where current date is always open
   insert into ggircs_portal.reporting_year(reporting_year, reporting_period_start, reporting_period_end, swrs_deadline, application_open_time, application_close_time)
   overriding system value
   values(
-    2019,
-    '2019-01-01 00:00:00.0-08',
-    '2019-12-31 23:59:59.0-08',
-    '2019-07-31 00:00:00.000000-07',
+    opened_reporting_year,
+    (opened_reporting_year::text || '-01-01 00:00:00.0-08')::timestamptz,
+    (opened_reporting_year::text || '-12-31 23:59:59.0-08')::timestamptz,
+    (opened_reporting_year::text || '-07-31 00:00:00.000000-07')::timestamptz,
     (select now() - interval '1 day'),
     (select now() + interval '1 day')
   ) on conflict(reporting_year) do update set
@@ -47,6 +50,7 @@ $function$
     application_close_time=excluded.application_close_time
   ;
 
-$function$ language sql;
+end;
+$function$ language plpgsql volatile;
 
 commit;

--- a/test_helper_schema/verify/mock_open_window.sql
+++ b/test_helper_schema/verify/mock_open_window.sql
@@ -2,6 +2,6 @@
 
 BEGIN;
 
-select pg_get_functiondef('test_helper.mock_open_window()'::regprocedure);
+select pg_get_functiondef('test_helper.mock_open_window(int)'::regprocedure);
 
 ROLLBACK;


### PR DESCRIPTION
This adds a input parameter to `test_helper_schema.mock_open_window( )`
- will modify the reporting year passed in to open `now() - 1 day` and close `now() + 1 day`
- defaults to reporting year 2019