### PR TITLE
Review step selector on application review page

### DIFF
--- a/app/components/Application/ApplicationOverrideNotificationCard.tsx
+++ b/app/components/Application/ApplicationOverrideNotificationCard.tsx
@@ -29,6 +29,9 @@ export const ApplicationOverrideNotification: React.FunctionComponent<Props> = (
           </Card>
         </Card.Body>
         <style jsx>{`
+          :global(#justification-card .bg-danger) {
+            color: #fff;
+          }
           #justification-card {
             margin: 1rem 0;
           }

--- a/app/components/Application/ApplicationOverrideNotificationCard.tsx
+++ b/app/components/Application/ApplicationOverrideNotificationCard.tsx
@@ -32,8 +32,8 @@ export const ApplicationOverrideNotification: React.FunctionComponent<Props> = (
           :global(#justification-card .bg-danger) {
             color: #fff;
           }
-          #justification-card {
-            margin: 1rem 0;
+          :global(#justification-card) {
+            margin: 1rem 15px;
           }
           #justification {
             max-height: 19.2em;

--- a/app/components/GenericConfirmationModal.tsx
+++ b/app/components/GenericConfirmationModal.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {Modal, Button} from 'react-bootstrap';
+
+interface Props {
+  show: boolean;
+  title: string;
+  onConfirm: () => void;
+  onCancel?: () => void;
+  confirmButtonText?: string;
+  cancelButtonText?: string;
+  confirmButtonVariant?: string;
+  cancelButtonVariant?: string;
+  size?: 'sm' | 'lg' | 'xl';
+}
+
+export const GenericConfirmationModal: React.FunctionComponent<Props> = ({
+  children,
+  show,
+  title,
+  onConfirm,
+  onCancel,
+  confirmButtonVariant,
+  confirmButtonText = 'Confirm',
+  cancelButtonVariant = 'secondary',
+  cancelButtonText = 'Cancel',
+  size
+}) => {
+  return (
+    <Modal onHide={onCancel} show={show} size={size} centered>
+      <Modal.Header>
+        <h2>{title}</h2>
+      </Modal.Header>
+      <Modal.Body>{children}</Modal.Body>
+      <Modal.Footer>
+        <Button id="cancel" onClick={onCancel} variant={cancelButtonVariant}>
+          {cancelButtonText}
+        </Button>
+        <Button id="confirm" onClick={onConfirm} variant={confirmButtonVariant}>
+          {confirmButtonText}
+        </Button>
+      </Modal.Footer>
+      <style jsx>{`
+        h2 {
+          margin-bottom: 0;
+        }
+      `}</style>
+      <style jsx global>{`
+        .modal-header {
+          background: #036;
+          color: #fff;
+        }
+        .btn-primary#confirm {
+          background: #036;
+        }
+        .btn-primary#confirm:hover,
+        .btn-primary#cancel:hover {
+          background: #002040;
+          border-color: #002040;
+        }
+        .btn-outline-primary#confirm,
+        .btn-outline-primary#cancel {
+          color: #036;
+          border-color: #036;
+        }
+        .btn-outline-primary#confirm:hover,
+        .btn-outline-primary#cancel:hover {
+          color: #fff;
+          background: #002040;
+        }
+        .btn-success#confirm {
+          background: #24883e;
+        }
+        .btn-outline-success#confirm {
+          color: #036;
+          border-color: #036;
+        }
+      `}</style>
+    </Modal>
+  );
+};
+
+export default GenericConfirmationModal;

--- a/app/components/GenericConfirmationModal.tsx
+++ b/app/components/GenericConfirmationModal.tsx
@@ -67,13 +67,6 @@ export const GenericConfirmationModal: React.FunctionComponent<Props> = ({
           color: #fff;
           background: #002040;
         }
-        .btn-success#confirm {
-          background: #24883e;
-        }
-        .btn-outline-success#confirm {
-          color: #036;
-          border-color: #036;
-        }
       `}</style>
     </Modal>
   );

