### PR TITLE
Feat: allow deprecation of emission categories

### DIFF
--- a/app/containers/Forms/EmissionCategoryRowIdField.tsx
+++ b/app/containers/Forms/EmissionCategoryRowIdField.tsx
@@ -22,10 +22,10 @@ export const EmissionCategoryRowIdFieldComponent: React.FunctionComponent<Props>
       ...props,
       schema: {
         ...props.schema,
-        enum: props.query.allEmissionCategories.edges.map(
+        enum: props.query.activeEmissionCategories.edges.map(
           ({node}) => node.rowId
         ),
-        enumNames: props.query.allEmissionCategories.edges.map(
+        enumNames: props.query.activeEmissionCategories.edges.map(
           ({node}) => node.displayName
         )
       },
@@ -34,13 +34,39 @@ export const EmissionCategoryRowIdFieldComponent: React.FunctionComponent<Props>
     [props]
   );
 
+  // If the form data is set to an archived emission category, we return a text field
+  if (props.formData !== undefined) {
+    const archivedEmissionCategory = props.query.archivedEmissionCategories.edges.find(
+      ({node}) => node.rowId === props.formData
+    );
+
+    if (archivedEmissionCategory !== undefined)
+      return (
+        <span className="col-md-12">
+          {archivedEmissionCategory.node.displayName}
+        </span>
+      );
+  }
+
   return <props.registry.fields.StringField {...fieldProps} />;
 };
 
 export default createFragmentContainer(EmissionCategoryRowIdFieldComponent, {
   query: graphql`
     fragment EmissionCategoryRowIdField_query on Query {
-      allEmissionCategories {
+      activeEmissionCategories: allEmissionCategories(
+        filter: {deletedAt: {isNull: true}}
+      ) {
+        edges {
+          node {
+            rowId
+            displayName
+          }
+        }
+      }
+      archivedEmissionCategories: allEmissionCategories(
+        filter: {deletedAt: {isNull: false}}
+      ) {
         edges {
           node {
             rowId

--- a/app/containers/Forms/FuelField.tsx
+++ b/app/containers/Forms/FuelField.tsx
@@ -3,7 +3,6 @@ import {FieldProps} from '@rjsf/core';
 import {createFragmentContainer, graphql} from 'react-relay';
 import {FuelField_query} from 'FuelField_query.graphql';
 import ObjectField from '@rjsf/core/dist/cjs/components/fields/ObjectField';
-import {Alert} from 'react-bootstrap';
 
 interface Props extends FieldProps {
   query: FuelField_query;
@@ -34,19 +33,7 @@ export const FuelFieldComponent: React.FunctionComponent<Props> = (props) => {
   };
 
   return (
-    <>
-      {isFuelArchived && (
-        <Alert variant="danger">
-          <strong>Warning:</strong> This fuel has been archived. Please remove
-          it and select an appropriate alternative.
-        </Alert>
-      )}
-      <ObjectField
-        {...props}
-        disabled={isFuelArchived}
-        onChange={handleChange}
-      />
-    </>
+    <ObjectField {...props} disabled={isFuelArchived} onChange={handleChange} />
   );
 };
 

--- a/app/tests/unit/containers/Forms/EmissionCategoryRowIdField.test.tsx
+++ b/app/tests/unit/containers/Forms/EmissionCategoryRowIdField.test.tsx
@@ -4,32 +4,15 @@ import {
   EmissionCategoryRowIdFieldComponent,
   Props
 } from 'containers/Forms/EmissionCategoryRowIdField';
-import {getDefaultRegistry} from '@rjsf/core/dist/cjs/utils';
+import {createDefaultJsonSchemaFormProps} from 'tests/json-schema-utils';
 
 describe('The EmissionCategoryRowIdField component', () => {
   it('injects the category ids and names in the json schema', () => {
-    const idSchema: any = {$id: 'emissionCategoryRowId'}; // TODO: revise type after react-jsonschema-form v2 is used
     const props: Props = {
-      name: 'emissionCategoryRowId',
-      schema: {
-        type: 'number',
-        title: 'emission category'
-      },
-      uiSchema: {},
-      idSchema,
-      formData: 1,
-      errorSchema: null,
-      onChange: jest.fn,
-      onBlur: jest.fn,
-      registry: getDefaultRegistry(),
-      formContext: null,
-      autofocus: false,
-      disabled: false,
-      readonly: false,
-      required: true,
+      ...createDefaultJsonSchemaFormProps(),
       query: {
         ' $refType': 'EmissionCategoryRowIdField_query',
-        allEmissionCategories: {
+        activeEmissionCategories: {
           edges: [
             {
               node: {
@@ -44,8 +27,14 @@ describe('The EmissionCategoryRowIdField component', () => {
               }
             }
           ]
+        },
+        archivedEmissionCategories: {
+          edges: []
         }
-      }
+      },
+      formData: 1,
+      name: 'emissionCategoryRowId',
+      required: true
     };
     const renderedField = shallow(
       <EmissionCategoryRowIdFieldComponent {...props} />
@@ -54,5 +43,34 @@ describe('The EmissionCategoryRowIdField component', () => {
     const fieldSchemaProp = renderedField.prop('schema');
     expect(fieldSchemaProp.enum).toHaveLength(2);
     expect(fieldSchemaProp.enumNames).toHaveLength(2);
+  });
+
+  it('Renders an uneditable <span> element if the emission category is archived', () => {
+    const props: Props = {
+      ...createDefaultJsonSchemaFormProps(),
+      query: {
+        ' $refType': 'EmissionCategoryRowIdField_query',
+        activeEmissionCategories: {
+          edges: []
+        },
+        archivedEmissionCategories: {
+          edges: [
+            {
+              node: {
+                rowId: 100,
+                displayName: 'Deleted Emission Category'
+              }
+            }
+          ]
+        }
+      },
+      formData: 100,
+      name: 'emissionCategoryRowId',
+      required: true
+    };
+    const renderedField = shallow(
+      <EmissionCategoryRowIdFieldComponent {...props} />
+    );
+    expect(renderedField).toMatchSnapshot();
   });
 });

--- a/app/tests/unit/containers/Forms/FuelField.test.tsx
+++ b/app/tests/unit/containers/Forms/FuelField.test.tsx
@@ -63,7 +63,7 @@ describe('The Fuel Field', () => {
     expect(component.find('ObjectField').at(0).prop('disabled')).toBe(false);
   });
 
-  it('renders an alert box and a disabled form when the form data fuel is archived', () => {
+  it('renders a disabled form when the form data fuel is archived', () => {
     const testQuery: FuelField_query = {
       allFuels: {
         edges: [

--- a/app/tests/unit/containers/Forms/__snapshots__/EmissionCategoryRowIdField.test.tsx.snap
+++ b/app/tests/unit/containers/Forms/__snapshots__/EmissionCategoryRowIdField.test.tsx.snap
@@ -1,20 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`The EmissionCategoryRowIdField component Renders an uneditable <span> element if the emission category is archived 1`] = `
+<span
+  className="col-md-12"
+>
+  Deleted Emission Category
+</span>
+`;
+
 exports[`The EmissionCategoryRowIdField component injects the category ids and names in the json schema 1`] = `
 <StringField
   autofocus={false}
   disabled={false}
-  errorSchema={null}
-  formContext={null}
+  errorSchema={Object {}}
+  formContext={Object {}}
   formData={1}
   idSchema={
     Object {
-      "$id": "emissionCategoryRowId",
+      "$id": null,
     }
   }
   name="emissionCategoryRowId"
-  onBlur={[Function]}
-  onChange={[Function]}
+  onBlur={[MockFunction]}
+  onChange={[MockFunction]}
   readonly={false}
   registry={
     Object {
@@ -69,8 +77,6 @@ exports[`The EmissionCategoryRowIdField component injects the category ids and n
         "cat A",
         "cat B",
       ],
-      "title": "emission category",
-      "type": "number",
     }
   }
   uiSchema={Object {}}

--- a/app/tests/unit/containers/Forms/__snapshots__/EmissionCategoryRowIdField.test.tsx.snap
+++ b/app/tests/unit/containers/Forms/__snapshots__/EmissionCategoryRowIdField.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`The EmissionCategoryRowIdField component injects the category ids and n
   formData={1}
   idSchema={
     Object {
-      "$id": null,
+      "$id": "myField",
     }
   }
   name="emissionCategoryRowId"

--- a/app/tests/unit/containers/Forms/__snapshots__/FuelField.test.tsx.snap
+++ b/app/tests/unit/containers/Forms/__snapshots__/FuelField.test.tsx.snap
@@ -13,27 +13,22 @@ exports[`The Fuel Field renders a disabled form when the form data fuel is archi
   }
   idSchema={
     Object {
-      "$id": null,
+      "$id": "myField",
     }
-    idSchema={
-      Object {
-        "$id": "myField",
-      }
-    }
-    name=""
-    onBlur={[MockFunction]}
-    onChange={[Function]}
-    query={
-      Object {
-        " $refType": "FuelField_query",
-        "allFuels": Object {
-          "edges": Array [
-            Object {
-              "node": Object {
-                "rowId": 1,
-                "state": "archived",
-                "units": "unit",
-              },
+  }
+  name=""
+  onBlur={[MockFunction]}
+  onChange={[Function]}
+  query={
+    Object {
+      " $refType": "FuelField_query",
+      "allFuels": Object {
+        "edges": Array [
+          Object {
+            "node": Object {
+              "rowId": 1,
+              "state": "archived",
+              "units": "unit",
             },
           },
         ],
@@ -99,10 +94,10 @@ exports[`The Fuel Field renders an interactive form when the form data fuel is a
     Object {
       "fuelRowId": 1,
     }
-    idSchema={
-      Object {
-        "$id": "myField",
-      }
+  }
+  idSchema={
+    Object {
+      "$id": "myField",
     }
   }
   name=""
@@ -183,10 +178,10 @@ exports[`The Fuel Field renders an interactive form when the form data is undefi
     Object {
       "fuelRowId": undefined,
     }
-    idSchema={
-      Object {
-        "$id": "myField",
-      }
+  }
+  idSchema={
+    Object {
+      "$id": "myField",
     }
   }
   name=""

--- a/app/tests/unit/containers/Forms/__snapshots__/FuelField.test.tsx.snap
+++ b/app/tests/unit/containers/Forms/__snapshots__/FuelField.test.tsx.snap
@@ -1,40 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`The Fuel Field renders an alert box and a disabled form when the form data fuel is archived 1`] = `
-<Fragment>
-  <Alert
-    closeLabel="Close alert"
-    show={true}
-    transition={
-      Object {
-        "$$typeof": Symbol(react.forward_ref),
-        "defaultProps": Object {
-          "appear": false,
-          "in": false,
-          "mountOnEnter": false,
-          "timeout": 300,
-          "unmountOnExit": false,
-        },
-        "displayName": "Fade",
-        "render": [Function],
-      }
+exports[`The Fuel Field renders a disabled form when the form data fuel is archived 1`] = `
+<ObjectField
+  autofocus={false}
+  disabled={true}
+  errorSchema={Object {}}
+  formContext={Object {}}
+  formData={
+    Object {
+      "fuelRowId": 1,
     }
-    variant="danger"
-  >
-    <strong>
-      Warning:
-    </strong>
-     This fuel has been archived. Please remove it and select an appropriate alternative.
-  </Alert>
-  <ObjectField
-    autofocus={false}
-    disabled={true}
-    errorSchema={Object {}}
-    formContext={Object {}}
-    formData={
-      Object {
-        "fuelRowId": 1,
-      }
+  }
+  idSchema={
+    Object {
+      "$id": null,
     }
     idSchema={
       Object {
@@ -56,228 +35,224 @@ exports[`The Fuel Field renders an alert box and a disabled form when the form d
                 "units": "unit",
               },
             },
-          ],
-        },
-      }
+          },
+        ],
+      },
     }
