### PR TITLE
Refine docs on release process

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -27,5 +27,5 @@ Steps 1.2 could automate 1.3 to 1.6. See https://github.com/conventional-changel
   * checkout `master` and pull to ensure your local master is up to date
   * `git merge develop --ff-only` to fast-forward the master branch
   * `git push origin master`
-- 2.4 The CIIP application should be ready to be deployed to the test and productions environment via https://cas-shipit.pathfinder.gov.bc.ca/
+- 2.4 The CIIP application should be ready to be deployed to the test and productions environment via https://cas-shipit.apps.silver.devops.gov.bc.ca/
 - 2.5 Add a `CIIP <version>` tag to the YouTrack cards corresponding to the commits being released.

--- a/docs/release.md
+++ b/docs/release.md
@@ -8,10 +8,11 @@ When merging to the `develop` branch, the CIIP application is continuously deplo
 - 1.2 From the root of the repository, run `./app/node_modules/.bin/standard-version`. This will generate the [changelog](../CHANGELOG.md), increase the version number following [semantic versioning](https://semver.org/), commit the changes and tag that commit.
 - 1.3 note the version number printed by standard-version (referred to as &`<version>` below)
 - 1.4 run `cd schema/ && sqitch tag v<version> -m "release v<version>"`
-- 1.5 In helm/cas-ciip-portal/Chart.yaml, set `appVersion` to `<version>`, and increase the `version` patch number.
-- 1.6 Commit with the chore(release) commit type.
+- 1.5 In `helm/cas-ciip-portal/Chart.yaml`, set `appVersion` to `<version>`, and increase the `version` patch number.
+- 1.6 Commit with the `chore(release)` commit type.
 - 1.7 Push using `git push --follow-tags`
-- 1.8 Create a pull request from chore/release to develop.
+- 1.8 Create a pull request from `chore/release` to `develop`.
+- 1.9 On approval and when checks have passed, merge the pull request before proceeding to the release CI workflow.
 
 ### Possible improvements
 
@@ -21,6 +22,10 @@ Steps 1.2 could automate 1.3 to 1.6. See https://github.com/conventional-changel
 
 - 2.1 Go to https://app.circleci.com/pipelines/github/bcgov/cas-ciip-portal?branch=develop
 - 2.2 Manually approve the `release_approval` job in the latest `release` workflow.
-- 2.3 Once the `release` workflow has passed, fast-forward the master branch and push.
+- 2.3 Once the `release` workflow has passed, the merge to `master` must be done locally:
+  * pull from `develop` (if the release PR was merged using the Github UI)
+  * checkout `master` and pull to ensure your local master is up to date
+  * `git merge develop --ff-only` to fast-forward the master branch
+  * `git push origin master`
 - 2.4 The CIIP application should be ready to be deployed to the test and productions environment via https://cas-shipit.pathfinder.gov.bc.ca/
 - 2.5 Add a `CIIP <version>` tag to the YouTrack cards corresponding to the commits being released.


### PR DESCRIPTION
- Adds (obvious? 😅) step to merge release PR before continuing to CI release workflow
- Clarifies the local merge steps that must be done for `develop` --> `master`
- Updates the URL for Shipit