--- a/app/components/GenericConfirmationModal.tsx
+++ b/app/components/GenericConfirmationModal.tsx
@@ -5,7 +5,7 @@ interface Props {
   show: boolean;
   title: string;
   onConfirm: () => void;
-  onCancel?: () => void;
+  onCancel: () => void;
   confirmButtonText?: string;
   cancelButtonText?: string;
   confirmButtonVariant?: string;

--- a/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
+++ b/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
@@ -21,7 +21,7 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
   return (
     <Row>
       <Col md={5}>
-        <ListGroup as="ul" role="listbox">
+        <ListGroup as="ul">
           {steps.map((edge) => {
             const {reviewStepId, isComplete} = edge.node;
             const isSelectedStep = edge.node.id === selectedStep;
@@ -32,7 +32,6 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
               <ListGroup.Item
                 as="li"
                 action
-                role="option"
                 tabIndex={0}
                 key={reviewStepId}
                 aria-selected={isSelectedStep}
@@ -64,7 +63,6 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
           <ListGroup.Item
             as="li"
             action
-            role="option"
             key="decision"
             tabIndex={0}
             disabled

--- a/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
+++ b/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React from 'react';
 import {Row, Col, ListGroup} from 'react-bootstrap';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faCheck} from '@fortawesome/free-solid-svg-icons';
@@ -29,11 +29,15 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
       <Col md={5}>
         <ListGroup as="ul" role="listbox">
           {steps.map((edge) => {
-            const {reviewStepId} = edge.node;
+            const {reviewStepId, isComplete} = edge.node;
             const isSelectedStep = edge.node === selectedStep;
+            const callToAction = `${isComplete ? '' : 'Open'} ${capitalize(
+              edge.node.reviewStepByReviewStepId.stepName
+            )} review ${isComplete ? 'completed' : ''}`;
             return (
               <ListGroup.Item
                 as="li"
+                action
                 role="option"
                 tabIndex={0}
                 key={reviewStepId}
@@ -43,19 +47,35 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') onSelectStep(edge.node);
                 }}
-                style={{cursor: 'pointer'}}
+                style={{
+                  cursor: 'pointer',
+                  position: 'relative',
+                  paddingLeft: '3rem'
+                }}
               >
-                {capitalize(edge.node.reviewStepByReviewStepId.stepName)}
+                {isComplete && (
+                  <FontAwesomeIcon
+                    icon={faCheck}
+                    style={{
+                      position: 'absolute',
+                      left: '1.2rem',
+                      top: 'calc(50% - 0.5em)'
+                    }}
+                  />
+                )}
+                {callToAction}
               </ListGroup.Item>
             );
           })}
           <ListGroup.Item
             as="li"
+            action
             role="option"
             key="decision"
             tabIndex={0}
             disabled
             aria-disabled
+            style={{cursor: 'pointer', paddingLeft: '3rem'}}
           >
             Make a decision or request changes
           </ListGroup.Item>

--- a/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
+++ b/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
@@ -84,7 +84,6 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
                 action
                 tabIndex={0}
                 key={reviewStepId}
-                aria-selected={isSelectedStep}
                 active={isSelectedStep}
                 onClick={() => onSelectStep(edge.node.id)}
                 onKeyDown={(e) => {

--- a/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
+++ b/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
@@ -131,14 +131,17 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
           </ListGroup.Item>
         </ListGroup>
       </div>
-        {changeDecision && (
-          <div id="change-decision" className="col-md-12 col-lg-4 col-xl-5 col-xxl-6">
-            <Button variant="link" onClick={changeDecision}>
-              <FontAwesomeIcon icon={faKey} style={{marginRight: 8}} />
-              Change decision
-            </Button>
-          </div>
-        )}
+      {changeDecision && (
+        <div
+          id="change-decision"
+          className="col-md-12 col-lg-4 col-xl-5 col-xxl-6"
+        >
+          <Button variant="link" onClick={changeDecision}>
+            <FontAwesomeIcon icon={faKey} style={{marginRight: 8}} />
+            Change decision
+          </Button>
+        </div>
+      )}
       <style jsx>{`
         #change-decision {
           display: flex;

--- a/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
+++ b/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Row, Col, ListGroup} from 'react-bootstrap';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {faCheck} from '@fortawesome/free-solid-svg-icons';
+import {faCheck, faComments} from '@fortawesome/free-solid-svg-icons';
 import {graphql, createFragmentContainer} from 'react-relay';
 import {ApplicationReviewStepSelector_applicationReviewSteps} from '__generated__/ApplicationReviewStepSelector_applicationReviewSteps.graphql';
 import {capitalize} from 'lib/text-transforms';
@@ -18,6 +18,16 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
   onSelectStep
 }) => {
   const steps = applicationReviewSteps.edges;
+  const renderStepStatusIcon = (icon) => (
+    <FontAwesomeIcon
+      icon={icon}
+      style={{
+        position: 'absolute',
+        left: '1.2rem',
+        top: 'calc(50% - 0.5em)'
+      }}
+    />
+  );
   return (
     <Row>
       <Col md={5}>
@@ -46,16 +56,7 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
                   paddingLeft: '3rem'
                 }}
               >
-                {isComplete && (
-                  <FontAwesomeIcon
-                    icon={faCheck}
-                    style={{
-                      position: 'absolute',
-                      left: '1.2rem',
-                      top: 'calc(50% - 0.5em)'
-                    }}
-                  />
-                )}
+                {renderStepStatusIcon(isComplete ? faCheck : faComments)}
                 {callToAction}
               </ListGroup.Item>
             );

--- a/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
+++ b/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
@@ -2,20 +2,18 @@ import React from 'react';
 import {Row, Col, ListGroup} from 'react-bootstrap';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faCheck} from '@fortawesome/free-solid-svg-icons';
-import {graphql, createFragmentContainer, RelayProp} from 'react-relay';
+import {graphql, createFragmentContainer} from 'react-relay';
 import {ApplicationReviewStepSelector_applicationReviewSteps} from '__generated__/ApplicationReviewStepSelector_applicationReviewSteps.graphql';
 import {capitalize} from 'lib/text-transforms';
 
 interface Props {
   applicationReviewSteps: ApplicationReviewStepSelector_applicationReviewSteps;
-  relay: RelayProp;
   selectedStep: string;
   onSelectStep: (stepId: string) => void;
 }
 
 export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
   applicationReviewSteps,
-  relay,
   selectedStep,
   onSelectStep
 }) => {

--- a/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
+++ b/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
@@ -1,0 +1,82 @@
+import React, {useState} from 'react';
+import {Row, Col, ListGroup} from 'react-bootstrap';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import {faCheck} from '@fortawesome/free-solid-svg-icons';
+import {graphql, createFragmentContainer, RelayProp} from 'react-relay';
+import {ApplicationReviewStepSelector_applicationReviewSteps} from '__generated__/ApplicationReviewStepSelector_applicationReviewSteps.graphql';
+import updateApplicationReviewStepMutation from 'mutations/application_review_step/updateApplicationReviewStepMutation';
+import {capitalize} from 'lib/text-transforms';
+
+interface Props {
+  applicationReviewSteps: ApplicationReviewStepSelector_applicationReviewSteps;
+  relay: RelayProp;
+  selectedStep: ApplicationReviewStepSelector_applicationReviewSteps['edges']['node'];
+  onSelectStep: (
+    step: ApplicationReviewStepSelector_applicationReviewSteps['edges']['node']
+  ) => void;
+}
+
+export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
+  applicationReviewSteps,
+  relay,
+  selectedStep,
+  onSelectStep
+}) => {
+  const steps = applicationReviewSteps.edges;
+  console.log('selector: selected step is ', selectedStep);
+  return (
+    <Row>
+      <Col md={5}>
+        <ListGroup as="ul" role="listbox">
+          {steps.map((edge) => {
+            const {reviewStepId} = edge.node;
+            const isSelectedStep = edge.node === selectedStep;
+            return (
+              <ListGroup.Item
+                as="li"
+                role="option"
+                tabIndex={0}
+                key={reviewStepId}
+                aria-selected={isSelectedStep}
+                active={isSelectedStep}
+                onClick={() => onSelectStep(edge.node)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') onSelectStep(edge.node);
+                }}
+                style={{cursor: 'pointer'}}
+              >
+                {capitalize(edge.node.reviewStepByReviewStepId.stepName)}
+              </ListGroup.Item>
+            );
+          })}
+          <ListGroup.Item
+            as="li"
+            role="option"
+            key="decision"
+            tabIndex={0}
+            disabled
+            aria-disabled
+          >
+            Make a decision or request changes
+          </ListGroup.Item>
+        </ListGroup>
+      </Col>
+    </Row>
+  );
+};
+
+export default createFragmentContainer(ApplicationReviewStepSelector, {
+  applicationReviewSteps: graphql`
+    fragment ApplicationReviewStepSelector_applicationReviewSteps on ApplicationReviewStepsConnection {
+      edges {
+        node {
+          isComplete
+          reviewStepId
+          reviewStepByReviewStepId {
+            stepName
+          }
+        }
+      }
+    }
+  `
+});

--- a/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
+++ b/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
@@ -4,16 +4,13 @@ import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faCheck} from '@fortawesome/free-solid-svg-icons';
 import {graphql, createFragmentContainer, RelayProp} from 'react-relay';
 import {ApplicationReviewStepSelector_applicationReviewSteps} from '__generated__/ApplicationReviewStepSelector_applicationReviewSteps.graphql';
-import updateApplicationReviewStepMutation from 'mutations/application_review_step/updateApplicationReviewStepMutation';
 import {capitalize} from 'lib/text-transforms';
 
 interface Props {
   applicationReviewSteps: ApplicationReviewStepSelector_applicationReviewSteps;
   relay: RelayProp;
-  selectedStep: ApplicationReviewStepSelector_applicationReviewSteps['edges']['node'];
-  onSelectStep: (
-    step: ApplicationReviewStepSelector_applicationReviewSteps['edges']['node']
-  ) => void;
+  selectedStep: string;
+  onSelectStep: (stepId: string) => void;
 }
 
 export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
@@ -23,14 +20,13 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
   onSelectStep
 }) => {
   const steps = applicationReviewSteps.edges;
-  console.log('selector: selected step is ', selectedStep);
   return (
     <Row>
       <Col md={5}>
         <ListGroup as="ul" role="listbox">
           {steps.map((edge) => {
             const {reviewStepId, isComplete} = edge.node;
-            const isSelectedStep = edge.node === selectedStep;
+            const isSelectedStep = edge.node.id === selectedStep;
             const callToAction = `${isComplete ? '' : 'Open'} ${capitalize(
               edge.node.reviewStepByReviewStepId.stepName
             )} review ${isComplete ? 'completed' : ''}`;
@@ -43,9 +39,9 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
                 key={reviewStepId}
                 aria-selected={isSelectedStep}
                 active={isSelectedStep}
-                onClick={() => onSelectStep(edge.node)}
+                onClick={() => onSelectStep(edge.node.id)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter') onSelectStep(edge.node);
+                  if (e.key === 'Enter') onSelectStep(edge.node.id);
                 }}
                 style={{
                   cursor: 'pointer',
@@ -90,6 +86,7 @@ export default createFragmentContainer(ApplicationReviewStepSelector, {
     fragment ApplicationReviewStepSelector_applicationReviewSteps on ApplicationReviewStepsConnection {
       edges {
         node {
+          id
           isComplete
           reviewStepId
           reviewStepByReviewStepId {

--- a/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
+++ b/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
@@ -9,6 +9,7 @@ import {
   faKey
 } from '@fortawesome/free-solid-svg-icons';
 import {graphql, createFragmentContainer} from 'react-relay';
+import {CiipApplicationRevisionStatus} from 'applicationReviewQuery.graphql';
 import {ApplicationReviewStepSelector_applicationReviewSteps} from '__generated__/ApplicationReviewStepSelector_applicationReviewSteps.graphql';
 import {capitalize} from 'lib/text-transforms';
 
@@ -16,11 +17,7 @@ interface Props {
   applicationReviewSteps: ApplicationReviewStepSelector_applicationReviewSteps;
   selectedStep: string;
   onSelectStep: (stepId: string) => void;
-  decisionOrChangeRequestStatus:
-    | 'SUBMITTED'
-    | 'APPROVED'
-    | 'REJECTED'
-    | 'REQUESTED_CHANGES';
+  decisionOrChangeRequestStatus: CiipApplicationRevisionStatus;
   onDecisionOrChangeRequestAction: () => void;
   changeDecision?: () => void;
 }
@@ -80,6 +77,7 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
             )} review ${isComplete ? 'completed' : ''}`;
             return (
               <ListGroup.Item
+                className="review-step-option"
                 as="li"
                 action
                 tabIndex={0}
@@ -101,6 +99,7 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
             );
           })}
           <ListGroup.Item
+            id="open-decision-dialog"
             as="li"
             action
             key="decision"
@@ -129,17 +128,14 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
           </ListGroup.Item>
         </ListGroup>
       </div>
-      <div
-        id="change-decision"
-        className="col-md-12 col-lg-4 col-xl-5 col-xxl-6"
-      >
         {changeDecision && (
-          <Button variant="link" onClick={changeDecision}>
-            <FontAwesomeIcon icon={faKey} style={{marginRight: 8}} />
-            Change decision
-          </Button>
+          <div id="change-decision" className="col-md-12 col-lg-4 col-xl-5 col-xxl-6">
+            <Button variant="link" onClick={changeDecision}>
+              <FontAwesomeIcon icon={faKey} style={{marginRight: 8}} />
+              Change decision
+            </Button>
+          </div>
         )}
-      </div>
       <style jsx>{`
         #change-decision {
           display: flex;

--- a/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
+++ b/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
@@ -108,7 +108,10 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
             style={{cursor: 'pointer', paddingLeft: '3rem'}}
             disabled={decisionOrChangeRequestIsDisabled}
             aria-disabled={decisionOrChangeRequestIsDisabled}
-            onClick={onDecisionOrChangeRequestAction}
+            onClick={() => {
+              if (!decisionOrChangeRequestIsDisabled)
+                onDecisionOrChangeRequestAction();
+            }}
             onKeyDown={(e) => {
               if (e.key === 'Enter' && !decisionOrChangeRequestIsDisabled)
                 onDecisionOrChangeRequestAction();

--- a/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
+++ b/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
@@ -78,7 +78,7 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
     <Button
       variant="link"
       disabled
-      style={{color: '#343a40', textAlign: 'left'}}
+      style={{opacity: 1, color: '#343a40', textAlign: 'left'}}
     >
       <FontAwesomeIcon icon={faLock} style={{marginRight: 8}} />
       There is a newer draft of this application.

--- a/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
+++ b/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import {Row, Col, ListGroup} from 'react-bootstrap';
+import {Row, Button, ListGroup} from 'react-bootstrap';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {
   faCheck,
   faComments,
   faTimes,
-  faHourglassHalf
+  faHourglassHalf,
+  faKey
 } from '@fortawesome/free-solid-svg-icons';
 import {graphql, createFragmentContainer} from 'react-relay';
 import {ApplicationReviewStepSelector_applicationReviewSteps} from '__generated__/ApplicationReviewStepSelector_applicationReviewSteps.graphql';
@@ -21,6 +22,7 @@ interface Props {
     | 'REJECTED'
     | 'REQUESTED_CHANGES';
   onDecisionOrChangeRequestAction: () => void;
+  changeDecision?: () => void;
 }
 
 const DECISION_BS_VARIANT = {
@@ -48,7 +50,8 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
   selectedStep,
   onSelectStep,
   decisionOrChangeRequestStatus,
-  onDecisionOrChangeRequestAction
+  onDecisionOrChangeRequestAction,
+  changeDecision
 }) => {
   const steps = applicationReviewSteps.edges;
   const allStepsAreComplete = steps.every((edge) => edge.node.isComplete);
@@ -67,7 +70,7 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
   );
   return (
     <Row>
-      <Col md={5}>
+      <div className="col-xxl-6 col-xl-7 col-lg-8 col-md-10">
         <ListGroup as="ul" id="selector">
           {steps.map((edge) => {
             const {reviewStepId, isComplete} = edge.node;
@@ -126,7 +129,24 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
             {DECISION_BUTTON_TEXT[decisionOrChangeRequestStatus]}
           </ListGroup.Item>
         </ListGroup>
-      </Col>
+      </div>
+      <div
+        id="change-decision"
+        className="col-md-12 col-lg-4 col-xl-5 col-xxl-6"
+      >
+        {changeDecision && (
+          <Button variant="link" onClick={changeDecision}>
+            <FontAwesomeIcon icon={faKey} style={{marginRight: 8}} />
+            Change decision
+          </Button>
+        )}
+      </div>
+      <style jsx>{`
+        #change-decision {
+          display: flex;
+          align-items: flex-end;
+        }
+      `}</style>
       <style jsx global>{`
         #selector .list-group-item-danger.disabled,
         .list-group-item-danger:disabled {

--- a/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
+++ b/app/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.tsx
@@ -4,6 +4,7 @@ import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {
   faCheck,
   faComments,
+  faLock,
   faTimes,
   faHourglassHalf,
   faKey
@@ -18,6 +19,7 @@ interface Props {
   selectedStep: string;
   onSelectStep: (stepId: string) => void;
   decisionOrChangeRequestStatus: CiipApplicationRevisionStatus;
+  newerDraftExists: boolean;
   onDecisionOrChangeRequestAction: () => void;
   changeDecision?: () => void;
 }
@@ -47,6 +49,7 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
   selectedStep,
   onSelectStep,
   decisionOrChangeRequestStatus,
+  newerDraftExists,
   onDecisionOrChangeRequestAction,
   changeDecision
 }) => {
@@ -64,6 +67,22 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
         top: 'calc(50% - 0.5em)'
       }}
     />
+  );
+  const changeDecisionButton = (
+    <Button variant="link" onClick={changeDecision}>
+      <FontAwesomeIcon icon={faKey} style={{marginRight: 8}} />
+      Change decision
+    </Button>
+  );
+  const newDraftIndicator = (
+    <Button
+      variant="link"
+      disabled
+      style={{color: '#343a40', textAlign: 'left'}}
+    >
+      <FontAwesomeIcon icon={faLock} style={{marginRight: 8}} />
+      There is a newer draft of this application.
+    </Button>
   );
   return (
     <Row>
@@ -136,10 +155,7 @@ export const ApplicationReviewStepSelector: React.FunctionComponent<Props> = ({
           id="change-decision"
           className="col-md-12 col-lg-4 col-xl-5 col-xxl-6"
         >
-          <Button variant="link" onClick={changeDecision}>
-            <FontAwesomeIcon icon={faKey} style={{marginRight: 8}} />
-            Change decision
-          </Button>
+          {newerDraftExists ? newDraftIndicator : changeDecisionButton}
         </div>
       )}
       <style jsx>{`

--- a/app/containers/Admin/ApplicationReview/ReviewSidebar.tsx
+++ b/app/containers/Admin/ApplicationReview/ReviewSidebar.tsx
@@ -15,6 +15,7 @@ import GenericConfirmationModal from 'components/GenericConfirmationModal';
 interface Props {
   onClose: () => void;
   applicationReviewStep: ReviewSidebar_applicationReviewStep;
+  isFinalized: boolean;
   relay: RelayProp;
   headerOffset?: number;
 }
@@ -22,6 +23,7 @@ interface Props {
 export const ReviewSidebar: React.FunctionComponent<Props> = ({
   onClose,
   applicationReviewStep,
+  isFinalized,
   relay,
   headerOffset = 68
 }) => {
@@ -86,6 +88,24 @@ export const ReviewSidebar: React.FunctionComponent<Props> = ({
       <FontAwesomeIcon icon={faCheck} style={{marginRight: '0.5rem'}} />
       Mark this review step completed
     </Button>
+  );
+  const markIncompleteButton = (
+    <p className="mark-incomplete">
+      <FontAwesomeIcon icon={faCheck} style={{marginRight: 2}} />
+      <span> This review step has been completed. </span>
+      <Button
+        variant="link"
+        style={{
+          padding: '0 0 2px 0',
+          fontSize: '0.9rem',
+          lineHeight: 1,
+          display: 'inline'
+        }}
+        onClick={() => markReviewStepComplete(false)}
+      >
+        Mark incomplete
+      </Button>
+    </p>
   );
   const resolveComment = async (id, resolve) => {
     const {environment} = relay;
@@ -182,26 +202,10 @@ export const ReviewSidebar: React.FunctionComponent<Props> = ({
         ×
       </button>
       <h2>{reviewStepName} Review</h2>
-      {applicationReviewStep?.isComplete ? (
-        <p className="mark-incomplete">
-          <FontAwesomeIcon icon={faCheck} style={{marginRight: 2}} />
-          <span> This review step has been completed. </span>
-          <Button
-            variant="link"
-            style={{
-              padding: '0 0 2px 0',
-              fontSize: '0.9rem',
-              lineHeight: 1,
-              display: 'inline'
-            }}
-            onClick={() => markReviewStepComplete(false)}
-          >
-            Mark incomplete
-          </Button>
-        </p>
-      ) : (
-        markCompletedButton
-      )}
+      {!isFinalized &&
+        (applicationReviewStep?.isComplete
+          ? markIncompleteButton
+          : markCompletedButton)}
       <div id="scrollable-comments" tabIndex={0}>
         <h3 id="general-comments-label">
           General Comments{' '}

--- a/app/containers/Admin/ApplicationReview/ReviewSidebar.tsx
+++ b/app/containers/Admin/ApplicationReview/ReviewSidebar.tsx
@@ -169,7 +169,7 @@ export const ReviewSidebar: React.FunctionComponent<Props> = ({
       onCancel={() => setShowUnresolvedCommentsModal(false)}
       confirmButtonVariant="outline-primary"
       cancelButtonVariant="primary"
-      cancelButtonText="Cancel and resolve comments"
+      cancelButtonText="Cancel"
       confirmButtonText="Mark this review step completed"
     >
       <div style={{padding: '1em 1em 0 1em'}}>

--- a/app/containers/Admin/ApplicationReview/ReviewSidebar.tsx
+++ b/app/containers/Admin/ApplicationReview/ReviewSidebar.tsx
@@ -27,23 +27,23 @@ export const ReviewSidebar: React.FunctionComponent<Props> = ({
   const [showingResolved, setShowingResolved] = useState(false);
   const toggleResolved = () => setShowingResolved((current) => !current);
   const reviewStepName = capitalize(
-    applicationReviewStep.reviewStepByReviewStepId.stepName
+    applicationReviewStep?.reviewStepByReviewStepId?.stepName
   );
 
-  const generalComments = applicationReviewStep.generalComments.edges;
-  const internalComments = applicationReviewStep.internalComments.edges;
+  const generalComments = applicationReviewStep?.generalComments?.edges;
+  const internalComments = applicationReviewStep?.internalComments?.edges;
   const noGeneralCommentsToShow =
-    generalComments.length === 0 ||
-    (!showingResolved && generalComments.every((c) => c.node.resolved));
+    generalComments?.length === 0 ||
+    (!showingResolved && generalComments?.every((c) => c.node.resolved));
   const noInternalCommentsToShow =
-    internalComments.length === 0 ||
-    (!showingResolved && internalComments.every((c) => c.node.resolved));
+    internalComments?.length === 0 ||
+    (!showingResolved && internalComments?.every((c) => c.node.resolved));
 
   const markReviewStepComplete = async (isComplete) => {
     const {environment} = relay;
     const variables = {
       input: {
-        id: applicationReviewStep.id,
+        id: applicationReviewStep?.id,
         applicationReviewStepPatch: {
           isComplete
         }
@@ -93,7 +93,7 @@ export const ReviewSidebar: React.FunctionComponent<Props> = ({
     await deleteReviewCommentMutation(
       environment,
       variables,
-      applicationReviewStep.id,
+      applicationReviewStep?.id,
       `ReviewSidebar_${commentType}Comments`
     );
   };
@@ -109,7 +109,7 @@ export const ReviewSidebar: React.FunctionComponent<Props> = ({
         description={description}
         createdAt={createdAt}
         createdBy={`${ciipUserByCreatedBy.firstName} ${ciipUserByCreatedBy.lastName}`}
-        viewOnly={applicationReviewStep.isComplete}
+        viewOnly={applicationReviewStep?.isComplete}
         isResolved={resolved}
         onResolveToggle={resolveComment}
         onDelete={(id) => deleteComment(id, commentType)}
@@ -128,7 +128,7 @@ export const ReviewSidebar: React.FunctionComponent<Props> = ({
         ×
       </button>
       <h2>{reviewStepName} Review</h2>
-      {applicationReviewStep.isComplete ? (
+      {applicationReviewStep?.isComplete ? (
         <p className="mark-incomplete">
           <FontAwesomeIcon icon={faCheck} style={{marginRight: 2}} />
           <span> This review step has been completed. </span>
@@ -159,7 +159,7 @@ export const ReviewSidebar: React.FunctionComponent<Props> = ({
           <p className="empty-comments">No general comments to show.</p>
         ) : (
           <ul aria-labelledby="general-comments-label">
-            {generalComments.map((comment) => {
+            {generalComments?.map((comment) => {
               const showComment = showingResolved || !comment.node.resolved;
               return showComment
                 ? renderComment('general', comment.node)
@@ -177,7 +177,7 @@ export const ReviewSidebar: React.FunctionComponent<Props> = ({
           <p className="empty-comments">No internal comments to show.</p>
         ) : (
           <ul aria-labelledby="internal-comments-label">
-            {internalComments.map((comment) => {
+            {internalComments?.map((comment) => {
               const showComment = showingResolved || !comment.node.resolved;
               return showComment
                 ? renderComment('internal', comment.node)
@@ -190,7 +190,7 @@ export const ReviewSidebar: React.FunctionComponent<Props> = ({
         <Button variant="link" style={{padding: 0}} onClick={toggleResolved}>
           {`${showingResolved ? 'Hide' : 'Show'} resolved comments`}
         </Button>
-        {!applicationReviewStep.isComplete && (
+        {!applicationReviewStep?.isComplete && (
           <Button variant="primary">+ New Comment</Button>
         )}
       </div>

--- a/app/containers/Admin/ApplicationReview/ReviewSidebar.tsx
+++ b/app/containers/Admin/ApplicationReview/ReviewSidebar.tsx
@@ -149,7 +149,7 @@ export const ReviewSidebar: React.FunctionComponent<Props> = ({
         description={description}
         createdAt={createdAt}
         createdBy={`${ciipUserByCreatedBy.firstName} ${ciipUserByCreatedBy.lastName}`}
-        viewOnly={applicationReviewStep?.isComplete}
+        viewOnly={isFinalized || applicationReviewStep?.isComplete}
         isResolved={resolved}
         onResolveToggle={resolveComment}
         onDelete={(id) => deleteComment(id, commentType)}
@@ -248,7 +248,7 @@ export const ReviewSidebar: React.FunctionComponent<Props> = ({
         <Button variant="link" style={{padding: 0}} onClick={toggleResolved}>
           {`${showingResolved ? 'Hide' : 'Show'} resolved comments`}
         </Button>
-        {!applicationReviewStep?.isComplete && (
+        {!isFinalized && !applicationReviewStep?.isComplete && (
           <Button variant="primary">+ New Comment</Button>
         )}
       </div>

--- a/app/containers/Applications/ApplicationDetailsContainer.tsx
+++ b/app/containers/Applications/ApplicationDetailsContainer.tsx
@@ -63,7 +63,7 @@ export const ApplicationDetailsComponent: React.FunctionComponent<Props> = ({
   return (
     <>
       <Row>
-        <Col md={{offset: 2}}>
+        <Col>
           {diffFromResults ? (
             <Form.Check
               label="Compare data between versions"

--- a/app/containers/Applications/ApplicationDetailsContainer.tsx
+++ b/app/containers/Applications/ApplicationDetailsContainer.tsx
@@ -66,6 +66,7 @@ export const ApplicationDetailsComponent: React.FunctionComponent<Props> = ({
         <Col>
           {diffFromResults ? (
             <Form.Check
+              id="toggle-diff"
               label="Compare data between versions"
               checked={showDiff}
               type="checkbox"

--- a/app/containers/Applications/ApplicationRevisionStatusContainer.tsx
+++ b/app/containers/Applications/ApplicationRevisionStatusContainer.tsx
@@ -1,13 +1,5 @@
 import React, {useState} from 'react';
-import {
-  Row,
-  Col,
-  Dropdown,
-  Button,
-  Badge,
-  Modal,
-  ListGroup
-} from 'react-bootstrap';
+import {Dropdown, Button, Badge, Modal} from 'react-bootstrap';
 import {graphql, createFragmentContainer, RelayProp} from 'react-relay';
 import DropdownMenuItemComponent from 'components/DropdownMenuItemComponent';
 import createApplicationRevisionStatusMutation from 'mutations/application/createApplicationRevisionStatusMutation';
@@ -110,61 +102,61 @@ export const ApplicationRevisionStatusComponent: React.FunctionComponent<Props> 
   } = props.applicationRevisionStatus.applicationRevisionByApplicationIdAndVersionNumber;
 
   return (
-    <Row>
+    <>
       {confirmStatusChangeModal}
       {isCurrentVersion ? (
-        <Col md={2}>
-          <Dropdown style={{width: '100%'}}>
-            <Dropdown.Toggle
-              pill
-              as={Badge}
-              style={{
-                padding: '0.6em 1em',
-                fontSize: '1em',
-                textTransform: 'uppercase'
-              }}
-              variant={
-                statusBadgeColor[
-                  props.applicationRevisionStatus.applicationRevisionStatus
-                ]
-              }
-              id="dropdown"
-            >
-              {getUserFriendlyStatusLabel(
-                props.applicationRevisionStatus.applicationRevisionStatus
-              )}
-            </Dropdown.Toggle>
-            <Dropdown.Menu style={{width: '100%'}}>
-              {Object.keys(statusBadgeColor)
-                .filter(
-                  (status) => !['DRAFT', currentRevisionStatus].includes(status)
-                )
-                .map((status) => (
-                  <DropdownMenuItemComponent
-                    key={status}
-                    itemEventKey={status}
-                    itemFunc={renderStatusConfirmationModal}
-                    itemTitle={getUserFriendlyStatusLabel(status)}
-                  />
-                ))}
-            </Dropdown.Menu>
-          </Dropdown>
-        </Col>
-      ) : (
-        <Col md={2}>
-          <Button
-            disabled
+        <Dropdown
+          as="span"
+          style={{width: '100%', fontSize: '1rem', marginLeft: '2rem'}}
+        >
+          <Dropdown.Toggle
+            pill
+            as={Badge}
+            style={{
+              padding: '0.6em 1em',
+              fontSize: '1em',
+              textTransform: 'uppercase'
+            }}
             variant={
               statusBadgeColor[
                 props.applicationRevisionStatus.applicationRevisionStatus
               ]
             }
+            id="dropdown"
           >
-            {props.applicationRevisionStatus.applicationRevisionStatus}
-          </Button>
-        </Col>
+            {getUserFriendlyStatusLabel(
+              props.applicationRevisionStatus.applicationRevisionStatus
+            )}
+          </Dropdown.Toggle>
+          <Dropdown.Menu style={{width: '100%'}}>
+            {Object.keys(statusBadgeColor)
+              .filter(
+                (status) => !['DRAFT', currentRevisionStatus].includes(status)
+              )
+              .map((status) => (
+                <DropdownMenuItemComponent
+                  key={status}
+                  itemEventKey={status}
+                  itemFunc={renderStatusConfirmationModal}
+                  itemTitle={getUserFriendlyStatusLabel(status)}
+                />
+              ))}
+          </Dropdown.Menu>
+        </Dropdown>
+      ) : (
+        <Button
+          disabled
+          variant={
+            statusBadgeColor[
+              props.applicationRevisionStatus.applicationRevisionStatus
+            ]
+          }
+          style={{fontSize: '1rem', marginLeft: '2rem'}}
+        >
+          {props.applicationRevisionStatus.applicationRevisionStatus}
+        </Button>
       )}
-    </Row>
+    </>
   );
 };
 

--- a/app/containers/Applications/ApplicationRevisionStatusContainer.tsx
+++ b/app/containers/Applications/ApplicationRevisionStatusContainer.tsx
@@ -1,5 +1,13 @@
 import React, {useState} from 'react';
-import {Row, Col, Dropdown, Button, Badge, Modal} from 'react-bootstrap';
+import {
+  Row,
+  Col,
+  Dropdown,
+  Button,
+  Badge,
+  Modal,
+  ListGroup
+} from 'react-bootstrap';
 import {graphql, createFragmentContainer, RelayProp} from 'react-relay';
 import DropdownMenuItemComponent from 'components/DropdownMenuItemComponent';
 import createApplicationRevisionStatusMutation from 'mutations/application/createApplicationRevisionStatusMutation';
@@ -103,10 +111,8 @@ export const ApplicationRevisionStatusComponent: React.FunctionComponent<Props> 
 
   return (
     <>
+      <h1>Application #[FILL ME IN]</h1>
       <Row>
-        <Col md={3}>
-          <h3>Application Status*: </h3>
-        </Col>
         {confirmStatusChangeModal}
         {isCurrentVersion ? (
           <Col md={2}>
@@ -162,19 +168,12 @@ export const ApplicationRevisionStatusComponent: React.FunctionComponent<Props> 
           </Col>
         )}
       </Row>
-      <Row>
-        <Col md={12}>
-          <p>
-            * Status changes will be immediately confirmed to the applicant by
-            email notification.
-            <br />
-            <span style={{marginLeft: '0.7em'}}>
-              General comments will become visible to the applicant once the
-              application status is updated.
-            </span>
-          </p>
-        </Col>
-      </Row>
+      <style jsx>{`
+        h1 {
+          font-size: 1.75rem;
+          margin-bottom: 20px;
+        }
+      `}</style>
     </>
   );
 };

--- a/app/containers/Applications/ApplicationRevisionStatusContainer.tsx
+++ b/app/containers/Applications/ApplicationRevisionStatusContainer.tsx
@@ -110,71 +110,61 @@ export const ApplicationRevisionStatusComponent: React.FunctionComponent<Props> 
   } = props.applicationRevisionStatus.applicationRevisionByApplicationIdAndVersionNumber;
 
   return (
-    <>
-      <h1>Application #[FILL ME IN]</h1>
-      <Row>
-        {confirmStatusChangeModal}
-        {isCurrentVersion ? (
-          <Col md={2}>
-            <Dropdown style={{width: '100%'}}>
-              <Dropdown.Toggle
-                pill
-                as={Badge}
-                style={{
-                  padding: '0.6em 1em',
-                  fontSize: '1em',
-                  textTransform: 'uppercase'
-                }}
-                variant={
-                  statusBadgeColor[
-                    props.applicationRevisionStatus.applicationRevisionStatus
-                  ]
-                }
-                id="dropdown"
-              >
-                {getUserFriendlyStatusLabel(
-                  props.applicationRevisionStatus.applicationRevisionStatus
-                )}
-              </Dropdown.Toggle>
-              <Dropdown.Menu style={{width: '100%'}}>
-                {Object.keys(statusBadgeColor)
-                  .filter(
-                    (status) =>
-                      !['DRAFT', currentRevisionStatus].includes(status)
-                  )
-                  .map((status) => (
-                    <DropdownMenuItemComponent
-                      key={status}
-                      itemEventKey={status}
-                      itemFunc={renderStatusConfirmationModal}
-                      itemTitle={getUserFriendlyStatusLabel(status)}
-                    />
-                  ))}
-              </Dropdown.Menu>
-            </Dropdown>
-          </Col>
-        ) : (
-          <Col md={2}>
-            <Button
-              disabled
+    <Row>
+      {confirmStatusChangeModal}
+      {isCurrentVersion ? (
+        <Col md={2}>
+          <Dropdown style={{width: '100%'}}>
+            <Dropdown.Toggle
+              pill
+              as={Badge}
+              style={{
+                padding: '0.6em 1em',
+                fontSize: '1em',
+                textTransform: 'uppercase'
+              }}
               variant={
                 statusBadgeColor[
                   props.applicationRevisionStatus.applicationRevisionStatus
                 ]
               }
+              id="dropdown"
             >
-              {props.applicationRevisionStatus.applicationRevisionStatus}
-            </Button>
-          </Col>
-        )}
-      </Row>
-      <style jsx>{`
-        h1 {
-          font-size: 1.75rem;
-          margin-bottom: 20px;
-        }
-      `}</style>
-    </>
+              {getUserFriendlyStatusLabel(
+                props.applicationRevisionStatus.applicationRevisionStatus
+              )}
+            </Dropdown.Toggle>
+            <Dropdown.Menu style={{width: '100%'}}>
+              {Object.keys(statusBadgeColor)
+                .filter(
+                  (status) => !['DRAFT', currentRevisionStatus].includes(status)
+                )
+                .map((status) => (
+                  <DropdownMenuItemComponent
+                    key={status}
+                    itemEventKey={status}
+                    itemFunc={renderStatusConfirmationModal}
+                    itemTitle={getUserFriendlyStatusLabel(status)}
+                  />
+                ))}
+            </Dropdown.Menu>
+          </Dropdown>
+        </Col>
+      ) : (
+        <Col md={2}>
+          <Button
+            disabled
+            variant={
+              statusBadgeColor[
+                props.applicationRevisionStatus.applicationRevisionStatus
+              ]
+            }
+          >
+            {props.applicationRevisionStatus.applicationRevisionStatus}
+          </Button>
+        </Col>
+      )}
+    </Row>
   );
 };
 

--- a/app/containers/Incentives/IncentiveCalculatorContainer.tsx
+++ b/app/containers/Incentives/IncentiveCalculatorContainer.tsx
@@ -17,7 +17,7 @@ export const IncentiveCalculator: React.FunctionComponent<Props> = ({
     <>
       <Jumbotron>
         <div style={{marginBottom: '30px'}}>
-          <h5>Incentive by Product:</h5>
+          <h2>Incentive by Product:</h2>
           <p>
             This formula gives the partial incentive for each product reported
             in <br />
@@ -53,6 +53,12 @@ export const IncentiveCalculator: React.FunctionComponent<Props> = ({
           ))}
         </tbody>
       </Table>
+      <style jsx>{`
+        h2 {
+          font-size: 1.25rem;
+          margin-botton: 0.5rem;
+        }
+      `}</style>
     </>
   );
 };

--- a/app/pages/analyst/application-review.tsx
+++ b/app/pages/analyst/application-review.tsx
@@ -63,6 +63,7 @@ class ApplicationReview extends Component<Props, State> {
         applicationRevision(id: $applicationRevisionId) {
           ...ApplicationDetailsContainer_applicationRevision
           overrideJustification
+          isCurrentVersion
           ...IncentiveCalculatorContainer_applicationRevision
         }
         ...ApplicationDetailsContainer_query
@@ -106,7 +107,10 @@ class ApplicationReview extends Component<Props, State> {
   }
   render() {
     const {query} = this.props;
-    const {overrideJustification} = query?.applicationRevision;
+    const {
+      overrideJustification,
+      isCurrentVersion
+    } = query?.applicationRevision;
     const {applicationRevisionStatus} = query?.application.reviewRevisionStatus;
     const {session} = query || {};
     const isUserAdmin = query?.session.userGroups.some((groupConst) =>
@@ -158,6 +162,7 @@ class ApplicationReview extends Component<Props, State> {
               }
               selectedStep={this.state.selectedReviewStepId}
               onSelectStep={this.selectReviewStep}
+              newerDraftExists={!isCurrentVersion}
               changeDecision={
                 isUserAdmin && currentReviewIsFinalized
                   ? handleChangeDecision

--- a/app/pages/analyst/application-review.tsx
+++ b/app/pages/analyst/application-review.tsx
@@ -46,6 +46,7 @@ class ApplicationReview extends Component<Props, State> {
           reviewRevisionStatus: applicationRevisionStatus(
             versionNumberInput: $version
           ) {
+            applicationRevisionStatus
             ...ApplicationRevisionStatusContainer_applicationRevisionStatus
           }
           applicationReviewStepsByApplicationId {
@@ -105,6 +106,7 @@ class ApplicationReview extends Component<Props, State> {
   render() {
     const {query} = this.props;
     const {overrideJustification} = query?.applicationRevision;
+    const {applicationRevisionStatus} = query?.application.reviewRevisionStatus;
     const {session} = query || {};
 
     return (
@@ -136,6 +138,10 @@ class ApplicationReview extends Component<Props, State> {
             <ApplicationReviewStepSelector
               applicationReviewSteps={
                 query.application.applicationReviewStepsByApplicationId
+              }
+              decisionOrChangeRequestStatus={applicationRevisionStatus}
+              onDecisionOrChangeRequestAction={() =>
+                console.log('implement me in 2294')
               }
               selectedStep={this.state.selectedReviewStepId}
               onSelectStep={this.selectReviewStep}

--- a/app/pages/analyst/application-review.tsx
+++ b/app/pages/analyst/application-review.tsx
@@ -197,10 +197,13 @@ class ApplicationReview extends Component<Props, State> {
           )}
           {!this.state.isSidebarOpened && <HelpButton isInternalUser />}
         </Row>
-        <style jsx>{`
+        <style jsx global>{`
           h1 {
-            font-size: 1.75rem;
             margin-bottom: 20px;
+          }
+          .list-group-item.active {
+            z-index: auto;
+            background: #38598a;
           }
         `}</style>
       </DefaultLayout>

--- a/app/pages/analyst/application-review.tsx
+++ b/app/pages/analyst/application-review.tsx
@@ -188,6 +188,7 @@ class ApplicationReview extends Component<Props, State> {
             >
               <Button
                 id="to-top"
+                aria-label="Return to top of page"
                 variant="dark"
                 type="button"
                 onClick={() => {

--- a/app/pages/analyst/application-review.tsx
+++ b/app/pages/analyst/application-review.tsx
@@ -39,6 +39,7 @@ class ApplicationReview extends Component<Props, State> {
     ) {
       query {
         session {
+          userGroups
           ...defaultLayout_session
         }
         application(id: $applicationId) {
@@ -108,6 +109,7 @@ class ApplicationReview extends Component<Props, State> {
     const {overrideJustification} = query?.applicationRevision;
     const {applicationRevisionStatus} = query?.application.reviewRevisionStatus;
     const {session} = query || {};
+    const currentReviewIsFinalized = applicationRevisionStatus !== 'SUBMITTED';
 
     return (
       <DefaultLayout
@@ -196,6 +198,7 @@ class ApplicationReview extends Component<Props, State> {
               applicationReviewStep={this.findStepById(
                 this.state.selectedReviewStepId
               )}
+              isFinalized={currentReviewIsFinalized}
               onClose={this.closeSidebar}
               headerOffset={runtimeConfig.SITEWIDE_NOTICE ? 108 : undefined}
             />

--- a/app/pages/analyst/application-review.tsx
+++ b/app/pages/analyst/application-review.tsx
@@ -52,7 +52,6 @@ class ApplicationReview extends Component<Props, State> {
             edges {
               node {
                 id
-                reviewStepId
                 ...ReviewSidebar_applicationReviewStep
               }
             }

--- a/app/pages/analyst/application-review.tsx
+++ b/app/pages/analyst/application-review.tsx
@@ -101,7 +101,7 @@ class ApplicationReview extends Component<Props> {
         fixedHeader
         disableHelpButton
       >
-        <Row className="application-container">
+        <Row>
           <div
             id="application-body"
             className={`
@@ -111,6 +111,7 @@ class ApplicationReview extends Component<Props> {
              offset-md-${this.state.isSidebarOpened ? 0 : 1}
              offset-lg-${this.state.isSidebarOpened ? 0 : 1}`}
           >
+            <h1>{`Application #${query.application.rowId}`}</h1>
             <ApplicationRevisionStatusContainer
               applicationRevisionStatus={query.application.reviewRevisionStatus}
               applicationRowId={query.application.rowId}
@@ -176,6 +177,12 @@ class ApplicationReview extends Component<Props> {
           )}
           {!this.state.isSidebarOpened && <HelpButton isInternalUser />}
         </Row>
+        <style jsx>{`
+          h1 {
+            font-size: 1.75rem;
+            margin-bottom: 20px;
+          }
+        `}</style>
       </DefaultLayout>
     );
   }

--- a/app/pages/analyst/application-review.tsx
+++ b/app/pages/analyst/application-review.tsx
@@ -109,7 +109,18 @@ class ApplicationReview extends Component<Props, State> {
     const {overrideJustification} = query?.applicationRevision;
     const {applicationRevisionStatus} = query?.application.reviewRevisionStatus;
     const {session} = query || {};
-    const currentReviewIsFinalized = applicationRevisionStatus !== 'SUBMITTED';
+    const isUserAdmin = query?.session.userGroups.some((groupConst) =>
+      ADMIN_GROUP.includes(groupConst)
+    );
+    const currentReviewIsFinalized =
+      this.props.query?.application.reviewRevisionStatus
+        .applicationRevisionStatus !== 'SUBMITTED';
+
+    const handleChangeDecision = () => {
+      console.log(
+        'implement me in 2294 - should open the decision dialog with admin-only option to revert (to SUBMITTED status)'
+      );
+    };
 
     return (
       <DefaultLayout
@@ -147,6 +158,11 @@ class ApplicationReview extends Component<Props, State> {
               }
               selectedStep={this.state.selectedReviewStepId}
               onSelectStep={this.selectReviewStep}
+              changeDecision={
+                isUserAdmin && currentReviewIsFinalized
+                  ? handleChangeDecision
+                  : undefined
+              }
             />
             <ApplicationOverrideNotification
               overrideJustification={overrideJustification}

--- a/app/pages/analyst/application-review.tsx
+++ b/app/pages/analyst/application-review.tsx
@@ -111,11 +111,15 @@ class ApplicationReview extends Component<Props> {
              offset-md-${this.state.isSidebarOpened ? 0 : 1}
              offset-lg-${this.state.isSidebarOpened ? 0 : 1}`}
           >
-            <h1>{`Application #${query.application.rowId}`}</h1>
-            <ApplicationRevisionStatusContainer
-              applicationRevisionStatus={query.application.reviewRevisionStatus}
-              applicationRowId={query.application.rowId}
-            />
+            <h1>
+              {`Application #${query.application.rowId}`}
+              <ApplicationRevisionStatusContainer
+                applicationRevisionStatus={
+                  query.application.reviewRevisionStatus
+                }
+                applicationRowId={query.application.rowId}
+              />
+            </h1>
             <ApplicationReviewStepSelector
               applicationReviewSteps={
                 query.application.applicationReviewStepsByApplicationId

--- a/app/pages/analyst/application-review.tsx
+++ b/app/pages/analyst/application-review.tsx
@@ -169,9 +169,11 @@ class ApplicationReview extends Component<Props, State> {
                   : undefined
               }
             />
-            <ApplicationOverrideNotification
-              overrideJustification={overrideJustification}
-            />
+            <Row style={{marginTop: 30}}>
+              <ApplicationOverrideNotification
+                overrideJustification={overrideJustification}
+              />
+            </Row>
             <hr />
             <ApplicationDetails
               review

--- a/app/tests/unit/components/GenericConfirmationModal.test.tsx
+++ b/app/tests/unit/components/GenericConfirmationModal.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import GenericConfirmationModal from 'components/GenericConfirmationModal';
+
+const getTestElement = ({
+  size = undefined,
+  title = 'Are you sure you want to continue?',
+  show = true,
+  onCancel = () => {},
+  onConfirm = () => {},
+  cancelButtonVariant = undefined,
+  confirmButtonVariant = undefined,
+  cancelButtonText = undefined,
+  confirmButtonText = undefined,
+  children = undefined
+}) => {
+  return children ? (
+    <GenericConfirmationModal
+      size={size}
+      title={title}
+      show={show}
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+      cancelButtonVariant={cancelButtonVariant}
+      confirmButtonVariant={confirmButtonVariant}
+      cancelButtonText={cancelButtonText}
+      confirmButtonText={confirmButtonText}
+    >
+      {children}
+    </GenericConfirmationModal>
+  ) : (
+    <GenericConfirmationModal
+      size={size}
+      title={title}
+      show={show}
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+      cancelButtonVariant={cancelButtonVariant}
+      confirmButtonVariant={confirmButtonVariant}
+      cancelButtonText={cancelButtonText}
+      confirmButtonText={confirmButtonText}
+    />
+  );
+};
+
+describe('Generic Confirmation Modal', () => {
+  it('should render a default Bootstrap modal with Cancel and Confirm buttons (no body content)', () => {
+    const wrapper = shallow(getTestElement({}));
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find('Modal').prop('show')).toBeTrue();
+    // quirk of react-bootstrap: will only render a 'medium' size if left unspecified
+    expect(wrapper.find('Modal').prop('size')).toBeUndefined();
+    expect(wrapper.find('Button#cancel').exists()).toBeTrue();
+    expect(wrapper.find('Button#confirm').exists()).toBeTrue();
+  });
+  it('should render a Bootstrap modal (with custom body content)', () => {
+    const children = (
+      <div>
+        <p>
+          There is something we want you to stop and consider before continuing.
+        </p>
+        <p>
+          Here is some more detail you should be aware of before confirming this
+          action.
+        </p>
+      </div>
+    );
+    const wrapper = shallow(getTestElement({children}));
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.contains(children)).toBeTrue();
+  });
+  it('displays the `title` prop as a heading', () => {
+    const title = 'Test Title';
+    const wrapper = shallow(getTestElement({title}));
+    expect(wrapper.find('h2').text()).toEqual(title);
+  });
+  it('passes the `size` prop to the Bootstrap modal for customization', () => {
+    const small = shallow(getTestElement({size: 'sm'}));
+    const smallModal = small.find('Modal');
+    expect(smallModal.prop('size')).toEqual('sm');
+    const large = shallow(getTestElement({size: 'lg'}));
+    const largeModal = large.find('Modal');
+    expect(largeModal.prop('size')).toEqual('lg');
+    const xLarge = shallow(getTestElement({size: 'xl'}));
+    const xLargeModal = xLarge.find('Modal');
+    expect(xLargeModal.prop('size')).toEqual('xl');
+  });
+  it('passes the `show` prop to the Bootstrap modal for customization', () => {
+    const opened = shallow(getTestElement({show: true}));
+    const openedModal = opened.find('Modal');
+    expect(openedModal.prop('show')).toBeTrue();
+    const closed = shallow(getTestElement({show: false}));
+    const closedModal = closed.find('Modal');
+    expect(closedModal.prop('show')).toBeFalse();
+  });
+  it('passes the confirm button variant to the Bootstrap button', () => {
+    const wrapper = shallow(getTestElement({confirmButtonVariant: 'danger'}));
+    const button = wrapper.find('Button#confirm');
+    expect(button.prop('variant')).toEqual('danger');
+  });
+  it('passes the cancel button variant to the Bootstrap button', () => {
+    const wrapper = shallow(
+      getTestElement({cancelButtonVariant: 'outline-danger'})
+    );
+    const button = wrapper.find('Button#cancel');
+    expect(button.prop('variant')).toEqual('outline-danger');
+  });
+  it('renders custom Confirm button text', () => {
+    const wrapper = shallow(getTestElement({confirmButtonText: 'Yep'}));
+    const button = wrapper.find('Button#confirm');
+    expect(button.text()).toEqual('Yep');
+  });
+  it('renders custom Cancel button text', () => {
+    const wrapper = shallow(getTestElement({cancelButtonText: 'Nope'}));
+    const button = wrapper.find('Button#cancel');
+    expect(button.text()).toEqual('Nope');
+  });
+  it('fires the onConfirm handler when the Confirm button is clicked', () => {
+    const spy = jest.fn();
+    const wrapper = shallow(getTestElement({onConfirm: spy}));
+    wrapper.find('Button#confirm').simulate('click');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+  it('fires the onCancel handler when the Cancel button is clicked', () => {
+    const spy = jest.fn();
+    const wrapper = shallow(getTestElement({onCancel: spy}));
+    wrapper.find('Button#cancel').simulate('click');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+  it('fires the onCancel handler when the dialog is exited by means other than the Cancel button', () => {
+    const spy = jest.fn();
+    const wrapper = shallow(getTestElement({onCancel: spy}));
+    const modalOnHide: () => void = wrapper.find('Modal').prop('onHide');
+    expect(modalOnHide).toBe(spy);
+    expect(spy).toHaveBeenCalledTimes(0);
+    modalOnHide();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/tests/unit/components/__snapshots__/ApplicationOverrideNotificationCard.test.tsx.snap
+++ b/app/tests/unit/components/__snapshots__/ApplicationOverrideNotificationCard.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`OverrideNotificationCard Should render the notification card & justific
   >
     <CardText>
       <strong
-        className="jsx-576105227"
+        className="jsx-601273411"
       >
         There were errors in this application that the reporter has chosen to override. Justification for overriding the errors is provided in the box below:
       </strong>
@@ -26,7 +26,7 @@ exports[`OverrideNotificationCard Should render the notification card & justific
       body={false}
     >
       <div
-        className="jsx-576105227 scrollbar"
+        className="jsx-601273411 scrollbar"
         id="justification"
       >
         <CardBody>
@@ -36,9 +36,9 @@ exports[`OverrideNotificationCard Should render the notification card & justific
     </Card>
   </CardBody>
   <JSXStyle
-    id="576105227"
+    id="601273411"
   >
-    #justification-card.jsx-576105227{margin:1rem 0;}#justification.jsx-576105227{max-height:19.2em;background:#eee;overflow-y:scroll;}.scrollbar.jsx-576105227::-webkit-scrollbar{-webkit-appearance:none;width:8px;}.scrollbar.jsx-576105227::-webkit-scrollbar-thumb{border-radius:4px;background-color:rgba(0,0,0,0.5);box-shadow:0 0 1px rgba(255,255,255,0.5);}
+    #justification-card .bg-danger{color:#fff;}#justification-card.jsx-601273411{margin:1rem 0;}#justification.jsx-601273411{max-height:19.2em;background:#eee;overflow-y:scroll;}.scrollbar.jsx-601273411::-webkit-scrollbar{-webkit-appearance:none;width:8px;}.scrollbar.jsx-601273411::-webkit-scrollbar-thumb{border-radius:4px;background-color:rgba(0,0,0,0.5);box-shadow:0 0 1px rgba(255,255,255,0.5);}
   </JSXStyle>
 </Card>
 `;

--- a/app/tests/unit/components/__snapshots__/ApplicationOverrideNotificationCard.test.tsx.snap
+++ b/app/tests/unit/components/__snapshots__/ApplicationOverrideNotificationCard.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`OverrideNotificationCard Should render the notification card & justific
   >
     <CardText>
       <strong
-        className="jsx-601273411"
+        className="jsx-274203529"
       >
         There were errors in this application that the reporter has chosen to override. Justification for overriding the errors is provided in the box below:
       </strong>
@@ -26,7 +26,7 @@ exports[`OverrideNotificationCard Should render the notification card & justific
       body={false}
     >
       <div
-        className="jsx-601273411 scrollbar"
+        className="jsx-274203529 scrollbar"
         id="justification"
       >
         <CardBody>
@@ -36,9 +36,9 @@ exports[`OverrideNotificationCard Should render the notification card & justific
     </Card>
   </CardBody>
   <JSXStyle
-    id="601273411"
+    id="274203529"
   >
-    #justification-card .bg-danger{color:#fff;}#justification-card.jsx-601273411{margin:1rem 0;}#justification.jsx-601273411{max-height:19.2em;background:#eee;overflow-y:scroll;}.scrollbar.jsx-601273411::-webkit-scrollbar{-webkit-appearance:none;width:8px;}.scrollbar.jsx-601273411::-webkit-scrollbar-thumb{border-radius:4px;background-color:rgba(0,0,0,0.5);box-shadow:0 0 1px rgba(255,255,255,0.5);}
+    #justification-card .bg-danger{color:#fff;}#justification-card{margin:1rem 15px;}#justification.jsx-274203529{max-height:19.2em;background:#eee;overflow-y:scroll;}.scrollbar.jsx-274203529::-webkit-scrollbar{-webkit-appearance:none;width:8px;}.scrollbar.jsx-274203529::-webkit-scrollbar-thumb{border-radius:4px;background-color:rgba(0,0,0,0.5);box-shadow:0 0 1px rgba(255,255,255,0.5);}
   </JSXStyle>
 </Card>
 `;

--- a/app/tests/unit/components/__snapshots__/GenericConfirmationModal.test.tsx.snap
+++ b/app/tests/unit/components/__snapshots__/GenericConfirmationModal.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`Generic Confirmation Modal should render a Bootstrap modal (with custom
     closeLabel="Close"
   >
     <h2
-      className="jsx-2580451210"
+      className="jsx-4105755554"
     >
       Are you sure you want to continue?
     </h2>
@@ -62,12 +62,12 @@ exports[`Generic Confirmation Modal should render a Bootstrap modal (with custom
   <JSXStyle
     id="3835795811"
   >
-    h2.jsx-2580451210{margin-bottom:0;}
+    h2.jsx-4105755554{margin-bottom:0;}
   </JSXStyle>
   <JSXStyle
-    id="2914746560"
+    id="2690782760"
   >
-    .modal-header{background:#036;color:#fff;}.btn-primary#confirm{background:#036;}.btn-primary#confirm:hover,.btn-primary#cancel:hover{background:#002040;border-color:#002040;}.btn-outline-primary#confirm,.btn-outline-primary#cancel{color:#036;border-color:#036;}.btn-outline-primary#confirm:hover,.btn-outline-primary#cancel:hover{color:#fff;background:#002040;}.btn-success#confirm{background:#24883e;}.btn-outline-success#confirm{color:#036;border-color:#036;}
+    .modal-header{background:#036;color:#fff;}.btn-primary#confirm{background:#036;}.btn-primary#confirm:hover,.btn-primary#cancel:hover{background:#002040;border-color:#002040;}.btn-outline-primary#confirm,.btn-outline-primary#cancel{color:#036;border-color:#036;}.btn-outline-primary#confirm:hover,.btn-outline-primary#cancel:hover{color:#fff;background:#002040;}
   </JSXStyle>
 </Modal>
 `;
@@ -96,7 +96,7 @@ exports[`Generic Confirmation Modal should render a default Bootstrap modal with
     closeLabel="Close"
   >
     <h2
-      className="jsx-2580451210"
+      className="jsx-4105755554"
     >
       Are you sure you want to continue?
     </h2>
@@ -125,12 +125,12 @@ exports[`Generic Confirmation Modal should render a default Bootstrap modal with
   <JSXStyle
     id="3835795811"
   >
-    h2.jsx-2580451210{margin-bottom:0;}
+    h2.jsx-4105755554{margin-bottom:0;}
   </JSXStyle>
   <JSXStyle
-    id="2914746560"
+    id="2690782760"
   >
-    .modal-header{background:#036;color:#fff;}.btn-primary#confirm{background:#036;}.btn-primary#confirm:hover,.btn-primary#cancel:hover{background:#002040;border-color:#002040;}.btn-outline-primary#confirm,.btn-outline-primary#cancel{color:#036;border-color:#036;}.btn-outline-primary#confirm:hover,.btn-outline-primary#cancel:hover{color:#fff;background:#002040;}.btn-success#confirm{background:#24883e;}.btn-outline-success#confirm{color:#036;border-color:#036;}
+    .modal-header{background:#036;color:#fff;}.btn-primary#confirm{background:#036;}.btn-primary#confirm:hover,.btn-primary#cancel:hover{background:#002040;border-color:#002040;}.btn-outline-primary#confirm,.btn-outline-primary#cancel{color:#036;border-color:#036;}.btn-outline-primary#confirm:hover,.btn-outline-primary#cancel:hover{color:#fff;background:#002040;}
   </JSXStyle>
 </Modal>
 `;

--- a/app/tests/unit/components/__snapshots__/GenericConfirmationModal.test.tsx.snap
+++ b/app/tests/unit/components/__snapshots__/GenericConfirmationModal.test.tsx.snap
@@ -1,0 +1,136 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Generic Confirmation Modal should render a Bootstrap modal (with custom body content) 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  centered={true}
+  dialogAs={
+    Object {
+      "$$typeof": Symbol(react.forward_ref),
+      "displayName": "ModalDialog",
+      "render": [Function],
+    }
+  }
+  enforceFocus={true}
+  keyboard={true}
+  onHide={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    closeButton={false}
+    closeLabel="Close"
+  >
+    <h2
+      className="jsx-2580451210"
+    >
+      Are you sure you want to continue?
+    </h2>
+  </ModalHeader>
+  <ModalBody>
+    <div>
+      <p>
+        There is something we want you to stop and consider before continuing.
+      </p>
+      <p>
+        Here is some more detail you should be aware of before confirming this action.
+      </p>
+    </div>
+  </ModalBody>
+  <ModalFooter>
+    <Button
+      active={false}
+      disabled={false}
+      id="cancel"
+      onClick={[Function]}
+      variant="secondary"
+    >
+      Cancel
+    </Button>
+    <Button
+      active={false}
+      disabled={false}
+      id="confirm"
+      onClick={[Function]}
+      variant="primary"
+    >
+      Confirm
+    </Button>
+  </ModalFooter>
+  <JSXStyle
+    id="3835795811"
+  >
+    h2.jsx-2580451210{margin-bottom:0;}
+  </JSXStyle>
+  <JSXStyle
+    id="2914746560"
+  >
+    .modal-header{background:#036;color:#fff;}.btn-primary#confirm{background:#036;}.btn-primary#confirm:hover,.btn-primary#cancel:hover{background:#002040;border-color:#002040;}.btn-outline-primary#confirm,.btn-outline-primary#cancel{color:#036;border-color:#036;}.btn-outline-primary#confirm:hover,.btn-outline-primary#cancel:hover{color:#fff;background:#002040;}.btn-success#confirm{background:#24883e;}.btn-outline-success#confirm{color:#036;border-color:#036;}
+  </JSXStyle>
+</Modal>
+`;
+
+exports[`Generic Confirmation Modal should render a default Bootstrap modal with Cancel and Confirm buttons (no body content) 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  centered={true}
+  dialogAs={
+    Object {
+      "$$typeof": Symbol(react.forward_ref),
+      "displayName": "ModalDialog",
+      "render": [Function],
+    }
+  }
+  enforceFocus={true}
+  keyboard={true}
+  onHide={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    closeButton={false}
+    closeLabel="Close"
+  >
+    <h2
+      className="jsx-2580451210"
+    >
+      Are you sure you want to continue?
+    </h2>
+  </ModalHeader>
+  <ModalBody />
+  <ModalFooter>
+    <Button
+      active={false}
+      disabled={false}
+      id="cancel"
+      onClick={[Function]}
+      variant="secondary"
+    >
+      Cancel
+    </Button>
+    <Button
+      active={false}
+      disabled={false}
+      id="confirm"
+      onClick={[Function]}
+      variant="primary"
+    >
+      Confirm
+    </Button>
+  </ModalFooter>
+  <JSXStyle
+    id="3835795811"
+  >
+    h2.jsx-2580451210{margin-bottom:0;}
+  </JSXStyle>
+  <JSXStyle
+    id="2914746560"
+  >
+    .modal-header{background:#036;color:#fff;}.btn-primary#confirm{background:#036;}.btn-primary#confirm:hover,.btn-primary#cancel:hover{background:#002040;border-color:#002040;}.btn-outline-primary#confirm,.btn-outline-primary#cancel{color:#036;border-color:#036;}.btn-outline-primary#confirm:hover,.btn-outline-primary#cancel:hover{color:#fff;background:#002040;}.btn-success#confirm{background:#24883e;}.btn-outline-success#confirm{color:#036;border-color:#036;}
+  </JSXStyle>
+</Modal>
+`;

--- a/app/tests/unit/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.test.tsx
+++ b/app/tests/unit/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.test.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {ApplicationReviewStepSelector} from 'containers/Admin/ApplicationReview/ApplicationReviewStepSelector';
+import {ApplicationReviewStepSelector_applicationReviewSteps} from '__generated__/ApplicationReviewStepSelector_applicationReviewSteps.graphql';
+import {CiipApplicationRevisionStatus} from 'applicationReviewQuery.graphql';
+
+const getApplicationReviewSteps = (allStepsCompleted, completedSteps) => {
+  return {
+    ' $refType': 'ApplicationReviewStepSelector_applicationReviewSteps',
+    edges: [
+      {
+        node: {
+          id: 'abc',
+          isComplete: allStepsCompleted || completedSteps.includes(1),
+          reviewStepId: 1,
+          reviewStepByReviewStepId: {
+            stepName: 'administrative'
+          }
+        }
+      },
+      {
+        node: {
+          id: 'def',
+          isComplete: allStepsCompleted || completedSteps.includes(2),
+          reviewStepId: 2,
+          reviewStepByReviewStepId: {
+            stepName: 'technical'
+          }
+        }
+      },
+      {
+        node: {
+          id: 'ghi',
+          isComplete: allStepsCompleted || completedSteps.includes(3),
+          reviewStepId: 3,
+          reviewStepByReviewStepId: {
+            stepName: 'another'
+          }
+        }
+      }
+    ],
+    ' $fragmentRefs': {
+      ApplicationReviewStepSelector_applicationReviewSteps: true
+    }
+  };
+};
+
+const getTestElement = ({
+  status = 'SUBMITTED',
+  selectedStep = null,
+  onSelectStep = () => {},
+  onDecisionOrChangeRequestAction = () => {},
+  changeDecision = undefined,
+  allStepsCompleted = false,
+  completedSteps = []
+}) => {
+  const data = getApplicationReviewSteps(allStepsCompleted, completedSteps);
+  return (
+    <ApplicationReviewStepSelector
+      applicationReviewSteps={
+        data as ApplicationReviewStepSelector_applicationReviewSteps
+      }
+      decisionOrChangeRequestStatus={status as CiipApplicationRevisionStatus}
+      selectedStep={selectedStep}
+      onSelectStep={onSelectStep}
+      onDecisionOrChangeRequestAction={onDecisionOrChangeRequestAction}
+      changeDecision={changeDecision}
+    />
+  );
+};
+
+describe('ApplicationReviewStepSelector', () => {
+  it('has no selected steps when `selectedStep` is null', () => {
+    const wrapper = shallow(getTestElement({}));
+    expect(wrapper).toMatchSnapshot();
+    wrapper.find('ListGroupItem').every((item) => {
+      return expect(item.prop('active')).toBeFalse();
+    });
+  });
+  it('shows the selected selected step when `selectedStep` is specified', () => {
+    const wrapper = shallow(getTestElement({selectedStep: 'def'}));
+    expect(wrapper).toMatchSnapshot();
+    expect(
+      wrapper
+        .find('ListGroupItem')
+        .filterWhere((item) => item.prop('active') === true)
+    ).toHaveLength(1);
+  });
+  it('shows the application decision if a decision has been made)', () => {
+    const approved = shallow(getTestElement({status: 'APPROVED'}));
+    const rejected = shallow(getTestElement({status: 'REJECTED'}));
+    const changesRequested = shallow(
+      getTestElement({status: 'REQUESTED_CHANGES'})
+    );
+    expect(approved).toMatchSnapshot();
+    expect(
+      approved.find('#open-decision-dialog').text().includes('approved')
+    ).toBeTrue();
+    expect(rejected).toMatchSnapshot();
+    expect(
+      rejected.find('#open-decision-dialog').text().includes('rejected')
+    ).toBeTrue();
+    expect(changesRequested).toMatchSnapshot();
+    expect(
+      changesRequested
+        .find('#open-decision-dialog')
+        .text()
+        .includes('Changes have been requested')
+    ).toBeTrue();
+  });
+  it('shows which review steps are completed', () => {
+    const wrapper = shallow(getTestElement({completedSteps: [2, 3]}));
+    expect(wrapper).toMatchSnapshot();
+    expect(
+      wrapper
+        .find('ListGroupItem.review-step-option')
+        .at(1)
+        .text()
+        .includes('completed')
+    ).toBeTrue();
+    expect(
+      wrapper
+        .find('ListGroupItem.review-step-option')
+        .at(2)
+        .text()
+        .includes('completed')
+    ).toBeTrue();
+    const notCompleted = wrapper
+      .find('ListGroupItem.review-step-option')
+      .filterWhere((item) => !item.text().includes('completed'));
+    notCompleted.forEach((item) =>
+      expect(item.text().includes('Administrative')).toBeTrue()
+    );
+  });
+  it('"make a decision or request changes" button is disabled until all review steps are complete', () => {
+    const spyForIncomplete = jest.fn();
+    const someStepsIncomplete = shallow(
+      getTestElement({
+        status: 'SUBMITTED',
+        completedSteps: [1],
+        onDecisionOrChangeRequestAction: spyForIncomplete
+      })
+    );
+    expect(someStepsIncomplete).toMatchSnapshot();
+    expect(
+      someStepsIncomplete
+        .find('ListGroupItem#open-decision-dialog')
+        .prop('disabled')
+    ).toBeTrue();
+    expect(
+      someStepsIncomplete
+        .find('ListGroupItem#open-decision-dialog')
+        .prop('aria-disabled')
+    ).toBeTrue();
+    // Ensure click handler is inactive when disabled:
+    someStepsIncomplete
+      .find('ListGroupItem#open-decision-dialog')
+      .simulate('click');
+    expect(spyForIncomplete).not.toHaveBeenCalled();
+    someStepsIncomplete
+      .find('ListGroupItem#open-decision-dialog')
+      .simulate('keydown', {key: 'Enter'});
+    expect(spyForIncomplete).not.toHaveBeenCalled();
+
+    const spyForAllStepsCompleted = jest.fn();
+    const allStepsCompleted = shallow(
+      getTestElement({
+        status: 'SUBMITTED',
+        allStepsCompleted: true,
+        onDecisionOrChangeRequestAction: spyForAllStepsCompleted
+      })
+    );
+    expect(allStepsCompleted).toMatchSnapshot();
+    expect(
+      allStepsCompleted
+        .find('ListGroupItem#open-decision-dialog')
+        .prop('disabled')
+    ).toBeFalse();
+    expect(
+      allStepsCompleted
+        .find('ListGroupItem#open-decision-dialog')
+        .prop('aria-disabled')
+    ).toBeFalse();
+    // Ensure click handler fires when not disabled:
+    allStepsCompleted
+      .find('ListGroupItem#open-decision-dialog')
+      .simulate('click');
+    expect(spyForAllStepsCompleted).toHaveBeenCalledTimes(1);
+    allStepsCompleted
+      .find('ListGroupItem#open-decision-dialog')
+      .simulate('keydown', {key: 'Enter'});
+    expect(spyForAllStepsCompleted).toHaveBeenCalledTimes(2);
+  });
+  it('"make a decision or request changes" button is disabled once a decision has been made', () => {
+    const spy = jest.fn();
+    const wrapper = shallow(
+      getTestElement({status: 'REJECTED', onDecisionOrChangeRequestAction: spy})
+    );
+    expect(wrapper).toMatchSnapshot();
+    const button = wrapper.find('ListGroupItem#open-decision-dialog');
+    expect(button.prop('disabled')).toBeTrue();
+    expect(button.prop('aria-disabled')).toBeTrue();
+    wrapper.simulate('click');
+    expect(spy).not.toHaveBeenCalled();
+  });
+  it('shows optional "Change decision" button', () => {
+    const spy = jest.fn();
+    const notEnabled = shallow(getTestElement({status: 'REJECTED'}));
+    const enabled = shallow(
+      getTestElement({status: 'REJECTED', changeDecision: spy})
+    );
+    // Ensure button to change decision not rendered or active unless enabled:
+    expect(
+      notEnabled
+        .find('Button')
+        .findWhere((el) => el.text().includes('Change decision'))
+        .exists()
+    ).toBeFalse();
+    const button = enabled.find('Button');
+    expect(button.text().includes('Change decision')).toBeTrue();
+    expect(enabled).toMatchSnapshot();
+    button.simulate('click');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/tests/unit/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.test.tsx
+++ b/app/tests/unit/containers/Admin/ApplicationReview/ApplicationReviewStepSelector.test.tsx
@@ -50,6 +50,7 @@ const getTestElement = ({
   selectedStep = null,
   onSelectStep = () => {},
   onDecisionOrChangeRequestAction = () => {},
+  newerDraftExists = false,
   changeDecision = undefined,
   allStepsCompleted = false,
   completedSteps = []
@@ -64,6 +65,7 @@ const getTestElement = ({
       selectedStep={selectedStep}
       onSelectStep={onSelectStep}
       onDecisionOrChangeRequestAction={onDecisionOrChangeRequestAction}
+      newerDraftExists={newerDraftExists}
       changeDecision={changeDecision}
     />
   );
@@ -221,5 +223,32 @@ describe('ApplicationReviewStepSelector', () => {
     expect(enabled).toMatchSnapshot();
     button.simulate('click');
     expect(spy).toHaveBeenCalledTimes(1);
+  });
+  it('"Change decision" button is inactive if a newer draft exists', () => {
+    const spyForEnabled = jest.fn();
+    const spyForDisabled = jest.fn();
+    const enabled = shallow(
+      getTestElement({
+        status: 'REQUESTED_CHANGES',
+        newerDraftExists: false,
+        changeDecision: spyForEnabled
+      })
+    );
+    const disabled = shallow(
+      getTestElement({
+        status: 'REQUESTED_CHANGES',
+        newerDraftExists: true,
+        changeDecision: spyForDisabled
+      })
+    );
+    expect(
+      enabled.find('#change-decision Button').prop('disabled')
+    ).toBeFalse();
+    enabled.find('#change-decision Button').simulate('click');
+    expect(spyForEnabled).toHaveBeenCalledTimes(1);
+    expect(
+      disabled.find('#change-decision Button').prop('disabled')
+    ).toBeTrue();
+    expect(spyForDisabled).not.toHaveBeenCalled();
   });
 });

--- a/app/tests/unit/containers/Admin/ApplicationReview/ReviewSidebar.test.tsx
+++ b/app/tests/unit/containers/Admin/ApplicationReview/ReviewSidebar.test.tsx
@@ -102,6 +102,7 @@ describe('ReviewSidebar', () => {
     const data = applicationReviewStepWithComments();
     const r = shallow(
       <ReviewSidebar
+        isFinalized={false}
         applicationReviewStep={data as ReviewSidebar_applicationReviewStep}
         onClose={() => {}}
         relay={relay as any}
@@ -114,6 +115,20 @@ describe('ReviewSidebar', () => {
     const data = applicationReviewStep();
     const r = shallow(
       <ReviewSidebar
+        isFinalized={false}
+        applicationReviewStep={data as ReviewSidebar_applicationReviewStep}
+        onClose={() => {}}
+        relay={relay as any}
+      />
+    );
+    expect(r).toMatchSnapshot();
+  });
+  it('should match the last accepted snapshot (review finalized, decision has been made)', async () => {
+    const relay = {environment: null};
+    const data = applicationReviewStepWithAllCommentsResolved();
+    const r = shallow(
+      <ReviewSidebar
+        isFinalized
         applicationReviewStep={data as ReviewSidebar_applicationReviewStep}
         onClose={() => {}}
         relay={relay as any}
@@ -126,6 +141,7 @@ describe('ReviewSidebar', () => {
     const data = applicationReviewStepWithComments();
     const r = shallow(
       <ReviewSidebar
+        isFinalized={false}
         applicationReviewStep={data as ReviewSidebar_applicationReviewStep}
         onClose={() => {}}
         relay={relay as any}
@@ -140,6 +156,7 @@ describe('ReviewSidebar', () => {
     const data = applicationReviewStepWithComments();
     const r = shallow(
       <ReviewSidebar
+        isFinalized={false}
         applicationReviewStep={data as ReviewSidebar_applicationReviewStep}
         onClose={() => {}}
         relay={relay as any}
@@ -190,6 +207,7 @@ describe('ReviewSidebar', () => {
     const data = applicationReviewStepWithComments();
     const r = shallow(
       <ReviewSidebar
+        isFinalized={false}
         applicationReviewStep={data as ReviewSidebar_applicationReviewStep}
         onClose={onClose}
         relay={relay as any}
@@ -207,6 +225,7 @@ describe('ReviewSidebar', () => {
     const data = applicationReviewStepWithComments();
     const r = mount(
       <ReviewSidebar
+        isFinalized={false}
         applicationReviewStep={data as ReviewSidebar_applicationReviewStep}
         onClose={() => {}}
         relay={relay as any}
@@ -225,6 +244,7 @@ describe('ReviewSidebar', () => {
     const data = applicationReviewStepWithAllCommentsResolved();
     const r = mount(
       <ReviewSidebar
+        isFinalized={false}
         applicationReviewStep={data as ReviewSidebar_applicationReviewStep}
         onClose={() => {}}
         relay={relay as any}
@@ -253,6 +273,7 @@ describe('ReviewSidebar', () => {
     const data = applicationReviewStepWithComments();
     const r = mount(
       <ReviewSidebar
+        isFinalized={false}
         applicationReviewStep={data as ReviewSidebar_applicationReviewStep}
         onClose={() => {}}
         relay={relay as any}
@@ -286,6 +307,7 @@ describe('ReviewSidebar', () => {
     };
     const r = shallow(
       <ReviewSidebar
+        isFinalized={false}
         applicationReviewStep={data as ReviewSidebar_applicationReviewStep}
         onClose={() => {}}
         relay={relay as any}

--- a/app/tests/unit/containers/Admin/ApplicationReview/__snapshots__/ApplicationReviewStepSelector.test.tsx.snap
+++ b/app/tests/unit/containers/Admin/ApplicationReview/__snapshots__/ApplicationReviewStepSelector.test.tsx.snap
@@ -1,0 +1,2445 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ApplicationReviewStepSelector "make a decision or request changes" button is disabled once a decision has been made 1`] = `
+<Row
+  noGutters={false}
+>
+  <div
+    className="jsx-118784165 col-xxl-6 col-xl-7 col-lg-8 col-md-10"
+  >
+    <ListGroup
+      as="ul"
+      id="selector"
+    >
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Administrative review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="2"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Technical review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="3"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Another review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        aria-disabled={true}
+        as="li"
+        disabled={true}
+        id="open-decision-dialog"
+        key="decision"
+        onClick={[MockFunction]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+          }
+        }
+        tabIndex={0}
+        variant="danger"
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                352,
+                512,
+                Array [],
+                "f00d",
+                "M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z",
+              ],
+              "iconName": "times",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Application has been rejected and applicant notified
+      </ListGroupItem>
+    </ListGroup>
+  </div>
+  <JSXStyle
+    id="1973324808"
+  >
+    #change-decision.jsx-118784165{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-align-items:flex-end;-webkit-box-align:flex-end;-ms-flex-align:flex-end;align-items:flex-end;}
+  </JSXStyle>
+  <JSXStyle
+    id="1693080580"
+  >
+    #selector .list-group-item-danger.disabled,.list-group-item-danger:disabled{color:#721c24;background-color:#f5c6cb;}#selector .list-group-item-success.disabled,.list-group-item-success:disabled{color:#155724;background-color:#c3e6cb;}#selector .list-group-item-secondary.disabled,.list-group-item-secondary:disabled{color:#383d41;background-color:#d6d8db;}
+  </JSXStyle>
+</Row>
+`;
+
+exports[`ApplicationReviewStepSelector "make a decision or request changes" button is disabled until all review steps are complete 1`] = `
+<Row
+  noGutters={false}
+>
+  <div
+    className="jsx-118784165 col-xxl-6 col-xl-7 col-lg-8 col-md-10"
+  >
+    <ListGroup
+      as="ul"
+      id="selector"
+    >
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                512,
+                512,
+                Array [],
+                "f00c",
+                "M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z",
+              ],
+              "iconName": "check",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+         Administrative review completed
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="2"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Technical review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="3"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Another review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        aria-disabled={true}
+        as="li"
+        disabled={true}
+        id="open-decision-dialog"
+        key="decision"
+        onClick={[MockFunction]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+          }
+        }
+        tabIndex={0}
+      >
+        Make a decision or request changes
+      </ListGroupItem>
+    </ListGroup>
+  </div>
+  <JSXStyle
+    id="1973324808"
+  >
+    #change-decision.jsx-118784165{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-align-items:flex-end;-webkit-box-align:flex-end;-ms-flex-align:flex-end;align-items:flex-end;}
+  </JSXStyle>
+  <JSXStyle
+    id="1693080580"
+  >
+    #selector .list-group-item-danger.disabled,.list-group-item-danger:disabled{color:#721c24;background-color:#f5c6cb;}#selector .list-group-item-success.disabled,.list-group-item-success:disabled{color:#155724;background-color:#c3e6cb;}#selector .list-group-item-secondary.disabled,.list-group-item-secondary:disabled{color:#383d41;background-color:#d6d8db;}
+  </JSXStyle>
+</Row>
+`;
+
+exports[`ApplicationReviewStepSelector "make a decision or request changes" button is disabled until all review steps are complete 2`] = `
+<Row
+  noGutters={false}
+>
+  <div
+    className="jsx-118784165 col-xxl-6 col-xl-7 col-lg-8 col-md-10"
+  >
+    <ListGroup
+      as="ul"
+      id="selector"
+    >
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                512,
+                512,
+                Array [],
+                "f00c",
+                "M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z",
+              ],
+              "iconName": "check",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+         Administrative review completed
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="2"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                512,
+                512,
+                Array [],
+                "f00c",
+                "M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z",
+              ],
+              "iconName": "check",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+         Technical review completed
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="3"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                512,
+                512,
+                Array [],
+                "f00c",
+                "M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z",
+              ],
+              "iconName": "check",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+         Another review completed
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        aria-disabled={false}
+        as="li"
+        disabled={false}
+        id="open-decision-dialog"
+        key="decision"
+        onClick={[MockFunction]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+          }
+        }
+        tabIndex={0}
+      >
+        Make a decision or request changes
+      </ListGroupItem>
+    </ListGroup>
+  </div>
+  <JSXStyle
+    id="1973324808"
+  >
+    #change-decision.jsx-118784165{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-align-items:flex-end;-webkit-box-align:flex-end;-ms-flex-align:flex-end;align-items:flex-end;}
+  </JSXStyle>
+  <JSXStyle
+    id="1693080580"
+  >
+    #selector .list-group-item-danger.disabled,.list-group-item-danger:disabled{color:#721c24;background-color:#f5c6cb;}#selector .list-group-item-success.disabled,.list-group-item-success:disabled{color:#155724;background-color:#c3e6cb;}#selector .list-group-item-secondary.disabled,.list-group-item-secondary:disabled{color:#383d41;background-color:#d6d8db;}
+  </JSXStyle>
+</Row>
+`;
+
+exports[`ApplicationReviewStepSelector has no selected steps when \`selectedStep\` is null 1`] = `
+<Row
+  noGutters={false}
+>
+  <div
+    className="jsx-118784165 col-xxl-6 col-xl-7 col-lg-8 col-md-10"
+  >
+    <ListGroup
+      as="ul"
+      id="selector"
+    >
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Administrative review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="2"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Technical review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="3"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Another review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        aria-disabled={true}
+        as="li"
+        disabled={true}
+        id="open-decision-dialog"
+        key="decision"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+          }
+        }
+        tabIndex={0}
+      >
+        Make a decision or request changes
+      </ListGroupItem>
+    </ListGroup>
+  </div>
+  <JSXStyle
+    id="1973324808"
+  >
+    #change-decision.jsx-118784165{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-align-items:flex-end;-webkit-box-align:flex-end;-ms-flex-align:flex-end;align-items:flex-end;}
+  </JSXStyle>
+  <JSXStyle
+    id="1693080580"
+  >
+    #selector .list-group-item-danger.disabled,.list-group-item-danger:disabled{color:#721c24;background-color:#f5c6cb;}#selector .list-group-item-success.disabled,.list-group-item-success:disabled{color:#155724;background-color:#c3e6cb;}#selector .list-group-item-secondary.disabled,.list-group-item-secondary:disabled{color:#383d41;background-color:#d6d8db;}
+  </JSXStyle>
+</Row>
+`;
+
+exports[`ApplicationReviewStepSelector shows optional "Change decision" button 1`] = `
+<Row
+  noGutters={false}
+>
+  <div
+    className="jsx-118784165 col-xxl-6 col-xl-7 col-lg-8 col-md-10"
+  >
+    <ListGroup
+      as="ul"
+      id="selector"
+    >
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Administrative review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="2"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Technical review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="3"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Another review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        aria-disabled={true}
+        as="li"
+        disabled={true}
+        id="open-decision-dialog"
+        key="decision"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+          }
+        }
+        tabIndex={0}
+        variant="danger"
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                352,
+                512,
+                Array [],
+                "f00d",
+                "M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z",
+              ],
+              "iconName": "times",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Application has been rejected and applicant notified
+      </ListGroupItem>
+    </ListGroup>
+  </div>
+  <div
+    className="jsx-118784165 col-md-12 col-lg-4 col-xl-5 col-xxl-6"
+    id="change-decision"
+  >
+    <Button
+      active={false}
+      disabled={false}
+      onClick={[MockFunction]}
+      variant="link"
+    >
+      <FontAwesomeIcon
+        border={false}
+        className=""
+        fixedWidth={false}
+        flip={null}
+        icon={
+          Object {
+            "icon": Array [
+              512,
+              512,
+              Array [],
+              "f084",
+              "M512 176.001C512 273.203 433.202 352 336 352c-11.22 0-22.19-1.062-32.827-3.069l-24.012 27.014A23.999 23.999 0 0 1 261.223 384H224v40c0 13.255-10.745 24-24 24h-40v40c0 13.255-10.745 24-24 24H24c-13.255 0-24-10.745-24-24v-78.059c0-6.365 2.529-12.47 7.029-16.971l161.802-161.802C163.108 213.814 160 195.271 160 176 160 78.798 238.797.001 335.999 0 433.488-.001 512 78.511 512 176.001zM336 128c0 26.51 21.49 48 48 48s48-21.49 48-48-21.49-48-48-48-48 21.49-48 48z",
+            ],
+            "iconName": "key",
+            "prefix": "fas",
+          }
+        }
+        inverse={false}
+        listItem={false}
+        mask={null}
+        pull={null}
+        pulse={false}
+        rotation={null}
+        size={null}
+        spin={false}
+        style={
+          Object {
+            "marginRight": 8,
+          }
+        }
+        swapOpacity={false}
+        symbol={false}
+        title=""
+        transform={null}
+      />
+      Change decision
+    </Button>
+  </div>
+  <JSXStyle
+    id="1973324808"
+  >
+    #change-decision.jsx-118784165{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-align-items:flex-end;-webkit-box-align:flex-end;-ms-flex-align:flex-end;align-items:flex-end;}
+  </JSXStyle>
+  <JSXStyle
+    id="1693080580"
+  >
+    #selector .list-group-item-danger.disabled,.list-group-item-danger:disabled{color:#721c24;background-color:#f5c6cb;}#selector .list-group-item-success.disabled,.list-group-item-success:disabled{color:#155724;background-color:#c3e6cb;}#selector .list-group-item-secondary.disabled,.list-group-item-secondary:disabled{color:#383d41;background-color:#d6d8db;}
+  </JSXStyle>
+</Row>
+`;
+
+exports[`ApplicationReviewStepSelector shows the application decision if a decision has been made) 1`] = `
+<Row
+  noGutters={false}
+>
+  <div
+    className="jsx-118784165 col-xxl-6 col-xl-7 col-lg-8 col-md-10"
+  >
+    <ListGroup
+      as="ul"
+      id="selector"
+    >
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Administrative review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="2"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Technical review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="3"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Another review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        aria-disabled={true}
+        as="li"
+        disabled={true}
+        id="open-decision-dialog"
+        key="decision"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+          }
+        }
+        tabIndex={0}
+        variant="success"
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                512,
+                512,
+                Array [],
+                "f00c",
+                "M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z",
+              ],
+              "iconName": "check",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Application has been approved and applicant notified
+      </ListGroupItem>
+    </ListGroup>
+  </div>
+  <JSXStyle
+    id="1973324808"
+  >
+    #change-decision.jsx-118784165{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-align-items:flex-end;-webkit-box-align:flex-end;-ms-flex-align:flex-end;align-items:flex-end;}
+  </JSXStyle>
+  <JSXStyle
+    id="1693080580"
+  >
+    #selector .list-group-item-danger.disabled,.list-group-item-danger:disabled{color:#721c24;background-color:#f5c6cb;}#selector .list-group-item-success.disabled,.list-group-item-success:disabled{color:#155724;background-color:#c3e6cb;}#selector .list-group-item-secondary.disabled,.list-group-item-secondary:disabled{color:#383d41;background-color:#d6d8db;}
+  </JSXStyle>
+</Row>
+`;
+
+exports[`ApplicationReviewStepSelector shows the application decision if a decision has been made) 2`] = `
+<Row
+  noGutters={false}
+>
+  <div
+    className="jsx-118784165 col-xxl-6 col-xl-7 col-lg-8 col-md-10"
+  >
+    <ListGroup
+      as="ul"
+      id="selector"
+    >
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Administrative review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="2"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Technical review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="3"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Another review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        aria-disabled={true}
+        as="li"
+        disabled={true}
+        id="open-decision-dialog"
+        key="decision"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+          }
+        }
+        tabIndex={0}
+        variant="danger"
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                352,
+                512,
+                Array [],
+                "f00d",
+                "M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z",
+              ],
+              "iconName": "times",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Application has been rejected and applicant notified
+      </ListGroupItem>
+    </ListGroup>
+  </div>
+  <JSXStyle
+    id="1973324808"
+  >
+    #change-decision.jsx-118784165{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-align-items:flex-end;-webkit-box-align:flex-end;-ms-flex-align:flex-end;align-items:flex-end;}
+  </JSXStyle>
+  <JSXStyle
+    id="1693080580"
+  >
+    #selector .list-group-item-danger.disabled,.list-group-item-danger:disabled{color:#721c24;background-color:#f5c6cb;}#selector .list-group-item-success.disabled,.list-group-item-success:disabled{color:#155724;background-color:#c3e6cb;}#selector .list-group-item-secondary.disabled,.list-group-item-secondary:disabled{color:#383d41;background-color:#d6d8db;}
+  </JSXStyle>
+</Row>
+`;
+
+exports[`ApplicationReviewStepSelector shows the application decision if a decision has been made) 3`] = `
+<Row
+  noGutters={false}
+>
+  <div
+    className="jsx-118784165 col-xxl-6 col-xl-7 col-lg-8 col-md-10"
+  >
+    <ListGroup
+      as="ul"
+      id="selector"
+    >
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Administrative review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="2"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Technical review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="3"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Another review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        aria-disabled={true}
+        as="li"
+        disabled={true}
+        id="open-decision-dialog"
+        key="decision"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+          }
+        }
+        tabIndex={0}
+        variant="secondary"
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                384,
+                512,
+                Array [],
+                "f252",
+                "M360 0H24C10.745 0 0 10.745 0 24v16c0 13.255 10.745 24 24 24 0 90.965 51.016 167.734 120.842 192C75.016 280.266 24 357.035 24 448c-13.255 0-24 10.745-24 24v16c0 13.255 10.745 24 24 24h336c13.255 0 24-10.745 24-24v-16c0-13.255-10.745-24-24-24 0-90.965-51.016-167.734-120.842-192C308.984 231.734 360 154.965 360 64c13.255 0 24-10.745 24-24V24c0-13.255-10.745-24-24-24zm-75.078 384H99.08c17.059-46.797 52.096-80 92.92-80 40.821 0 75.862 33.196 92.922 80zm.019-256H99.078C91.988 108.548 88 86.748 88 64h208c0 22.805-3.987 44.587-11.059 64z",
+              ],
+              "iconName": "hourglass-half",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Changes have been requested and applicant notified
+      </ListGroupItem>
+    </ListGroup>
+  </div>
+  <JSXStyle
+    id="1973324808"
+  >
+    #change-decision.jsx-118784165{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-align-items:flex-end;-webkit-box-align:flex-end;-ms-flex-align:flex-end;align-items:flex-end;}
+  </JSXStyle>
+  <JSXStyle
+    id="1693080580"
+  >
+    #selector .list-group-item-danger.disabled,.list-group-item-danger:disabled{color:#721c24;background-color:#f5c6cb;}#selector .list-group-item-success.disabled,.list-group-item-success:disabled{color:#155724;background-color:#c3e6cb;}#selector .list-group-item-secondary.disabled,.list-group-item-secondary:disabled{color:#383d41;background-color:#d6d8db;}
+  </JSXStyle>
+</Row>
+`;
+
+exports[`ApplicationReviewStepSelector shows the selected selected step when \`selectedStep\` is specified 1`] = `
+<Row
+  noGutters={false}
+>
+  <div
+    className="jsx-118784165 col-xxl-6 col-xl-7 col-lg-8 col-md-10"
+  >
+    <ListGroup
+      as="ul"
+      id="selector"
+    >
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Administrative review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={true}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="2"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Technical review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="3"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Another review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        aria-disabled={true}
+        as="li"
+        disabled={true}
+        id="open-decision-dialog"
+        key="decision"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+          }
+        }
+        tabIndex={0}
+      >
+        Make a decision or request changes
+      </ListGroupItem>
+    </ListGroup>
+  </div>
+  <JSXStyle
+    id="1973324808"
+  >
+    #change-decision.jsx-118784165{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-align-items:flex-end;-webkit-box-align:flex-end;-ms-flex-align:flex-end;align-items:flex-end;}
+  </JSXStyle>
+  <JSXStyle
+    id="1693080580"
+  >
+    #selector .list-group-item-danger.disabled,.list-group-item-danger:disabled{color:#721c24;background-color:#f5c6cb;}#selector .list-group-item-success.disabled,.list-group-item-success:disabled{color:#155724;background-color:#c3e6cb;}#selector .list-group-item-secondary.disabled,.list-group-item-secondary:disabled{color:#383d41;background-color:#d6d8db;}
+  </JSXStyle>
+</Row>
+`;
+
+exports[`ApplicationReviewStepSelector shows which review steps are completed 1`] = `
+<Row
+  noGutters={false}
+>
+  <div
+    className="jsx-118784165 col-xxl-6 col-xl-7 col-lg-8 col-md-10"
+  >
+    <ListGroup
+      as="ul"
+      id="selector"
+    >
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f086",
+                "M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z",
+              ],
+              "iconName": "comments",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+        Open Administrative review 
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="2"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                512,
+                512,
+                Array [],
+                "f00c",
+                "M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z",
+              ],
+              "iconName": "check",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+         Technical review completed
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        as="li"
+        className="review-step-option"
+        disabled={false}
+        key="3"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+            "position": "relative",
+          }
+        }
+        tabIndex={0}
+      >
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                512,
+                512,
+                Array [],
+                "f00c",
+                "M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z",
+              ],
+              "iconName": "check",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          style={
+            Object {
+              "left": "1.2rem",
+              "position": "absolute",
+              "top": "calc(50% - 0.5em)",
+            }
+          }
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+         Another review completed
+      </ListGroupItem>
+      <ListGroupItem
+        action={true}
+        active={false}
+        aria-disabled={true}
+        as="li"
+        disabled={true}
+        id="open-decision-dialog"
+        key="decision"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "paddingLeft": "3rem",
+          }
+        }
+        tabIndex={0}
+      >
+        Make a decision or request changes
+      </ListGroupItem>
+    </ListGroup>
+  </div>
+  <JSXStyle
+    id="1973324808"
+  >
+    #change-decision.jsx-118784165{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-align-items:flex-end;-webkit-box-align:flex-end;-ms-flex-align:flex-end;align-items:flex-end;}
+  </JSXStyle>
+  <JSXStyle
+    id="1693080580"
+  >
+    #selector .list-group-item-danger.disabled,.list-group-item-danger:disabled{color:#721c24;background-color:#f5c6cb;}#selector .list-group-item-success.disabled,.list-group-item-success:disabled{color:#155724;background-color:#c3e6cb;}#selector .list-group-item-secondary.disabled,.list-group-item-secondary:disabled{color:#383d41;background-color:#d6d8db;}
+  </JSXStyle>
+</Row>
+`;

--- a/app/tests/unit/containers/Admin/ApplicationReview/__snapshots__/ApplicationReviewStepSelector.test.tsx.snap
+++ b/app/tests/unit/containers/Admin/ApplicationReview/__snapshots__/ApplicationReviewStepSelector.test.tsx.snap
@@ -193,7 +193,7 @@ exports[`ApplicationReviewStepSelector "make a decision or request changes" butt
         disabled={true}
         id="open-decision-dialog"
         key="decision"
-        onClick={[MockFunction]}
+        onClick={[Function]}
         onKeyDown={[Function]}
         style={
           Object {
@@ -452,7 +452,7 @@ exports[`ApplicationReviewStepSelector "make a decision or request changes" butt
         disabled={true}
         id="open-decision-dialog"
         key="decision"
-        onClick={[MockFunction]}
+        onClick={[Function]}
         onKeyDown={[Function]}
         style={
           Object {
@@ -672,7 +672,7 @@ exports[`ApplicationReviewStepSelector "make a decision or request changes" butt
         disabled={false}
         id="open-decision-dialog"
         key="decision"
-        onClick={[MockFunction]}
+        onClick={[Function]}
         onKeyDown={[Function]}
         style={
           Object {

--- a/app/tests/unit/containers/Admin/ApplicationReview/__snapshots__/ReviewSidebar.test.tsx.snap
+++ b/app/tests/unit/containers/Admin/ApplicationReview/__snapshots__/ReviewSidebar.test.tsx.snap
@@ -191,6 +191,137 @@ exports[`ReviewSidebar should match the last accepted snapshot (no comments) 1`]
 </div>
 `;
 
+exports[`ReviewSidebar should match the last accepted snapshot (review finalized, decision has been made) 1`] = `
+<div
+  className="jsx-3598414504 col-md-5 col-lg-4 col-xxl-3"
+  id="sidebar"
+>
+  <button
+    aria-label="Close Technical Review"
+    className="jsx-3598414504"
+    id="close"
+    onClick={[Function]}
+    type="button"
+  >
+    ×
+  </button>
+  <h2
+    className="jsx-3598414504"
+  >
+    Technical
+     Review
+  </h2>
+  <div
+    className="jsx-3598414504"
+    id="scrollable-comments"
+    tabIndex={0}
+  >
+    <h3
+      className="jsx-3598414504"
+      id="general-comments-label"
+    >
+      General Comments
+       
+      <small
+        className="jsx-3598414504"
+      >
+        <em
+          className="jsx-3598414504"
+        >
+          (Visible to applicant)
+        </em>
+      </small>
+    </h3>
+    <p
+      className="jsx-3598414504 empty-comments"
+    >
+      No general comments to show.
+    </p>
+    <h3
+      className="jsx-3598414504"
+      id="internal-comments-label"
+    >
+      Internal Comments 
+      <FontAwesomeIcon
+        border={false}
+        className=""
+        fixedWidth={false}
+        flip={null}
+        icon={
+          Object {
+            "icon": Array [
+              448,
+              512,
+              Array [],
+              "f023",
+              "M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z",
+            ],
+            "iconName": "lock",
+            "prefix": "fas",
+          }
+        }
+        inverse={false}
+        listItem={false}
+        mask={null}
+        pull={null}
+        pulse={false}
+        rotation={null}
+        size={null}
+        spin={false}
+        swapOpacity={false}
+        symbol={false}
+        title=""
+        transform={null}
+      />
+       
+      <small
+        className="jsx-3598414504"
+      >
+        <em
+          className="jsx-3598414504"
+        >
+          (Not visible to applicant)
+        </em>
+      </small>
+    </h3>
+    <p
+      className="jsx-3598414504 empty-comments"
+    >
+      No internal comments to show.
+    </p>
+  </div>
+  <div
+    className="jsx-3598414504"
+    id="button-footer"
+  >
+    <Button
+      active={false}
+      disabled={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "padding": 0,
+        }
+      }
+      variant="link"
+    >
+      Show resolved comments
+    </Button>
+  </div>
+  <JSXStyle
+    dynamic={
+      Array [
+        68,
+        68,
+      ]
+    }
+    id="3059376100"
+  >
+    #sidebar.__jsx-style-dynamic-selector{position:fixed;top:68px;right:0;height:calc(100% - 68px);background:#f7f7f7;border:1px solid transparent;border-left-color:#dfdfdf;padding:0 1.5em;}#close.__jsx-style-dynamic-selector{font-size:2.2rem;position:absolute;top:0;left:1rem;cursor:pointer;border:none;background:none;}h2.__jsx-style-dynamic-selector{margin:15px 0;text-align:center;}h3.__jsx-style-dynamic-selector{font-size:1em;font-weight:bold;margin:5px 0 15px 0;}h3.__jsx-style-dynamic-selector:not(:first-of-type){margin-top:2em;}#scrollable-comments.__jsx-style-dynamic-selector{overflow-y:scroll;height:calc(100% - 108px - 2.4rem - 53px);margin:1.2rem 0;padding:0.7rem;border-radius:4px;}#scrollable-comments.__jsx-style-dynamic-selector:hover{box-shadow:inset 0 0px 7px -1px #999;}#scrollable-comments.__jsx-style-dynamic-selector::-webkit-scrollbar{-webkit-appearance:none;width:8px;}#scrollable-comments.__jsx-style-dynamic-selector::-webkit-scrollbar-thumb{border-radius:4px;background-color:rgba(0,0,0,0.5);box-shadow:0 0 1px rgba(255,255,255,0.5);}#button-footer.__jsx-style-dynamic-selector{position:absolute;bottom:0;margin-bottom:15px;width:calc(100% - 3em);display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-pack:justify;-webkit-justify-content:space-between;-ms-flex-pack:justify;justify-content:space-between;}.mark-incomplete.__jsx-style-dynamic-selector{line-height:1;font-size:0.9em;text-align:center;margin:35px 0;}h3.__jsx-style-dynamic-selector~ul.__jsx-style-dynamic-selector,h3.__jsx-style-dynamic-selector~p.__jsx-style-dynamic-selector{padding-left:0.3em;}ul.__jsx-style-dynamic-selector:last-of-type{margin:0;}.empty-comments.__jsx-style-dynamic-selector{font-style:italic;font-size:0.9em;margin-bottom:0;line-height:1.5;color:#666;}
+  </JSXStyle>
+</div>
+`;
+
 exports[`ReviewSidebar should match the last accepted snapshot (with comments) 1`] = `
 <div
   className="jsx-3598414504 col-md-5 col-lg-4 col-xxl-3"

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationDetailsContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationDetailsContainer.test.tsx.snap
@@ -5,13 +5,7 @@ exports[`ApplicationDetailsComponent should match the snapshot with the Applicat
   <Row
     noGutters={false}
   >
-    <Col
-      md={
-        Object {
-          "offset": 2,
-        }
-      }
-    />
+    <Col />
   </Row>
   <br
     className="jsx-2472284510"

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationStatusContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationStatusContainer.test.tsx.snap
@@ -1,250 +1,190 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ApplicationRevisionStatusItem should render the application status in a disabled button if isCurrentVersion is false 1`] = `
-<Fragment>
-  <Row
-    noGutters={false}
-  >
-    <Col
-      md={3}
-    >
-      <h3>
-        Application Status*: 
-      </h3>
-    </Col>
-    <Modal
-      animation={true}
-      autoFocus={true}
-      backdrop={true}
-      dialogAs={
-        Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "displayName": "ModalDialog",
-          "render": [Function],
-        }
+<Row
+  noGutters={false}
+>
+  <Modal
+    animation={true}
+    autoFocus={true}
+    backdrop={true}
+    dialogAs={
+      Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "displayName": "ModalDialog",
+        "render": [Function],
       }
-      enforceFocus={true}
-      keyboard={true}
-      onHide={[Function]}
-      restoreFocus={true}
-      show={false}
+    }
+    enforceFocus={true}
+    keyboard={true}
+    onHide={[Function]}
+    restoreFocus={true}
+    show={false}
+  >
+    <ModalHeader
+      closeButton={false}
+      closeLabel="Close"
     >
-      <ModalHeader
-        closeButton={false}
-        closeLabel="Close"
-      >
-        <ModalTitle>
-          Confirm Status Change
-        </ModalTitle>
-      </ModalHeader>
-      <ModalBody>
-        <p>
-          Changing this status will result in an email being sent to the reporter notifying them that their application status has been changed.
-        </p>
-      </ModalBody>
-      <ModalFooter>
-        <Button
-          active={false}
-          disabled={false}
-          onClick={[Function]}
-          variant="success"
-        >
-          Confirm
-        </Button>
-        <Button
-          active={false}
-          disabled={false}
-          onClick={[Function]}
-          variant="secondary"
-        >
-          Cancel
-        </Button>
-      </ModalFooter>
-    </Modal>
-    <Col
-      md={2}
-    >
+      <ModalTitle>
+        Confirm Status Change
+      </ModalTitle>
+    </ModalHeader>
+    <ModalBody>
+      <p>
+        Changing this status will result in an email being sent to the reporter notifying them that their application status has been changed.
+      </p>
+    </ModalBody>
+    <ModalFooter>
       <Button
         active={false}
-        disabled={true}
-        variant="info"
+        disabled={false}
+        onClick={[Function]}
+        variant="success"
       >
-        SUBMITTED
+        Confirm
       </Button>
-    </Col>
-  </Row>
-  <Row
-    noGutters={false}
+      <Button
+        active={false}
+        disabled={false}
+        onClick={[Function]}
+        variant="secondary"
+      >
+        Cancel
+      </Button>
+    </ModalFooter>
+  </Modal>
+  <Col
+    md={2}
   >
-    <Col
-      md={12}
+    <Button
+      active={false}
+      disabled={true}
+      variant="info"
     >
-      <p>
-        * Status changes will be immediately confirmed to the applicant by email notification.
-        <br />
-        <span
-          style={
-            Object {
-              "marginLeft": "0.7em",
-            }
-          }
-        >
-          General comments will become visible to the applicant once the application status is updated.
-        </span>
-      </p>
-    </Col>
-  </Row>
-</Fragment>
+      SUBMITTED
+    </Button>
+  </Col>
+</Row>
 `;
 
 exports[`ApplicationRevisionStatusItem should render the application status in a dropdown if isCurrentVersion is true 1`] = `
-<Fragment>
-  <Row
-    noGutters={false}
+<Row
+  noGutters={false}
+>
+  <Modal
+    animation={true}
+    autoFocus={true}
+    backdrop={true}
+    dialogAs={
+      Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "displayName": "ModalDialog",
+        "render": [Function],
+      }
+    }
+    enforceFocus={true}
+    keyboard={true}
+    onHide={[Function]}
+    restoreFocus={true}
+    show={false}
   >
-    <Col
-      md={3}
+    <ModalHeader
+      closeButton={false}
+      closeLabel="Close"
     >
-      <h3>
-        Application Status*: 
-      </h3>
-    </Col>
-    <Modal
-      animation={true}
-      autoFocus={true}
-      backdrop={true}
-      dialogAs={
+      <ModalTitle>
+        Confirm Status Change
+      </ModalTitle>
+    </ModalHeader>
+    <ModalBody>
+      <p>
+        Changing this status will result in an email being sent to the reporter notifying them that their application status has been changed.
+      </p>
+    </ModalBody>
+    <ModalFooter>
+      <Button
+        active={false}
+        disabled={false}
+        onClick={[Function]}
+        variant="success"
+      >
+        Confirm
+      </Button>
+      <Button
+        active={false}
+        disabled={false}
+        onClick={[Function]}
+        variant="secondary"
+      >
+        Cancel
+      </Button>
+    </ModalFooter>
+  </Modal>
+  <Col
+    md={2}
+  >
+    <Dropdown
+      navbar={false}
+      style={
         Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "displayName": "ModalDialog",
-          "render": [Function],
+          "width": "100%",
         }
       }
-      enforceFocus={true}
-      keyboard={true}
-      onHide={[Function]}
-      restoreFocus={true}
-      show={false}
     >
-      <ModalHeader
-        closeButton={false}
-        closeLabel="Close"
+      <DropdownToggle
+        as={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "defaultProps": Object {
+              "pill": false,
+            },
+            "displayName": "Badge",
+            "render": [Function],
+          }
+        }
+        id="dropdown"
+        pill={true}
+        style={
+          Object {
+            "fontSize": "1em",
+            "padding": "0.6em 1em",
+            "textTransform": "uppercase",
+          }
+        }
+        variant="info"
       >
-        <ModalTitle>
-          Confirm Status Change
-        </ModalTitle>
-      </ModalHeader>
-      <ModalBody>
-        <p>
-          Changing this status will result in an email being sent to the reporter notifying them that their application status has been changed.
-        </p>
-      </ModalBody>
-      <ModalFooter>
-        <Button
-          active={false}
-          disabled={false}
-          onClick={[Function]}
-          variant="success"
-        >
-          Confirm
-        </Button>
-        <Button
-          active={false}
-          disabled={false}
-          onClick={[Function]}
-          variant="secondary"
-        >
-          Cancel
-        </Button>
-      </ModalFooter>
-    </Modal>
-    <Col
-      md={2}
-    >
-      <Dropdown
-        navbar={false}
+        Submitted
+      </DropdownToggle>
+      <DropdownMenu
+        align="left"
+        alignRight={false}
+        flip={true}
         style={
           Object {
             "width": "100%",
           }
         }
       >
-        <DropdownToggle
-          as={
-            Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "defaultProps": Object {
-                "pill": false,
-              },
-              "displayName": "Badge",
-              "render": [Function],
-            }
-          }
-          id="dropdown"
-          pill={true}
-          style={
-            Object {
-              "fontSize": "1em",
-              "padding": "0.6em 1em",
-              "textTransform": "uppercase",
-            }
-          }
-          variant="info"
-        >
-          Submitted
-        </DropdownToggle>
-        <DropdownMenu
-          align="left"
-          alignRight={false}
-          flip={true}
-          style={
-            Object {
-              "width": "100%",
-            }
-          }
-        >
-          <DropdownMenuItemComponent
-            itemEventKey="REJECTED"
-            itemFunc={[Function]}
-            itemTitle="Rejected"
-            key="REJECTED"
-          />
-          <DropdownMenuItemComponent
-            itemEventKey="APPROVED"
-            itemFunc={[Function]}
-            itemTitle="Approved"
-            key="APPROVED"
-          />
-          <DropdownMenuItemComponent
-            itemEventKey="REQUESTED_CHANGES"
-            itemFunc={[Function]}
-            itemTitle="Changes requested"
-            key="REQUESTED_CHANGES"
-          />
-        </DropdownMenu>
-      </Dropdown>
-    </Col>
-  </Row>
-  <Row
-    noGutters={false}
-  >
-    <Col
-      md={12}
-    >
-      <p>
-        * Status changes will be immediately confirmed to the applicant by email notification.
-        <br />
-        <span
-          style={
-            Object {
-              "marginLeft": "0.7em",
-            }
-          }
-        >
-          General comments will become visible to the applicant once the application status is updated.
-        </span>
-      </p>
-    </Col>
-  </Row>
-</Fragment>
+        <DropdownMenuItemComponent
+          itemEventKey="REJECTED"
+          itemFunc={[Function]}
+          itemTitle="Rejected"
+          key="REJECTED"
+        />
+        <DropdownMenuItemComponent
+          itemEventKey="APPROVED"
+          itemFunc={[Function]}
+          itemTitle="Approved"
+          key="APPROVED"
+        />
+        <DropdownMenuItemComponent
+          itemEventKey="REQUESTED_CHANGES"
+          itemFunc={[Function]}
+          itemTitle="Changes requested"
+          key="REQUESTED_CHANGES"
+        />
+      </DropdownMenu>
+    </Dropdown>
+  </Col>
+</Row>
 `;

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationStatusContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationStatusContainer.test.tsx.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ApplicationRevisionStatusItem should render the application status in a disabled button if isCurrentVersion is false 1`] = `
-<Row
-  noGutters={false}
->
+<Fragment>
   <Modal
     animation={true}
     autoFocus={true}
@@ -53,24 +51,24 @@ exports[`ApplicationRevisionStatusItem should render the application status in a
       </Button>
     </ModalFooter>
   </Modal>
-  <Col
-    md={2}
+  <Button
+    active={false}
+    disabled={true}
+    style={
+      Object {
+        "fontSize": "1rem",
+        "marginLeft": "2rem",
+      }
+    }
+    variant="info"
   >
-    <Button
-      active={false}
-      disabled={true}
-      variant="info"
-    >
-      SUBMITTED
-    </Button>
-  </Col>
-</Row>
+    SUBMITTED
+  </Button>
+</Fragment>
 `;
 
 exports[`ApplicationRevisionStatusItem should render the application status in a dropdown if isCurrentVersion is true 1`] = `
-<Row
-  noGutters={false}
->
+<Fragment>
   <Modal
     animation={true}
     autoFocus={true}
@@ -120,71 +118,70 @@ exports[`ApplicationRevisionStatusItem should render the application status in a
       </Button>
     </ModalFooter>
   </Modal>
-  <Col
-    md={2}
+  <Dropdown
+    as="span"
+    navbar={false}
+    style={
+      Object {
+        "fontSize": "1rem",
+        "marginLeft": "2rem",
+        "width": "100%",
+      }
+    }
   >
-    <Dropdown
-      navbar={false}
+    <DropdownToggle
+      as={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "defaultProps": Object {
+            "pill": false,
+          },
+          "displayName": "Badge",
+          "render": [Function],
+        }
+      }
+      id="dropdown"
+      pill={true}
+      style={
+        Object {
+          "fontSize": "1em",
+          "padding": "0.6em 1em",
+          "textTransform": "uppercase",
+        }
+      }
+      variant="info"
+    >
+      Submitted
+    </DropdownToggle>
+    <DropdownMenu
+      align="left"
+      alignRight={false}
+      flip={true}
       style={
         Object {
           "width": "100%",
         }
       }
     >
-      <DropdownToggle
-        as={
-          Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "defaultProps": Object {
-              "pill": false,
-            },
-            "displayName": "Badge",
-            "render": [Function],
-          }
-        }
-        id="dropdown"
-        pill={true}
-        style={
-          Object {
-            "fontSize": "1em",
-            "padding": "0.6em 1em",
-            "textTransform": "uppercase",
-          }
-        }
-        variant="info"
-      >
-        Submitted
-      </DropdownToggle>
-      <DropdownMenu
-        align="left"
-        alignRight={false}
-        flip={true}
-        style={
-          Object {
-            "width": "100%",
-          }
-        }
-      >
-        <DropdownMenuItemComponent
-          itemEventKey="REJECTED"
-          itemFunc={[Function]}
-          itemTitle="Rejected"
-          key="REJECTED"
-        />
-        <DropdownMenuItemComponent
-          itemEventKey="APPROVED"
-          itemFunc={[Function]}
-          itemTitle="Approved"
-          key="APPROVED"
-        />
-        <DropdownMenuItemComponent
-          itemEventKey="REQUESTED_CHANGES"
-          itemFunc={[Function]}
-          itemTitle="Changes requested"
-          key="REQUESTED_CHANGES"
-        />
-      </DropdownMenu>
-    </Dropdown>
-  </Col>
-</Row>
+      <DropdownMenuItemComponent
+        itemEventKey="REJECTED"
+        itemFunc={[Function]}
+        itemTitle="Rejected"
+        key="REJECTED"
+      />
+      <DropdownMenuItemComponent
+        itemEventKey="APPROVED"
+        itemFunc={[Function]}
+        itemTitle="Approved"
+        key="APPROVED"
+      />
+      <DropdownMenuItemComponent
+        itemEventKey="REQUESTED_CHANGES"
+        itemFunc={[Function]}
+        itemTitle="Changes requested"
+        key="REQUESTED_CHANGES"
+      />
+    </DropdownMenu>
+  </Dropdown>
+</Fragment>
 `;

--- a/app/tests/unit/containers/Incentives/__snapshots__/IncentiveCalculatorContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Incentives/__snapshots__/IncentiveCalculatorContainer.test.tsx.snap
@@ -6,20 +6,29 @@ exports[`IncentiveCalculator should render the page 1`] = `
     fluid={false}
   >
     <div
+      className="jsx-3958786356"
       style={
         Object {
           "marginBottom": "30px",
         }
       }
     >
-      <h5>
+      <h2
+        className="jsx-3958786356"
+      >
         Incentive by Product:
-      </h5>
-      <p>
+      </h2>
+      <p
+        className="jsx-3958786356"
+      >
         This formula gives the partial incentive for each product reported in 
-        <br />
+        <br
+          className="jsx-3958786356"
+        />
         the CIIP application. The total Incentive is the sum of these partial incentives.
-        <br />
+        <br
+          className="jsx-3958786356"
+        />
       </p>
     </div>
     <IncentiveSegmentFormula />
@@ -30,41 +39,67 @@ exports[`IncentiveCalculator should render the page 1`] = `
     responsive="lg"
     striped={true}
   >
-    <thead>
-      <tr>
-        <th>
+    <thead
+      className="jsx-3958786356"
+    >
+      <tr
+        className="jsx-3958786356"
+      >
+        <th
+          className="jsx-3958786356"
+        >
           Product Name
         </th>
-        <th>
+        <th
+          className="jsx-3958786356"
+        >
           Emission Intensity
         </th>
-        <th>
+        <th
+          className="jsx-3958786356"
+        >
           Benchmark
         </th>
-        <th>
+        <th
+          className="jsx-3958786356"
+        >
           Eligibility Threshold
         </th>
-        <th>
+        <th
+          className="jsx-3958786356"
+        >
           Threshold Chart
         </th>
-        <th>
+        <th
+          className="jsx-3958786356"
+        >
           Incentive Ratio
         </th>
-        <th>
+        <th
+          className="jsx-3958786356"
+        >
           Incentive Multiplier
         </th>
-        <th>
+        <th
+          className="jsx-3958786356"
+        >
           Payment Allocation
         </th>
-        <th>
+        <th
+          className="jsx-3958786356"
+        >
           Calculated Incentive (CAD)
         </th>
-        <th>
+        <th
+          className="jsx-3958786356"
+        >
           Maximum Incentive (CAD)
         </th>
       </tr>
     </thead>
-    <tbody>
+    <tbody
+      className="jsx-3958786356"
+    >
       <Relay(IncentiveSegmentContainer)
         ciipIncentiveByProduct={
           Object {
@@ -78,5 +113,10 @@ exports[`IncentiveCalculator should render the page 1`] = `
       />
     </tbody>
   </ForwardRef>
+  <JSXStyle
+    id="3958786356"
+  >
+    h2.jsx-3958786356{font-size:1.25rem;margin-botton:0.5rem;}
+  </JSXStyle>
 </Fragment>
 `;

--- a/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
+++ b/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
@@ -36,12 +36,26 @@ exports[`The application-review page matches the last snapshot (with review side
         }
         applicationRowId={1}
       />
-      <button
-        onClick={[Function]}
-        type="button"
-      >
-        Click to toggle review comments
-      </button>
+      <Relay(ApplicationReviewStepSelector)
+        applicationReviewSteps={
+          Object {
+            " $fragmentRefs": Object {
+              "ApplicationReviewStepSelector_applicationReviewSteps": true,
+            },
+            "edges": Array [
+              Object {
+                "node": Object {
+                  " $fragmentRefs": Object {
+                    "ReviewSidebar_applicationReviewStep": true,
+                  },
+                },
+              },
+            ],
+          }
+        }
+        onSelectStep={[Function]}
+        selectedStep={null}
+      />
       <ApplicationOverrideNotification
         overrideJustification={null}
       />
@@ -65,6 +79,9 @@ exports[`The application-review page matches the last snapshot (with review side
                 "ApplicationDetailsContainer_application": true,
               },
               "applicationReviewStepsByApplicationId": Object {
+                " $fragmentRefs": Object {
+                  "ApplicationReviewStepSelector_applicationReviewSteps": true,
+                },
                 "edges": Array [
                   Object {
                     "node": Object {
@@ -106,6 +123,9 @@ exports[`The application-review page matches the last snapshot (with review side
                 "ApplicationDetailsContainer_application": true,
               },
               "applicationReviewStepsByApplicationId": Object {
+                " $fragmentRefs": Object {
+                  "ApplicationReviewStepSelector_applicationReviewSteps": true,
+                },
                 "edges": Array [
                   Object {
                     "node": Object {
@@ -255,12 +275,26 @@ exports[`The application-review page matches the last snapshot (with review side
         }
         applicationRowId={1}
       />
-      <button
-        onClick={[Function]}
-        type="button"
-      >
-        Click to toggle review comments
-      </button>
+      <Relay(ApplicationReviewStepSelector)
+        applicationReviewSteps={
+          Object {
+            " $fragmentRefs": Object {
+              "ApplicationReviewStepSelector_applicationReviewSteps": true,
+            },
+            "edges": Array [
+              Object {
+                "node": Object {
+                  " $fragmentRefs": Object {
+                    "ReviewSidebar_applicationReviewStep": true,
+                  },
+                },
+              },
+            ],
+          }
+        }
+        onSelectStep={[Function]}
+        selectedStep={null}
+      />
       <ApplicationOverrideNotification
         overrideJustification={null}
       />
@@ -284,6 +318,9 @@ exports[`The application-review page matches the last snapshot (with review side
                 "ApplicationDetailsContainer_application": true,
               },
               "applicationReviewStepsByApplicationId": Object {
+                " $fragmentRefs": Object {
+                  "ApplicationReviewStepSelector_applicationReviewSteps": true,
+                },
                 "edges": Array [
                   Object {
                     "node": Object {
@@ -325,6 +362,9 @@ exports[`The application-review page matches the last snapshot (with review side
                 "ApplicationDetailsContainer_application": true,
               },
               "applicationReviewStepsByApplicationId": Object {
+                " $fragmentRefs": Object {
+                  "ApplicationReviewStepSelector_applicationReviewSteps": true,
+                },
                 "edges": Array [
                   Object {
                     "node": Object {
@@ -432,13 +472,7 @@ exports[`The application-review page matches the last snapshot (with review side
       </OverlayTrigger>
     </div>
     <Relay(ReviewSidebar)
-      applicationReviewStep={
-        Object {
-          " $fragmentRefs": Object {
-            "ReviewSidebar_applicationReviewStep": true,
-          },
-        }
-      }
+      applicationReviewStep={null}
       onClose={[Function]}
     />
   </Row>

--- a/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
+++ b/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
@@ -9,6 +9,9 @@ exports[`The application-review page matches the last snapshot (with review side
       " $fragmentRefs": Object {
         "defaultLayout_session": true,
       },
+      "userGroups": Array [
+        "Incentive Analyst",
+      ],
     }
   }
   width="wide"
@@ -35,6 +38,7 @@ exports[`The application-review page matches the last snapshot (with review side
               " $fragmentRefs": Object {
                 "ApplicationRevisionStatusContainer_applicationRevisionStatus": true,
               },
+              "applicationRevisionStatus": "SUBMITTED",
             }
           }
           applicationRowId={1}
@@ -52,11 +56,13 @@ exports[`The application-review page matches the last snapshot (with review side
                   " $fragmentRefs": Object {
                     "ReviewSidebar_applicationReviewStep": true,
                   },
+                  "id": "abc",
                 },
               },
             ],
           }
         }
+        decisionOrChangeRequestStatus="SUBMITTED"
         onDecisionOrChangeRequestAction={[Function]}
         onSelectStep={[Function]}
         selectedStep={null}
@@ -71,6 +77,7 @@ exports[`The application-review page matches the last snapshot (with review side
         applicationRevision={
           Object {
             " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_applicationRevision": true,
               "IncentiveCalculatorContainer_applicationRevision": true,
             },
             "overrideJustification": null,
@@ -79,6 +86,7 @@ exports[`The application-review page matches the last snapshot (with review side
         diffQuery={
           Object {
             " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_diffQuery": true,
               "ApplicationDetailsContainer_query": true,
             },
             "application": Object {
@@ -95,6 +103,7 @@ exports[`The application-review page matches the last snapshot (with review side
                       " $fragmentRefs": Object {
                         "ReviewSidebar_applicationReviewStep": true,
                       },
+                      "id": "abc",
                     },
                   },
                 ],
@@ -103,11 +112,13 @@ exports[`The application-review page matches the last snapshot (with review side
                 " $fragmentRefs": Object {
                   "ApplicationRevisionStatusContainer_applicationRevisionStatus": true,
                 },
+                "applicationRevisionStatus": "SUBMITTED",
               },
               "rowId": 1,
             },
             "applicationRevision": Object {
               " $fragmentRefs": Object {
+                "ApplicationDetailsContainer_applicationRevision": true,
                 "IncentiveCalculatorContainer_applicationRevision": true,
               },
               "overrideJustification": null,
@@ -116,6 +127,9 @@ exports[`The application-review page matches the last snapshot (with review side
               " $fragmentRefs": Object {
                 "defaultLayout_session": true,
               },
+              "userGroups": Array [
+                "Incentive Analyst",
+              ],
             },
           }
         }
@@ -123,6 +137,7 @@ exports[`The application-review page matches the last snapshot (with review side
         query={
           Object {
             " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_diffQuery": true,
               "ApplicationDetailsContainer_query": true,
             },
             "application": Object {
@@ -139,6 +154,7 @@ exports[`The application-review page matches the last snapshot (with review side
                       " $fragmentRefs": Object {
                         "ReviewSidebar_applicationReviewStep": true,
                       },
+                      "id": "abc",
                     },
                   },
                 ],
@@ -147,11 +163,13 @@ exports[`The application-review page matches the last snapshot (with review side
                 " $fragmentRefs": Object {
                   "ApplicationRevisionStatusContainer_applicationRevisionStatus": true,
                 },
+                "applicationRevisionStatus": "SUBMITTED",
               },
               "rowId": 1,
             },
             "applicationRevision": Object {
               " $fragmentRefs": Object {
+                "ApplicationDetailsContainer_applicationRevision": true,
                 "IncentiveCalculatorContainer_applicationRevision": true,
               },
               "overrideJustification": null,
@@ -160,6 +178,9 @@ exports[`The application-review page matches the last snapshot (with review side
               " $fragmentRefs": Object {
                 "defaultLayout_session": true,
               },
+              "userGroups": Array [
+                "Incentive Analyst",
+              ],
             },
           }
         }
@@ -169,6 +190,7 @@ exports[`The application-review page matches the last snapshot (with review side
         applicationRevision={
           Object {
             " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_applicationRevision": true,
               "IncentiveCalculatorContainer_applicationRevision": true,
             },
             "overrideJustification": null,
@@ -260,6 +282,9 @@ exports[`The application-review page matches the last snapshot (with review side
       " $fragmentRefs": Object {
         "defaultLayout_session": true,
       },
+      "userGroups": Array [
+        "Incentive Analyst",
+      ],
     }
   }
   width="wide"
@@ -286,6 +311,7 @@ exports[`The application-review page matches the last snapshot (with review side
               " $fragmentRefs": Object {
                 "ApplicationRevisionStatusContainer_applicationRevisionStatus": true,
               },
+              "applicationRevisionStatus": "SUBMITTED",
             }
           }
           applicationRowId={1}
@@ -303,11 +329,13 @@ exports[`The application-review page matches the last snapshot (with review side
                   " $fragmentRefs": Object {
                     "ReviewSidebar_applicationReviewStep": true,
                   },
+                  "id": "abc",
                 },
               },
             ],
           }
         }
+        decisionOrChangeRequestStatus="SUBMITTED"
         onDecisionOrChangeRequestAction={[Function]}
         onSelectStep={[Function]}
         selectedStep={null}
@@ -322,6 +350,7 @@ exports[`The application-review page matches the last snapshot (with review side
         applicationRevision={
           Object {
             " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_applicationRevision": true,
               "IncentiveCalculatorContainer_applicationRevision": true,
             },
             "overrideJustification": null,
@@ -330,6 +359,7 @@ exports[`The application-review page matches the last snapshot (with review side
         diffQuery={
           Object {
             " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_diffQuery": true,
               "ApplicationDetailsContainer_query": true,
             },
             "application": Object {
@@ -346,6 +376,7 @@ exports[`The application-review page matches the last snapshot (with review side
                       " $fragmentRefs": Object {
                         "ReviewSidebar_applicationReviewStep": true,
                       },
+                      "id": "abc",
                     },
                   },
                 ],
@@ -354,11 +385,13 @@ exports[`The application-review page matches the last snapshot (with review side
                 " $fragmentRefs": Object {
                   "ApplicationRevisionStatusContainer_applicationRevisionStatus": true,
                 },
+                "applicationRevisionStatus": "SUBMITTED",
               },
               "rowId": 1,
             },
             "applicationRevision": Object {
               " $fragmentRefs": Object {
+                "ApplicationDetailsContainer_applicationRevision": true,
                 "IncentiveCalculatorContainer_applicationRevision": true,
               },
               "overrideJustification": null,
@@ -367,6 +400,9 @@ exports[`The application-review page matches the last snapshot (with review side
               " $fragmentRefs": Object {
                 "defaultLayout_session": true,
               },
+              "userGroups": Array [
+                "Incentive Analyst",
+              ],
             },
           }
         }
@@ -374,6 +410,7 @@ exports[`The application-review page matches the last snapshot (with review side
         query={
           Object {
             " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_diffQuery": true,
               "ApplicationDetailsContainer_query": true,
             },
             "application": Object {
@@ -390,6 +427,7 @@ exports[`The application-review page matches the last snapshot (with review side
                       " $fragmentRefs": Object {
                         "ReviewSidebar_applicationReviewStep": true,
                       },
+                      "id": "abc",
                     },
                   },
                 ],
@@ -398,11 +436,13 @@ exports[`The application-review page matches the last snapshot (with review side
                 " $fragmentRefs": Object {
                   "ApplicationRevisionStatusContainer_applicationRevisionStatus": true,
                 },
+                "applicationRevisionStatus": "SUBMITTED",
               },
               "rowId": 1,
             },
             "applicationRevision": Object {
               " $fragmentRefs": Object {
+                "ApplicationDetailsContainer_applicationRevision": true,
                 "IncentiveCalculatorContainer_applicationRevision": true,
               },
               "overrideJustification": null,
@@ -411,6 +451,9 @@ exports[`The application-review page matches the last snapshot (with review side
               " $fragmentRefs": Object {
                 "defaultLayout_session": true,
               },
+              "userGroups": Array [
+                "Incentive Analyst",
+              ],
             },
           }
         }
@@ -420,6 +463,7 @@ exports[`The application-review page matches the last snapshot (with review side
         applicationRevision={
           Object {
             " $fragmentRefs": Object {
+              "ApplicationDetailsContainer_applicationRevision": true,
               "IncentiveCalculatorContainer_applicationRevision": true,
             },
             "overrideJustification": null,
@@ -491,6 +535,7 @@ exports[`The application-review page matches the last snapshot (with review side
       </OverlayTrigger>
     </div>
     <Relay(ReviewSidebar)
+      isFinalized={false}
       onClose={[Function]}
     />
   </Row>

--- a/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
+++ b/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
@@ -489,7 +489,6 @@ exports[`The application-review page matches the last snapshot (with review side
       </OverlayTrigger>
     </div>
     <Relay(ReviewSidebar)
-      applicationReviewStep={null}
       onClose={[Function]}
     />
   </Row>

--- a/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
+++ b/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`The application-review page matches the last snapshot (with review side
             ],
           }
         }
+        onDecisionOrChangeRequestAction={[Function]}
         onSelectStep={[Function]}
         selectedStep={null}
       />
@@ -307,6 +308,7 @@ exports[`The application-review page matches the last snapshot (with review side
             ],
           }
         }
+        onDecisionOrChangeRequestAction={[Function]}
         onSelectStep={[Function]}
         selectedStep={null}
       />

--- a/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
+++ b/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
@@ -63,6 +63,7 @@ exports[`The application-review page matches the last snapshot (with review side
           }
         }
         decisionOrChangeRequestStatus="SUBMITTED"
+        newerDraftExists={false}
         onDecisionOrChangeRequestAction={[Function]}
         onSelectStep={[Function]}
         selectedStep={null}
@@ -80,6 +81,7 @@ exports[`The application-review page matches the last snapshot (with review side
               "ApplicationDetailsContainer_applicationRevision": true,
               "IncentiveCalculatorContainer_applicationRevision": true,
             },
+            "isCurrentVersion": true,
             "overrideJustification": null,
           }
         }
@@ -121,6 +123,7 @@ exports[`The application-review page matches the last snapshot (with review side
                 "ApplicationDetailsContainer_applicationRevision": true,
                 "IncentiveCalculatorContainer_applicationRevision": true,
               },
+              "isCurrentVersion": true,
               "overrideJustification": null,
             },
             "session": Object {
@@ -172,6 +175,7 @@ exports[`The application-review page matches the last snapshot (with review side
                 "ApplicationDetailsContainer_applicationRevision": true,
                 "IncentiveCalculatorContainer_applicationRevision": true,
               },
+              "isCurrentVersion": true,
               "overrideJustification": null,
             },
             "session": Object {
@@ -193,6 +197,7 @@ exports[`The application-review page matches the last snapshot (with review side
               "ApplicationDetailsContainer_applicationRevision": true,
               "IncentiveCalculatorContainer_applicationRevision": true,
             },
+            "isCurrentVersion": true,
             "overrideJustification": null,
           }
         }
@@ -337,6 +342,7 @@ exports[`The application-review page matches the last snapshot (with review side
           }
         }
         decisionOrChangeRequestStatus="SUBMITTED"
+        newerDraftExists={false}
         onDecisionOrChangeRequestAction={[Function]}
         onSelectStep={[Function]}
         selectedStep={null}
@@ -354,6 +360,7 @@ exports[`The application-review page matches the last snapshot (with review side
               "ApplicationDetailsContainer_applicationRevision": true,
               "IncentiveCalculatorContainer_applicationRevision": true,
             },
+            "isCurrentVersion": true,
             "overrideJustification": null,
           }
         }
@@ -395,6 +402,7 @@ exports[`The application-review page matches the last snapshot (with review side
                 "ApplicationDetailsContainer_applicationRevision": true,
                 "IncentiveCalculatorContainer_applicationRevision": true,
               },
+              "isCurrentVersion": true,
               "overrideJustification": null,
             },
             "session": Object {
@@ -446,6 +454,7 @@ exports[`The application-review page matches the last snapshot (with review side
                 "ApplicationDetailsContainer_applicationRevision": true,
                 "IncentiveCalculatorContainer_applicationRevision": true,
               },
+              "isCurrentVersion": true,
               "overrideJustification": null,
             },
             "session": Object {
@@ -467,6 +476,7 @@ exports[`The application-review page matches the last snapshot (with review side
               "ApplicationDetailsContainer_applicationRevision": true,
               "IncentiveCalculatorContainer_applicationRevision": true,
             },
+            "isCurrentVersion": true,
             "overrideJustification": null,
           }
         }

--- a/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
+++ b/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
@@ -29,17 +29,17 @@ exports[`The application-review page matches the last snapshot (with review side
         className="jsx-2513507238"
       >
         Application #1
-      </h1>
-      <Relay(ApplicationRevisionStatusComponent)
-        applicationRevisionStatus={
-          Object {
-            " $fragmentRefs": Object {
-              "ApplicationRevisionStatusContainer_applicationRevisionStatus": true,
-            },
+        <Relay(ApplicationRevisionStatusComponent)
+          applicationRevisionStatus={
+            Object {
+              " $fragmentRefs": Object {
+                "ApplicationRevisionStatusContainer_applicationRevisionStatus": true,
+              },
+            }
           }
-        }
-        applicationRowId={1}
-      />
+          applicationRowId={1}
+        />
+      </h1>
       <Relay(ApplicationReviewStepSelector)
         applicationReviewSteps={
           Object {
@@ -279,17 +279,17 @@ exports[`The application-review page matches the last snapshot (with review side
         className="jsx-2513507238"
       >
         Application #1
-      </h1>
-      <Relay(ApplicationRevisionStatusComponent)
-        applicationRevisionStatus={
-          Object {
-            " $fragmentRefs": Object {
-              "ApplicationRevisionStatusContainer_applicationRevisionStatus": true,
-            },
+        <Relay(ApplicationRevisionStatusComponent)
+          applicationRevisionStatus={
+            Object {
+              " $fragmentRefs": Object {
+                "ApplicationRevisionStatusContainer_applicationRevisionStatus": true,
+              },
+            }
           }
-        }
-        applicationRowId={1}
-      />
+          applicationRowId={1}
+        />
+      </h1>
       <Relay(ApplicationReviewStepSelector)
         applicationReviewSteps={
           Object {

--- a/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
+++ b/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
@@ -68,9 +68,18 @@ exports[`The application-review page matches the last snapshot (with review side
         onSelectStep={[Function]}
         selectedStep={null}
       />
-      <ApplicationOverrideNotification
-        overrideJustification={null}
-      />
+      <Row
+        noGutters={false}
+        style={
+          Object {
+            "marginTop": 30,
+          }
+        }
+      >
+        <ApplicationOverrideNotification
+          overrideJustification={null}
+        />
+      </Row>
       <hr
         className="jsx-2573804510"
       />
@@ -347,9 +356,18 @@ exports[`The application-review page matches the last snapshot (with review side
         onSelectStep={[Function]}
         selectedStep={null}
       />
-      <ApplicationOverrideNotification
-        overrideJustification={null}
-      />
+      <Row
+        noGutters={false}
+        style={
+          Object {
+            "marginTop": 30,
+          }
+        }
+      >
+        <ApplicationOverrideNotification
+          overrideJustification={null}
+        />
+      </Row>
       <hr
         className="jsx-2573804510"
       />

--- a/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
+++ b/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`The application-review page matches the last snapshot (with review side
     noGutters={false}
   >
     <div
-      className="jsx-2513507238 
+      className="jsx-2573804510 
              col-md-10
              col-lg-10
              col-xxl-10
@@ -26,7 +26,7 @@ exports[`The application-review page matches the last snapshot (with review side
       id="application-body"
     >
       <h1
-        className="jsx-2513507238"
+        className="jsx-2573804510"
       >
         Application #1
         <Relay(ApplicationRevisionStatusComponent)
@@ -64,7 +64,7 @@ exports[`The application-review page matches the last snapshot (with review side
         overrideJustification={null}
       />
       <hr
-        className="jsx-2513507238"
+        className="jsx-2573804510"
       />
       <Relay(ApplicationDetailsComponent)
         applicationRevision={
@@ -243,9 +243,9 @@ exports[`The application-review page matches the last snapshot (with review side
     />
   </Row>
   <JSXStyle
-    id="2513507238"
+    id="2573804510"
   >
-    h1.jsx-2513507238{font-size:1.75rem;margin-bottom:20px;}
+    h1{margin-bottom:20px;}.list-group-item.active{z-index:auto;background:#38598a;}
   </JSXStyle>
 </Relay(DefaultLayout)>
 `;
@@ -267,7 +267,7 @@ exports[`The application-review page matches the last snapshot (with review side
     noGutters={false}
   >
     <div
-      className="jsx-2513507238 
+      className="jsx-2573804510 
              col-md-7
              col-lg-8
              col-xxl-9
@@ -276,7 +276,7 @@ exports[`The application-review page matches the last snapshot (with review side
       id="application-body"
     >
       <h1
-        className="jsx-2513507238"
+        className="jsx-2573804510"
       >
         Application #1
         <Relay(ApplicationRevisionStatusComponent)
@@ -314,7 +314,7 @@ exports[`The application-review page matches the last snapshot (with review side
         overrideJustification={null}
       />
       <hr
-        className="jsx-2513507238"
+        className="jsx-2573804510"
       />
       <Relay(ApplicationDetailsComponent)
         applicationRevision={
@@ -493,9 +493,9 @@ exports[`The application-review page matches the last snapshot (with review side
     />
   </Row>
   <JSXStyle
-    id="2513507238"
+    id="2573804510"
   >
-    h1.jsx-2513507238{font-size:1.75rem;margin-bottom:20px;}
+    h1{margin-bottom:20px;}.list-group-item.active{z-index:auto;background:#38598a;}
   </JSXStyle>
 </Relay(DefaultLayout)>
 `;

--- a/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
+++ b/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
@@ -210,6 +210,7 @@ exports[`The application-review page matches the last snapshot (with review side
       >
         <Button
           active={false}
+          aria-label="Return to top of page"
           disabled={false}
           id="to-top"
           onClick={[Function]}
@@ -483,6 +484,7 @@ exports[`The application-review page matches the last snapshot (with review side
       >
         <Button
           active={false}
+          aria-label="Return to top of page"
           disabled={false}
           id="to-top"
           onClick={[Function]}

--- a/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
+++ b/app/tests/unit/pages/analyst/__snapshots__/application-review.test.tsx.snap
@@ -14,11 +14,10 @@ exports[`The application-review page matches the last snapshot (with review side
   width="wide"
 >
   <Row
-    className="application-container"
     noGutters={false}
   >
     <div
-      className="
+      className="jsx-2513507238 
              col-md-10
              col-lg-10
              col-xxl-10
@@ -26,6 +25,11 @@ exports[`The application-review page matches the last snapshot (with review side
              offset-lg-1"
       id="application-body"
     >
+      <h1
+        className="jsx-2513507238"
+      >
+        Application #1
+      </h1>
       <Relay(ApplicationRevisionStatusComponent)
         applicationRevisionStatus={
           Object {
@@ -59,7 +63,9 @@ exports[`The application-review page matches the last snapshot (with review side
       <ApplicationOverrideNotification
         overrideJustification={null}
       />
-      <hr />
+      <hr
+        className="jsx-2513507238"
+      />
       <Relay(ApplicationDetailsComponent)
         applicationRevision={
           Object {
@@ -236,6 +242,11 @@ exports[`The application-review page matches the last snapshot (with review side
       isInternalUser={true}
     />
   </Row>
+  <JSXStyle
+    id="2513507238"
+  >
+    h1.jsx-2513507238{font-size:1.75rem;margin-bottom:20px;}
+  </JSXStyle>
 </Relay(DefaultLayout)>
 `;
 
@@ -253,11 +264,10 @@ exports[`The application-review page matches the last snapshot (with review side
   width="wide"
 >
   <Row
-    className="application-container"
     noGutters={false}
   >
     <div
-      className="
+      className="jsx-2513507238 
              col-md-7
              col-lg-8
              col-xxl-9
@@ -265,6 +275,11 @@ exports[`The application-review page matches the last snapshot (with review side
              offset-lg-0"
       id="application-body"
     >
+      <h1
+        className="jsx-2513507238"
+      >
+        Application #1
+      </h1>
       <Relay(ApplicationRevisionStatusComponent)
         applicationRevisionStatus={
           Object {
@@ -298,7 +313,9 @@ exports[`The application-review page matches the last snapshot (with review side
       <ApplicationOverrideNotification
         overrideJustification={null}
       />
-      <hr />
+      <hr
+        className="jsx-2513507238"
+      />
       <Relay(ApplicationDetailsComponent)
         applicationRevision={
           Object {
@@ -476,5 +493,10 @@ exports[`The application-review page matches the last snapshot (with review side
       onClose={[Function]}
     />
   </Row>
+  <JSXStyle
+    id="2513507238"
+  >
+    h1.jsx-2513507238{font-size:1.75rem;margin-bottom:20px;}
+  </JSXStyle>
 </Relay(DefaultLayout)>
 `;

--- a/app/tests/unit/pages/analyst/application-review.test.tsx
+++ b/app/tests/unit/pages/analyst/application-review.test.tsx
@@ -29,7 +29,10 @@ const getTestQuery = () => {
               }
             }
           }
-        ]
+        ],
+        ' $fragmentRefs': {
+          ApplicationReviewStepSelector_applicationReviewSteps: true
+        }
       }
     },
     applicationRevision: {
@@ -66,10 +69,12 @@ describe('The application-review page', () => {
     );
     expect(wrapper.exists('Relay(ReviewSidebar)')).toBeFalse();
     // Open the sidebar:
-    wrapper
-      .find('button')
-      .filterWhere((n) => n.text() === 'Click to toggle review comments')
-      .simulate('click');
+    wrapper.setState((state) => {
+      return {
+        ...state,
+        isSidebarOpened: true
+      };
+    });
     expect(wrapper.exists('Relay(ReviewSidebar)')).toBeTrue();
     expect(wrapper.exists('HelpButton')).toBeFalse();
     expect(wrapper).toMatchSnapshot();
@@ -85,10 +90,12 @@ describe('The application-review page', () => {
     );
     expect(wrapper.exists('HelpButton')).toBeTrue();
     // Open the sidebar:
-    wrapper
-      .find('button')
-      .filterWhere((n) => n.text() === 'Click to toggle review comments')
-      .simulate('click');
+    wrapper.setState((state) => {
+      return {
+        ...state,
+        isSidebarOpened: true
+      };
+    });
     expect(wrapper.exists('HelpButton')).toBeFalse();
   });
 

--- a/app/tests/unit/pages/analyst/application-review.test.tsx
+++ b/app/tests/unit/pages/analyst/application-review.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {shallow, mount} from 'enzyme';
+import {shallow} from 'enzyme';
 import ApplicationReview from 'pages/analyst/application-review';
 import {
   applicationReviewQueryResponse,


### PR DESCRIPTION
- Review step selector shows selected review step in sidebar
- Shows completion state of each step
   * marking a step complete shows a confirmation modal when there remain unresolved comments, requested by SME
- "Make a decision or request changes" button remains disabled until all steps are marked completed
    * once a decision is made, text/color/icon indicates the decision
- "Change decision" button preserves current functionality for admins (but not analysts, per SME) to change the decision
    * actual making/changing of decision will be implemented in [GGIRCS-2294](https://youtrack.button.is/issue/GGIRCS-2294) when the status dropdown will finally be removed.
    * disabled when a newer draft exists
    * instead, disabled button indicates the existence of newer draft
- Once a decision is made, review becomes view-only (reversible if the decision is reversed)
    * disables marking steps incomplete, creation/modification of comments
- Minor accessibility fixes for the page
- Implements a reusable `GenericConfirmationModal` for use in patterns requiring confirmation to continue

[GGIRCS-2293](https://youtrack.button.is/issue/GGIRCS-2293)

<img width="1440" alt="Screen Shot 2021-04-23 at 8 00 31 AM" src="https://user-images.githubusercontent.com/5522075/115891014-7422d480-a40a-11eb-8c8d-a95cef746211.png">
<img width="823" alt="Screen Shot 2021-04-23 at 8 01 14 AM" src="https://user-images.githubusercontent.com/5522075/115891032-784ef200-a40a-11eb-8c01-6345a5d618af.png">
<img width="1440" alt="Screen Shot 2021-04-23 at 7 59 40 AM" src="https://user-images.githubusercontent.com/5522075/115891109-90267600-a40a-11eb-81c4-76ba17ee7852.png">
<img width="1214" alt="Screen Shot 2021-04-23 at 8 05 38 AM" src="https://user-images.githubusercontent.com/5522075/115891234-b3e9bc00-a40a-11eb-8c56-2d3bbcee2a3a.png">