-    readonly={false}
-    registry={
-      Object {
-        "definitions": Object {},
-        "fields": Object {
-          "AnyOfField": [Function],
-          "ArrayField": [Function],
-          "BooleanField": [Function],
-          "DescriptionField": [Function],
-          "NullField": [Function],
-          "NumberField": [Function],
-          "ObjectField": undefined,
-          "OneOfField": [Function],
-          "SchemaField": [Function],
-          "StringField": [Function],
-          "TitleField": [Function],
-          "UnsupportedField": [Function],
-        },
-        "formContext": Object {},
-        "rootSchema": Object {},
-        "widgets": Object {
-          "AltDateTimeWidget": [Function],
-          "AltDateWidget": [Function],
-          "BaseInput": [Function],
-          "CheckboxWidget": [Function],
-          "CheckboxesWidget": [Function],
-          "ColorWidget": [Function],
-          "DateTimeWidget": [Function],
-          "DateWidget": [Function],
-          "EmailWidget": [Function],
-          "FileWidget": [Function],
-          "HiddenWidget": [Function],
-          "PasswordWidget": [Function],
-          "RadioWidget": [Function],
-          "RangeWidget": [Function],
-          "SelectWidget": [Function],
-          "TextWidget": [Function],
-          "TextareaWidget": [Function],
-          "URLWidget": [Function],
-          "UpDownWidget": [Function],
-        },
-      }
+  }
+  readonly={false}
+  registry={
+    Object {
+      "definitions": Object {},
+      "fields": Object {
+        "AnyOfField": [Function],
+        "ArrayField": [Function],
+        "BooleanField": [Function],
+        "DescriptionField": [Function],
+        "NullField": [Function],
+        "NumberField": [Function],
+        "ObjectField": undefined,
+        "OneOfField": [Function],
+        "SchemaField": [Function],
+        "StringField": [Function],
+        "TitleField": [Function],
+        "UnsupportedField": [Function],
+      },
+      "formContext": Object {},
+      "rootSchema": Object {},
+      "widgets": Object {
+        "AltDateTimeWidget": [Function],
+        "AltDateWidget": [Function],
+        "BaseInput": [Function],
+        "CheckboxWidget": [Function],
+        "CheckboxesWidget": [Function],
+        "ColorWidget": [Function],
+        "DateTimeWidget": [Function],
+        "DateWidget": [Function],
+        "EmailWidget": [Function],
+        "FileWidget": [Function],
+        "HiddenWidget": [Function],
+        "PasswordWidget": [Function],
+        "RadioWidget": [Function],
+        "RangeWidget": [Function],
+        "SelectWidget": [Function],
+        "TextWidget": [Function],
+        "TextareaWidget": [Function],
+        "URLWidget": [Function],
+        "UpDownWidget": [Function],
+      },
     }
-    required={false}
-    schema={Object {}}
-    uiSchema={Object {}}
-  />
-</Fragment>
+  }
+  required={false}
+  schema={Object {}}
+  uiSchema={Object {}}
+/>
 `;
 
 exports[`The Fuel Field renders an interactive form when the form data fuel is active 1`] = `
-<Fragment>
-  <ObjectField
-    autofocus={false}
-    disabled={false}
-    errorSchema={Object {}}
-    formContext={Object {}}
-    formData={
-      Object {
-        "fuelRowId": 1,
-      }
+<ObjectField
+  autofocus={false}
+  disabled={false}
+  errorSchema={Object {}}
+  formContext={Object {}}
+  formData={
+    Object {
+      "fuelRowId": 1,
     }
     idSchema={
       Object {
         "$id": "myField",
       }
     }
-    name=""
-    onBlur={[MockFunction]}
-    onChange={[Function]}
-    query={
-      Object {
-        " $refType": "FuelField_query",
-        "allFuels": Object {
-          "edges": Array [
-            Object {
-              "node": Object {
-                "rowId": 1,
-                "state": "published",
-                "units": "unit",
-              },
+  }
+  name=""
+  onBlur={[MockFunction]}
+  onChange={[Function]}
+  query={
+    Object {
+      " $refType": "FuelField_query",
+      "allFuels": Object {
+        "edges": Array [
+          Object {
+            "node": Object {
+              "rowId": 1,
+              "state": "published",
+              "units": "unit",
             },
-          ],
-        },
-      }
+          },
+        ],
+      },
     }
-    readonly={false}
-    registry={
-      Object {
-        "definitions": Object {},
-        "fields": Object {
-          "AnyOfField": [Function],
-          "ArrayField": [Function],
-          "BooleanField": [Function],
-          "DescriptionField": [Function],
-          "NullField": [Function],
-          "NumberField": [Function],
-          "ObjectField": undefined,
-          "OneOfField": [Function],
-          "SchemaField": [Function],
-          "StringField": [Function],
-          "TitleField": [Function],
-          "UnsupportedField": [Function],
-        },
-        "formContext": Object {},
-        "rootSchema": Object {},
-        "widgets": Object {
-          "AltDateTimeWidget": [Function],
-          "AltDateWidget": [Function],
-          "BaseInput": [Function],
-          "CheckboxWidget": [Function],
-          "CheckboxesWidget": [Function],
-          "ColorWidget": [Function],
-          "DateTimeWidget": [Function],
-          "DateWidget": [Function],
-          "EmailWidget": [Function],
-          "FileWidget": [Function],
-          "HiddenWidget": [Function],
-          "PasswordWidget": [Function],
-          "RadioWidget": [Function],
-          "RangeWidget": [Function],
-          "SelectWidget": [Function],
-          "TextWidget": [Function],
-          "TextareaWidget": [Function],
-          "URLWidget": [Function],
-          "UpDownWidget": [Function],
-        },
-      }
+  }
+  readonly={false}
+  registry={
+    Object {
+      "definitions": Object {},
+      "fields": Object {
+        "AnyOfField": [Function],
+        "ArrayField": [Function],
+        "BooleanField": [Function],
+        "DescriptionField": [Function],
+        "NullField": [Function],
+        "NumberField": [Function],
+        "ObjectField": undefined,
+        "OneOfField": [Function],
+        "SchemaField": [Function],
+        "StringField": [Function],
+        "TitleField": [Function],
+        "UnsupportedField": [Function],
+      },
+      "formContext": Object {},
+      "rootSchema": Object {},
+      "widgets": Object {
+        "AltDateTimeWidget": [Function],
+        "AltDateWidget": [Function],
+        "BaseInput": [Function],
+        "CheckboxWidget": [Function],
+        "CheckboxesWidget": [Function],
+        "ColorWidget": [Function],
+        "DateTimeWidget": [Function],
+        "DateWidget": [Function],
+        "EmailWidget": [Function],
+        "FileWidget": [Function],
+        "HiddenWidget": [Function],
+        "PasswordWidget": [Function],
+        "RadioWidget": [Function],
+        "RangeWidget": [Function],
+        "SelectWidget": [Function],
+        "TextWidget": [Function],
+        "TextareaWidget": [Function],
+        "URLWidget": [Function],
+        "UpDownWidget": [Function],
+      },
     }
-    required={false}
-    schema={Object {}}
-    uiSchema={Object {}}
-  />
-</Fragment>
+  }
+  required={false}
+  schema={Object {}}
+  uiSchema={Object {}}
+/>
 `;
 
 exports[`The Fuel Field renders an interactive form when the form data is undefined 1`] = `
-<Fragment>
-  <ObjectField
-    autofocus={false}
-    disabled={false}
-    errorSchema={Object {}}
-    formContext={Object {}}
-    formData={
-      Object {
-        "fuelRowId": undefined,
-      }
+<ObjectField
+  autofocus={false}
+  disabled={false}
+  errorSchema={Object {}}
+  formContext={Object {}}
+  formData={
+    Object {
+      "fuelRowId": undefined,
     }
     idSchema={
       Object {
         "$id": "myField",
       }
     }
-    name=""
-    onBlur={[MockFunction]}
-    onChange={[Function]}
-    query={
-      Object {
-        " $refType": "FuelField_query",
-        "allFuels": Object {
-          "edges": Array [
-            Object {
-              "node": Object {
-                "rowId": 1,
-                "state": "published",
-                "units": "unit",
-              },
+  }
+  name=""
+  onBlur={[MockFunction]}
+  onChange={[Function]}
+  query={
+    Object {
+      " $refType": "FuelField_query",
+      "allFuels": Object {
+        "edges": Array [
+          Object {
+            "node": Object {
+              "rowId": 1,
+              "state": "published",
+              "units": "unit",
             },
-          ],
-        },
-      }
+          },
+        ],
+      },
     }
-    readonly={false}
-    registry={
-      Object {
-        "definitions": Object {},
-        "fields": Object {
-          "AnyOfField": [Function],
-          "ArrayField": [Function],
-          "BooleanField": [Function],
-          "DescriptionField": [Function],
-          "NullField": [Function],
-          "NumberField": [Function],
-          "ObjectField": undefined,
-          "OneOfField": [Function],
-          "SchemaField": [Function],
-          "StringField": [Function],
-          "TitleField": [Function],
-          "UnsupportedField": [Function],
-        },
-        "formContext": Object {},
-        "rootSchema": Object {},
-        "widgets": Object {
-          "AltDateTimeWidget": [Function],
-          "AltDateWidget": [Function],
-          "BaseInput": [Function],
-          "CheckboxWidget": [Function],
-          "CheckboxesWidget": [Function],
-          "ColorWidget": [Function],
-          "DateTimeWidget": [Function],
-          "DateWidget": [Function],
-          "EmailWidget": [Function],
-          "FileWidget": [Function],
-          "HiddenWidget": [Function],
-          "PasswordWidget": [Function],
-          "RadioWidget": [Function],
-          "RangeWidget": [Function],
-          "SelectWidget": [Function],
-          "TextWidget": [Function],
-          "TextareaWidget": [Function],
-          "URLWidget": [Function],
-          "UpDownWidget": [Function],
-        },
-      }
+  }
+  readonly={false}
+  registry={
+    Object {
+      "definitions": Object {},
+      "fields": Object {
+        "AnyOfField": [Function],
+        "ArrayField": [Function],
+        "BooleanField": [Function],
+        "DescriptionField": [Function],
+        "NullField": [Function],
+        "NumberField": [Function],
+        "ObjectField": undefined,
+        "OneOfField": [Function],
+        "SchemaField": [Function],
+        "StringField": [Function],
+        "TitleField": [Function],
+        "UnsupportedField": [Function],
+      },
+      "formContext": Object {},
+      "rootSchema": Object {},
+      "widgets": Object {
+        "AltDateTimeWidget": [Function],
+        "AltDateWidget": [Function],
+        "BaseInput": [Function],
+        "CheckboxWidget": [Function],
+        "CheckboxesWidget": [Function],
+        "ColorWidget": [Function],
+        "DateTimeWidget": [Function],
+        "DateWidget": [Function],
+        "EmailWidget": [Function],
+        "FileWidget": [Function],
+        "HiddenWidget": [Function],
+        "PasswordWidget": [Function],
+        "RadioWidget": [Function],
+        "RangeWidget": [Function],
+        "SelectWidget": [Function],
+        "TextWidget": [Function],
+        "TextareaWidget": [Function],
+        "URLWidget": [Function],
+        "UpDownWidget": [Function],
+      },
     }
-    required={false}
-    schema={Object {}}
-    uiSchema={Object {}}
-  />
-</Fragment>
+  }
+  required={false}
+  schema={Object {}}
+  uiSchema={Object {}}
+/>
 `;

--- a/schema/data/deploy-data.sh
+++ b/schema/data/deploy-data.sh
@@ -217,7 +217,7 @@ deployDevData() {
   _psql -f "./dev/application.sql"
   _psql -f "./dev/form_result.sql"
   _psql -f "./dev/application-2018.sql"
-  _psql -f "./dev/certification_url.sql"
+  _psql -f "./dev/application_submission.sql"
   _psql -f "./dev/linked_product.sql"
   return 0;
 }

--- a/schema/data/dev/application.sql
+++ b/schema/data/dev/application.sql
@@ -23,11 +23,20 @@ begin;
   select ggircs_portal.create_application_mutation_chain(1);
   select ggircs_portal.create_application_mutation_chain(2);
 
+  select ggircs_portal.create_application_mutation_chain(10);
+  select ggircs_portal.create_application_mutation_chain(11);
+  select ggircs_portal.create_application_mutation_chain(12);
+
   -- Create an application revision on application id=1
   select ggircs_portal.create_application_revision_mutation_chain(1,1);
+  select ggircs_portal.create_application_revision_mutation_chain(3,1);
 
   -- Set legal_disclaimer_accepted to true for application id=1
   update ggircs_portal.application_revision set legal_disclaimer_accepted = true where application_id=1;
+
+  update ggircs_portal.application_revision set legal_disclaimer_accepted = true where application_id=3;
+  update ggircs_portal.application_revision set legal_disclaimer_accepted = true where application_id=4;
+  update ggircs_portal.application_revision set legal_disclaimer_accepted = true where application_id=5;
 
   alter table ggircs_portal.application_revision_status enable trigger _status_change_email;
   alter table ggircs_portal.application enable trigger _send_draft_application_email;

--- a/schema/data/dev/application_submission.sql
+++ b/schema/data/dev/application_submission.sql
@@ -14,25 +14,15 @@ select mocks.set_mocked_time_in_transaction(
   )
 );
 
-with rows as (
-insert into ggircs_portal.certification_url(id, application_id, version_number)
-overriding system value
-values
-('\xad58dd1b39a4dff1cc1e0bb1dce2d80793b85e1be4d465f6b598aa5e44558065', 1, 1),('\xad58dd1b39a4dff1cc1e0bb1dce2d80793b85e1be4d465f6b598aa5e44558065', 1, 2)
-on conflict(id) do update set
-application_id=excluded.application_id
-returning 1
-) select 'Inserted ' || count(*) || ' rows into ggircs_portal.certification_url' from rows;
-
-update ggircs_portal.certification_url set certification_signature = '12345' where application_id =1 and version_number=1;
-update ggircs_portal.certification_url set certification_signature = 'signed' where application_id =1 and version_number=2;
-
 alter table ggircs_portal.application_revision_status disable trigger _status_change_email;
 alter table ggircs_portal.application_revision_status disable trigger _read_only_status_for_non_current_version;
 
 -- Update the status of application with id=1 to be 'submitted'
 insert into ggircs_portal.application_revision_status(application_id, version_number, application_revision_status)
-  values (1,1,'submitted');
+  values
+  (1,1,'submitted'),
+  (4,1,'submitted'),
+  (5,1,'submitted');
 
 -- Moving timestamp one second forward to avoid revisions being submitted at the same time
 select mocks.set_mocked_time_in_transaction(

--- a/schema/data/dev/ciip_user_organisation.sql
+++ b/schema/data/dev/ciip_user_organisation.sql
@@ -13,12 +13,16 @@ begin;
   alter table ggircs_portal.ciip_user_organisation
     disable trigger _send_access_approved_email;
 
+  -- giving cypresstestreporter access to some organisations by default
   with rows as (
   insert into ggircs_portal.ciip_user_organisation(id, user_id, organisation_id, status)
   overriding system value
   values
   (1, 3, 8, 'approved'),
-  (2, 3, 7, 'approved')
+  (2, 3, 7, 'approved'),
+  (3, 6, 1, 'approved'),
+  (4, 6, 7, 'approved'),
+  (5, 6, 8, 'approved')
   on conflict(id) do update set
     user_id=excluded.user_id,
     organisation_id=excluded.organisation_id,

--- a/schema/data/dev/product.sql
+++ b/schema/data/dev/product.sql
@@ -39,7 +39,9 @@ values
 (38, 'Petroleum Refining','BC refining complexity factor unit','published',true, true, false, false),
 (39, 'Wood pellets', 'bone dry tonnes','published', true, true, false, false),
 (40, 'Wood chips', 'bone dry tonnes','published', true, true, false, false),
-(41, 'Waste rendering', 'tonnes','published', true, true, false, false)
+(41, 'Waste rendering', 'tonnes','published', true, true, false, false),
+-- An archived product for test purposes
+(42, 'Test Product', 'tonnes','archived', true, true, false, false)
 
 -- NOTE: Any changes to this file affects prod/energy_product.sql.
 --       Remember to update the IDs as necessary in that file as well.

--- a/schema/data/prod/emission.sql
+++ b/schema/data/prod/emission.sql
@@ -1,20 +1,20 @@
 begin;
 
 with rows as (
-insert into ggircs_portal.emission_category(id, swrs_emission_category, display_name)
+insert into ggircs_portal.emission_category(id, swrs_emission_category, display_name, deleted_at)
 overriding system value
 values
-(1, 'BC_ScheduleB_GeneralStationaryCombustionEmissions', 'General Stationary Combustion'),
-(2, 'BC_ScheduleB_IndustrialProcessEmissions', 'Industrial Process'),
-(3, 'BC_ScheduleB_VentingEmissions', 'Venting'),
-(4, 'BC_ScheduleB_FlaringEmissions', 'Flaring'),
-(5, 'BC_ScheduleB_FugitiveEmissions', 'Fugitive'),
-(6, 'BC_ScheduleB_OnSiteTransportationEmissions', 'On-Site Transportation'),
-(7, 'BC_ScheduleB_WasteEmissions', 'Waste'),
-(8, 'BC_ScheduleB_WastewaterEmissions', 'Wastewater'),
-(9, null, 'Other, non-carbon taxed')
+(1, 'BC_ScheduleB_GeneralStationaryCombustionEmissions', 'General Stationary Combustion', null),
+(2, 'BC_ScheduleB_IndustrialProcessEmissions', 'Industrial Process', null),
+(3, 'BC_ScheduleB_VentingEmissions', 'Venting', null),
+(4, 'BC_ScheduleB_FlaringEmissions', 'Flaring', null),
+(5, 'BC_ScheduleB_FugitiveEmissions', 'Fugitive', null),
+(6, 'BC_ScheduleB_OnSiteTransportationEmissions', 'On-Site Transportation', null),
+(7, 'BC_ScheduleB_WasteEmissions', 'Waste', null),
+(8, 'BC_ScheduleB_WastewaterEmissions', 'Wastewater', null),
+(9, null, 'Other, non-carbon taxed', '2021-04-13 00:00:00-07')
 
-on conflict(id) do update set swrs_emission_category=excluded.swrs_emission_category, display_name=excluded.display_name
+on conflict(id) do update set swrs_emission_category=excluded.swrs_emission_category, display_name=excluded.display_name, deleted_at=excluded.deleted_at
 returning 1
 ) select 'Inserted ' || count(*) || ' rows into ggircs_portal.emission_category' from rows;
 

--- a/schema/test/data/dev_data_test.sql
+++ b/schema/test/data/dev_data_test.sql
@@ -3,7 +3,7 @@ create extension if not exists pgtap;
 reset client_min_messages;
 
 begin;
-select plan(13);
+select plan(12);
 
 -- Following dev data (including prod) should exist
 
@@ -17,7 +17,6 @@ prepare facility_data as select * from ggircs_portal.facility;
 prepare gas_data as select * from ggircs_portal.gas;
 prepare benchmark_data as select * from ggircs_portal.benchmark;
 prepare user_data as select * from ggircs_portal.ciip_user;
-prepare certification_url_data as select * from ggircs_portal.certification_url;
 prepare application_data as select * from ggircs_portal.application;
 prepare form_result_data as select * from ggircs_portal.form_result;
 
@@ -31,7 +30,6 @@ select isnt_empty('facility_data', 'facility table should not be empty');
 select isnt_empty('gas_data', 'gas table should not be empty');
 select isnt_empty('benchmark_data', 'benchmark table should not be empty');
 select isnt_empty('user_data', 'ciip_user table should be empty');
-select isnt_empty('certification_url_data', 'certification_url table should be empty');
 select isnt_empty('application_data', 'application table should be empty');
 select isnt_empty('form_result_data', 'form_result table should be empty');
 

--- a/schema/test/unit/tables/ciip_user_organisation_test.sql
+++ b/schema/test/unit/tables/ciip_user_organisation_test.sql
@@ -126,7 +126,7 @@ select results_eq(
   $$
     select count(*) from ggircs_portal.ciip_user_organisation
   $$,
-  ARRAY[5::bigint],
+  ARRAY[8::bigint],
   'Analyst can select all from table ciip_user_organisation'
 );
 


### PR DESCRIPTION
Deprecating the 'other, non carbon-taxed' emission category

This feature will make sure that any emission category with the 'deleted_at' field set will render as read-only in existing applications, and won't be shown as an option for new applications.