### PR TITLE
fix: update contact us page email locations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,6 +379,7 @@ jobs:
             SMTP_CONNECTION_STRING: smtp://@localhost:1025
             SENDER_EMAIL: example@cas.com
             ADMIN_EMAIL: GHGRegulator@gov.bc.ca
+            SUPPORT_EMAIL: ggircs@gov.bc.ca
             ENABLE_DB_MOCKS_COOKIES_ONLY: "true" # Allow cookies to be set by cypress
           command: |
             source ~/.asdf/asdf.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,8 +377,8 @@ jobs:
           name: run end-to-end tests with happo and cypress
           environment:
             SMTP_CONNECTION_STRING: smtp://@localhost:1025
-            SENDER_EMAIL: BCCAS <example@cas.com>
-            ADMIN_EMAIL: GHG Regulator <GHGRegulator@gov.bc.ca>
+            SENDER_EMAIL: example@cas.com
+            ADMIN_EMAIL: GHGRegulator@gov.bc.ca
             ENABLE_DB_MOCKS_COOKIES_ONLY: "true" # Allow cookies to be set by cypress
           command: |
             source ~/.asdf/asdf.sh

--- a/app/.env.example
+++ b/app/.env.example
@@ -4,6 +4,7 @@ GRAPHQL_API_URL=<URL>
 SMTP_CONNECTION_STRING=<connection string>
 SENDER_EMAIL=<sender's email>
 ADMIN_EMAIL=<admin's email>
+SUPPORT_EMAIL=<support email>
 HOST=<host address>
 
 # true if we want the mocks database schema to be deployed, false otherwise

--- a/app/containers/Applications/ApplyButtonContainer.tsx
+++ b/app/containers/Applications/ApplyButtonContainer.tsx
@@ -3,6 +3,7 @@ import {Button, Modal} from 'react-bootstrap';
 import {graphql, createFragmentContainer, RelayProp} from 'react-relay';
 import Link from 'next/link';
 import {useRouter} from 'next/router';
+import getConfig from 'next/config';
 import createApplicationMutation from 'mutations/application/createApplicationMutation';
 import {ApplyButtonContainer_applyButtonDetails} from 'ApplyButtonContainer_applyButtonDetails.graphql';
 import {ApplyButtonContainer_query} from 'ApplyButtonContainer_query.graphql';
@@ -33,6 +34,9 @@ export const ApplyButton: React.FunctionComponent<Props> = ({
   const applicationId = applicationByApplicationId?.id;
   const [showMissingReportModal, setShowMissingReportModal] = useState(false);
   const [applyButtonClicked, setApplyButtonClicked] = useState(false);
+
+  const adminEmail = getConfig()?.publicRuntimeConfig.ADMIN_EMAIL;
+  const adminMailToUrl = adminEmail ? `mailto:${adminEmail}` : '#';
 
   const router = useRouter();
 
@@ -117,9 +121,8 @@ export const ApplyButton: React.FunctionComponent<Props> = ({
             its regulations.
           </p>
           <p>
-            For any questions, please{' '}
-            <a href="mailto: ghgregulator@gov.bc.ca">contact</a> the Climate
-            Action Secretariat at GHGRegulator@gov.bc.ca
+            For any questions, please <a href={adminMailToUrl}>contact</a> the
+            Climate Action Secretariat at {adminEmail}
           </p>
         </Modal.Body>
         <Modal.Footer>

--- a/app/containers/Facilities/FacilitiesListContainer.tsx
+++ b/app/containers/Facilities/FacilitiesListContainer.tsx
@@ -1,5 +1,6 @@
 import React, {useMemo} from 'react';
 import {graphql, createFragmentContainer} from 'react-relay';
+import getConfig from 'next/config';
 import {FacilitiesListContainer_query} from 'FacilitiesListContainer_query.graphql';
 import FacilitiesRowItemContainer from './FacilitiesRowItemContainer';
 import {
@@ -44,6 +45,9 @@ export const FacilitiesList: React.FunctionComponent<Props> = ({query}) => {
     defaultDisplayedReportingYear
   } = query;
 
+  const adminEmail = getConfig()?.publicRuntimeConfig.ADMIN_EMAIL;
+  const adminMailToUrl = adminEmail ? `mailto:${adminEmail}` : '#';
+
   const router = useRouter();
   const selectedReportingYear = useMemo(
     () =>
@@ -87,7 +91,7 @@ export const FacilitiesList: React.FunctionComponent<Props> = ({query}) => {
         totalCount={totalCount}
       />
       If you cannot find your facility in the list, please{' '}
-      <a href="mailto:ghgregulator@gov.bc.ca">contact CAS</a> for assistance.
+      <a href={adminMailToUrl}>contact CAS</a> at {adminEmail} for assistance.
     </>
   );
 };

--- a/app/containers/Organisations/Organisations.tsx
+++ b/app/containers/Organisations/Organisations.tsx
@@ -10,6 +10,7 @@ import {
   Row,
   Col
 } from 'react-bootstrap';
+import getConfig from 'next/config';
 import {Organisations_query} from 'Organisations_query.graphql';
 import RelayModernEnvironment from 'relay-runtime/lib/store/RelayModernEnvironment';
 import LoadingSpinner from 'components/LoadingSpinner';
@@ -34,6 +35,10 @@ export const OrganisationsComponent: React.FunctionComponent<Props> = (
   props
 ) => {
   const {session, allOrganisations} = props.query;
+  const adminEmail = getConfig()?.publicRuntimeConfig.ADMIN_EMAIL;
+  const adminMailToUrl = adminEmail
+    ? `mailto:${adminEmail}?subject=CIIP Portal Inquiry`
+    : '#';
   if (!session) return <LoadingSpinner />;
 
   const changeInput = (event) => {
@@ -198,9 +203,7 @@ export const OrganisationsComponent: React.FunctionComponent<Props> = (
                   </p>
                   <p>
                     Please email{' '}
-                    <Alert.Link href="mailto:GHGRegulator@gov.bc.ca?subject=CIIP Portal Inquiry">
-                      GHGRegulator@gov.bc.ca
-                    </Alert.Link>{' '}
+                    <Alert.Link href={adminMailToUrl}>{adminEmail}</Alert.Link>{' '}
                     if you have any questions.
                   </p>
                 </Alert>
@@ -240,8 +243,7 @@ export const OrganisationsComponent: React.FunctionComponent<Props> = (
             )}
             <hr />
             If you cannot find your operator in the list, please{' '}
-            <a href="mailto:ghgregulator@gov.bc.ca">contact CAS</a> for
-            assistance.
+            <a href={adminMailToUrl}>contact CAS</a> for assistance.
             <style jsx>
               {`
                 .org-scroll {

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -22,6 +22,7 @@ module.exports = {
   },
   publicRuntimeConfig: {
     NO_MATHJAX: process.env.NO_MATHJAX,
+    ADMIN_EMAIL: process.env.ADMIN_EMAIL,
     SUPPORT_EMAIL: process.env.SUPPORT_EMAIL,
     ENABLE_ANALYTICS: process.env.ENABLE_ANALYTICS,
     SITEWIDE_NOTICE: process.env.SITEWIDE_NOTICE,

--- a/app/pages/resources/contact.tsx
+++ b/app/pages/resources/contact.tsx
@@ -3,9 +3,11 @@ import {Container, Alert} from 'react-bootstrap';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faInfoCircle} from '@fortawesome/free-solid-svg-icons';
 import {graphql} from 'react-relay';
+import getConfig from 'next/config';
 import {CiipPageComponentProps} from 'next-env';
 import {contactQueryResponse} from 'contactQuery.graphql';
 import DefaultLayout from 'layouts/default-layout';
+const getEmailShortForm = require('app/server/helpers/getEmailShortForm.js');
 
 interface Props extends CiipPageComponentProps {
   query: contactQueryResponse['query'];
@@ -26,6 +28,10 @@ class Contact extends Component<Props> {
   render() {
     const {query} = this.props;
     const {session} = query || {};
+    const supportEmail = getConfig()?.publicRuntimeConfig.SUPPORT_EMAIL;
+    const adminEmail = getEmailShortForm(
+      getConfig()?.publicRuntimeConfig.ADMIN_EMAIL
+    );
     return (
       <DefaultLayout session={session} title="Contact Us">
         <Container>
@@ -34,15 +40,15 @@ class Contact extends Component<Props> {
             <span className="pl-2">
               For help with your CIIP application, or questions about the
               CleanBC Industrial Incentive Program, please email{' '}
-              <a href="mailto:GHGRegulator@gov.bc.ca?subject=Support Request (CIIP)">
-                GHGRegulator@gov.bc.ca
+              <a href={`mailto:${adminEmail}?subject=Support Request (CIIP)`}>
+                {adminEmail}
               </a>
             </span>
           </Alert>
           <p className="px-4 py-3">
             To report a website error, contact the development team at{' '}
-            <a href="mailto:ggircs@gov.bc.ca?subject=Support Request (CIIP)">
-              ggircs@gov.bc.ca
+            <a href={`mailto:${supportEmail}?subject=Support Request (CIIP)`}>
+              {supportEmail}
             </a>
             .
           </p>

--- a/app/pages/resources/contact.tsx
+++ b/app/pages/resources/contact.tsx
@@ -29,9 +29,16 @@ class Contact extends Component<Props> {
     const {query} = this.props;
     const {session} = query || {};
     const supportEmail = getConfig()?.publicRuntimeConfig.SUPPORT_EMAIL;
+    const supportMailToUrl = supportEmail
+      ? `mailto:${supportEmail}?subject=Support Request (CIIP)`
+      : '#';
     const adminEmail = getEmailShortForm(
       getConfig()?.publicRuntimeConfig.ADMIN_EMAIL
     );
+    const adminMailToUrl = supportEmail
+      ? `mailto:${adminEmail}?subject=Support Request (CIIP)`
+      : '#';
+
     return (
       <DefaultLayout session={session} title="Contact Us">
         <Container>
@@ -40,17 +47,12 @@ class Contact extends Component<Props> {
             <span className="pl-2">
               For help with your CIIP application, or questions about the
               CleanBC Industrial Incentive Program, please email{' '}
-              <a href={`mailto:${adminEmail}?subject=Support Request (CIIP)`}>
-                {adminEmail}
-              </a>
+              <a href={adminMailToUrl}>{adminEmail}</a>
             </span>
           </Alert>
           <p className="px-4 py-3">
             To report a website error, contact the development team at{' '}
-            <a href={`mailto:${supportEmail}?subject=Support Request (CIIP)`}>
-              {supportEmail}
-            </a>
-            .
+            <a href={supportMailToUrl}>{supportEmail}</a>.
           </p>
         </Container>
       </DefaultLayout>

--- a/app/pages/resources/contact.tsx
+++ b/app/pages/resources/contact.tsx
@@ -7,7 +7,6 @@ import getConfig from 'next/config';
 import {CiipPageComponentProps} from 'next-env';
 import {contactQueryResponse} from 'contactQuery.graphql';
 import DefaultLayout from 'layouts/default-layout';
-const getEmailShortForm = require('app/server/helpers/getEmailShortForm.js');
 
 interface Props extends CiipPageComponentProps {
   query: contactQueryResponse['query'];
@@ -32,10 +31,8 @@ class Contact extends Component<Props> {
     const supportMailToUrl = supportEmail
       ? `mailto:${supportEmail}?subject=Support Request (CIIP)`
       : '#';
-    const adminEmail = getEmailShortForm(
-      getConfig()?.publicRuntimeConfig.ADMIN_EMAIL
-    );
-    const adminMailToUrl = supportEmail
+    const adminEmail = getConfig()?.publicRuntimeConfig.ADMIN_EMAIL;
+    const adminMailToUrl = adminEmail
       ? `mailto:${adminEmail}?subject=Support Request (CIIP)`
       : '#';
 

--- a/app/pages/resources/contact.tsx
+++ b/app/pages/resources/contact.tsx
@@ -1,5 +1,7 @@
 import React, {Component} from 'react';
-import {Container} from 'react-bootstrap';
+import {Container, Alert} from 'react-bootstrap';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import {faInfoCircle} from '@fortawesome/free-solid-svg-icons';
 import {graphql} from 'react-relay';
 import {CiipPageComponentProps} from 'next-env';
 import {contactQueryResponse} from 'contactQuery.graphql';
@@ -21,19 +23,28 @@ class Contact extends Component<Props> {
     }
   `;
 
-  // TODO: Add content to this empty page
   render() {
     const {query} = this.props;
     const {session} = query || {};
     return (
       <DefaultLayout session={session} title="Contact Us">
         <Container>
-          <p>
-            Please email{' '}
-            <a href="mailto:GHGRegulator@gov.bc.ca?subject=CIIP Portal Inquiry">
-              GHGRegulator@gov.bc.ca
-            </a>{' '}
-            with any questions or concerns.
+          <Alert variant="info">
+            <FontAwesomeIcon icon={faInfoCircle} />
+            <span className="pl-2">
+              For help with your CIIP application, or questions about the
+              CleanBC Industrial Incentive Program, please email{' '}
+              <a href="mailto:GHGRegulator@gov.bc.ca?subject=Support Request (CIIP)">
+                GHGRegulator@gov.bc.ca
+              </a>
+            </span>
+          </Alert>
+          <p className="px-4 py-3">
+            To report a website error, contact the development team at{' '}
+            <a href="mailto:ggircs@gov.bc.ca?subject=Support Request (CIIP)">
+              ggircs@gov.bc.ca
+            </a>
+            .
           </p>
         </Container>
       </DefaultLayout>

--- a/app/pages/resources/contact.tsx
+++ b/app/pages/resources/contact.tsx
@@ -33,7 +33,7 @@ class Contact extends Component<Props> {
       : '#';
     const adminEmail = getConfig()?.publicRuntimeConfig.ADMIN_EMAIL;
     const adminMailToUrl = adminEmail
-      ? `mailto:${adminEmail}?subject=Support Request (CIIP)`
+      ? `mailto:${adminEmail}?subject=CIIP Inquiry`
       : '#';
 
     return (

--- a/app/server/helpers/getEmailShortForm.js
+++ b/app/server/helpers/getEmailShortForm.js
@@ -1,5 +1,0 @@
-module.exports = (longForm) => {
-  const pattern = new RegExp(/<(.+)>$/);
-  const match = pattern.exec(`${longForm}`);
-  return match ? match[1] : '';
-};

--- a/app/server/tasks/sendMail.js
+++ b/app/server/tasks/sendMail.js
@@ -9,10 +9,11 @@ const createOrganisationAccessApprovedMail = require('../emailTemplates/organisa
 const createNotifyAdminApplicationSubmittedMail = require('../emailTemplates/notifyAdminApplicationSubmitted.js');
 const createNotifyAdminAccessRequestMail = require('../emailTemplates/notifyAdminOrganisationAccess');
 const createDraftApplicationStartedMail = require('../emailTemplates/draftApplicationStarted');
-const getEmailShortForm = require('../helpers/getEmailShortForm');
 dotenv.config();
 
-const ADMIN_EMAIL_SHORT = getEmailShortForm(process.env.ADMIN_EMAIL);
+const adminEmail = process.env.ADMIN_EMAIL;
+const receiverEmail = `GHG Regulator <${adminEmail}>`;
+const senderEmail = `BCCAS <${process.env.SENDER_EMAIL}>`;
 
 module.exports = async ({
   type,
@@ -49,7 +50,7 @@ module.exports = async ({
         email,
         firstName,
         lastName,
-        contactEmail: ADMIN_EMAIL_SHORT
+        contactEmail: adminEmail
       });
       break;
     // Confirmation of CIIP Application submission
@@ -64,7 +65,7 @@ module.exports = async ({
         operatorName,
         organisationId,
         versionNumber,
-        contactEmail: ADMIN_EMAIL_SHORT
+        contactEmail: adminEmail
       });
       break;
     case 'status_change_approved':
@@ -77,7 +78,7 @@ module.exports = async ({
         operatorName,
         organisationId,
         status,
-        contactEmail: ADMIN_EMAIL_SHORT
+        contactEmail: adminEmail
       });
       break;
     case 'status_change_rejected':
@@ -89,7 +90,7 @@ module.exports = async ({
         facilityName,
         operatorName,
         status,
-        contactEmail: ADMIN_EMAIL_SHORT
+        contactEmail: adminEmail
       });
       break;
     case 'status_change_requested_changes':
@@ -102,7 +103,7 @@ module.exports = async ({
         facilityName,
         operatorName,
         versionNumber,
-        contactEmail: ADMIN_EMAIL_SHORT
+        contactEmail: adminEmail
       });
       break;
     case 'request_for_organisation_access':
@@ -113,7 +114,7 @@ module.exports = async ({
         lastName,
         facilityName,
         operatorName,
-        contactEmail: ADMIN_EMAIL_SHORT
+        contactEmail: adminEmail
       });
       break;
     case 'organisation_access_approved':
@@ -124,7 +125,7 @@ module.exports = async ({
         lastName,
         operatorName,
         organisationId,
-        contactEmail: ADMIN_EMAIL_SHORT
+        contactEmail: adminEmail
       });
       break;
     case 'notify_admin_submitted':
@@ -135,7 +136,7 @@ module.exports = async ({
         operatorName,
         versionNumber
       });
-      email = process.env.ADMIN_EMAIL;
+      email = receiverEmail;
       break;
     case 'notify_admin_organisation_access':
       subject = 'CIIP Organisation Access Request';
@@ -144,7 +145,7 @@ module.exports = async ({
         lastName,
         operatorName
       });
-      email = process.env.ADMIN_EMAIL;
+      email = receiverEmail;
       break;
     case 'draft_application_started':
       subject = 'CIIP Draft Application Started';
@@ -155,7 +156,7 @@ module.exports = async ({
         email,
         operatorName,
         facilityName,
-        contactEmail: ADMIN_EMAIL_SHORT
+        contactEmail: adminEmail
       });
       break;
     default:
@@ -169,7 +170,7 @@ module.exports = async ({
   }
 
   const message = {
-    from: process.env.SENDER_EMAIL,
+    from: senderEmail,
     to: email,
     subject,
     html: htmlContent

--- a/app/server/tasks/sendMail.js
+++ b/app/server/tasks/sendMail.js
@@ -13,7 +13,7 @@ dotenv.config();
 
 const adminEmail = process.env.ADMIN_EMAIL;
 const receiverEmail = `GHG Regulator <${adminEmail}>`;
-const senderEmail = `BCCAS <${process.env.SENDER_EMAIL}>`;
+const senderEmail = `CIIP Admin, BC Climate Action Secretariat <${process.env.SENDER_EMAIL}>`;
 
 module.exports = async ({
   type,

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplyButtonContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplyButtonContainer.test.tsx.snap
@@ -170,14 +170,13 @@ exports[`The apply button should render a warning modal if no swrs report exists
          or its regulations.
       </p>
       <p>
-        For any questions, please
-         
+        For any questions, please 
         <a
-          href="mailto: ghgregulator@gov.bc.ca"
+          href="#"
         >
           contact
         </a>
-         the Climate Action Secretariat at GHGRegulator@gov.bc.ca
+         the Climate Action Secretariat at 
       </p>
     </ModalBody>
     <ModalFooter>
@@ -264,14 +263,13 @@ exports[`The apply button should render an Apply For CIIP button if no applicati
          or its regulations.
       </p>
       <p>
-        For any questions, please
-         
+        For any questions, please 
         <a
-          href="mailto: ghgregulator@gov.bc.ca"
+          href="#"
         >
           contact
         </a>
-         the Climate Action Secretariat at GHGRegulator@gov.bc.ca
+         the Climate Action Secretariat at 
       </p>
     </ModalBody>
     <ModalFooter>

--- a/app/tests/unit/containers/Facility/__snapshots__/FacilitiesListContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Facility/__snapshots__/FacilitiesListContainer.test.tsx.snap
@@ -200,10 +200,11 @@ exports[`FacilitiesListContainer should match the previous snapshot 1`] = `
   If you cannot find your facility in the list, please
    
   <a
-    href="mailto:ghgregulator@gov.bc.ca"
+    href="#"
   >
     contact CAS
   </a>
+   at 
    for assistance.
 </Fragment>
 `;

--- a/app/tests/unit/containers/Organisation/__snapshots__/Organisations.test.tsx.snap
+++ b/app/tests/unit/containers/Organisation/__snapshots__/Organisations.test.tsx.snap
@@ -130,10 +130,8 @@ exports[`Organisations should render no organisations if the user has not reques
               Please email
                
               <AlertLink
-                href="mailto:GHGRegulator@gov.bc.ca?subject=CIIP Portal Inquiry"
-              >
-                GHGRegulator@gov.bc.ca
-              </AlertLink>
+                href="#"
+              />
                
               if you have any questions.
             </p>
@@ -177,7 +175,7 @@ exports[`Organisations should render no organisations if the user has not reques
          
         <a
           className="jsx-3491480756"
-          href="mailto:ghgregulator@gov.bc.ca"
+          href="#"
         >
           contact CAS
         </a>
@@ -380,10 +378,8 @@ exports[`Organisations should render the user's requested organisations 1`] = `
               Please email
                
               <AlertLink
-                href="mailto:GHGRegulator@gov.bc.ca?subject=CIIP Portal Inquiry"
-              >
-                GHGRegulator@gov.bc.ca
-              </AlertLink>
+                href="#"
+              />
                
               if you have any questions.
             </p>
@@ -427,7 +423,7 @@ exports[`Organisations should render the user's requested organisations 1`] = `
          
         <a
           className="jsx-3491480756"
-          href="mailto:ghgregulator@gov.bc.ca"
+          href="#"
         >
           contact CAS
         </a>

--- a/app/tests/unit/pages/resources/__snapshots__/contact.test.tsx.snap
+++ b/app/tests/unit/pages/resources/__snapshots__/contact.test.tsx.snap
@@ -70,10 +70,8 @@ exports[`Contact page matches the last accepted Snapshot 1`] = `
         For help with your CIIP application, or questions about the CleanBC Industrial Incentive Program, please email
          
         <a
-          href="mailto:GHGRegulator@gov.bc.ca?subject=Support Request (CIIP)"
-        >
-          GHGRegulator@gov.bc.ca
-        </a>
+          href="mailto:#"
+        />
       </span>
     </Alert>
     <p
@@ -82,10 +80,8 @@ exports[`Contact page matches the last accepted Snapshot 1`] = `
       To report a website error, contact the development team at
        
       <a
-        href="mailto:ggircs@gov.bc.ca?subject=Support Request (CIIP)"
-      >
-        ggircs@gov.bc.ca
-      </a>
+        href="mailto:#"
+      />
       .
     </p>
   </Container>

--- a/app/tests/unit/pages/resources/__snapshots__/contact.test.tsx.snap
+++ b/app/tests/unit/pages/resources/__snapshots__/contact.test.tsx.snap
@@ -14,16 +14,79 @@ exports[`Contact page matches the last accepted Snapshot 1`] = `
   <Container
     fluid={false}
   >
-    <p>
-      Please email
+    <Alert
+      closeLabel="Close alert"
+      show={true}
+      transition={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "defaultProps": Object {
+            "appear": false,
+            "in": false,
+            "mountOnEnter": false,
+            "timeout": 300,
+            "unmountOnExit": false,
+          },
+          "displayName": "Fade",
+          "render": [Function],
+        }
+      }
+      variant="info"
+    >
+      <FontAwesomeIcon
+        border={false}
+        className=""
+        fixedWidth={false}
+        flip={null}
+        icon={
+          Object {
+            "icon": Array [
+              512,
+              512,
+              Array [],
+              "f05a",
+              "M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z",
+            ],
+            "iconName": "info-circle",
+            "prefix": "fas",
+          }
+        }
+        inverse={false}
+        listItem={false}
+        mask={null}
+        pull={null}
+        pulse={false}
+        rotation={null}
+        size={null}
+        spin={false}
+        swapOpacity={false}
+        symbol={false}
+        title=""
+        transform={null}
+      />
+      <span
+        className="pl-2"
+      >
+        For help with your CIIP application, or questions about the CleanBC Industrial Incentive Program, please email
+         
+        <a
+          href="mailto:GHGRegulator@gov.bc.ca?subject=Support Request (CIIP)"
+        >
+          GHGRegulator@gov.bc.ca
+        </a>
+      </span>
+    </Alert>
+    <p
+      className="px-4 py-3"
+    >
+      To report a website error, contact the development team at
        
       <a
-        href="mailto:GHGRegulator@gov.bc.ca?subject=CIIP Portal Inquiry"
+        href="mailto:ggircs@gov.bc.ca?subject=Support Request (CIIP)"
       >
-        GHGRegulator@gov.bc.ca
+        ggircs@gov.bc.ca
       </a>
-       
-      with any questions or concerns.
+      .
     </p>
   </Container>
 </Relay(DefaultLayout)>

--- a/app/tests/unit/pages/resources/__snapshots__/contact.test.tsx.snap
+++ b/app/tests/unit/pages/resources/__snapshots__/contact.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`Contact page matches the last accepted Snapshot 1`] = `
         For help with your CIIP application, or questions about the CleanBC Industrial Incentive Program, please email
          
         <a
-          href="mailto:#"
+          href="#"
         />
       </span>
     </Alert>
@@ -80,7 +80,7 @@ exports[`Contact page matches the last accepted Snapshot 1`] = `
       To report a website error, contact the development team at
        
       <a
-        href="mailto:#"
+        href="#"
       />
       .
     </p>

--- a/helm/cas-ciip-portal/values-dev.yaml
+++ b/helm/cas-ciip-portal/values-dev.yaml
@@ -37,8 +37,8 @@ dag:
 
 env:
   smtpConnectionString: smtp://cas-ciip-portal-mailhog:1025
-  senderEmail: BC Climate Action Secretariat <no-reply-dev.cas@gov.bc.ca>
-  adminEmail: CIIP Admin, BC Climate Action Secretariat <admin@ciip.dev>
+  senderEmail: no-reply-dev.cas@gov.bc.ca
+  adminEmail: admin@ciip.dev
   enableDbMocks: true
 
 sitewide_notice:

--- a/helm/cas-ciip-portal/values-test.yaml
+++ b/helm/cas-ciip-portal/values-test.yaml
@@ -4,8 +4,8 @@ route:
 
 env:
   smtpConnectionString: smtp://cas-ciip-portal-mailhog:1025
-  senderEmail: BC Climate Action Secretariat <no-reply-dev.cas@gov.bc.ca>
-  adminEmail: CIIP Admin, BC Climate Action Secretariat <admin@ciip.test>
+  senderEmail: no-reply-dev.cas@gov.bc.ca
+  adminEmail: admin@ciip.test
   enableDbMocks: true
 
 analytics:

--- a/helm/cas-ciip-portal/values.yaml
+++ b/helm/cas-ciip-portal/values.yaml
@@ -59,8 +59,8 @@ dag:
 
 env:
   smtpConnectionString: smtp://apps.smtp.gov.bc.ca/?port=25&ignoreTLS=true&secure=false
-  senderEmail: BCCAS <no-reply.cas@gov.bc.ca>
-  adminEmail: GHG Regulator <GHGRegulator@gov.bc.ca>
+  senderEmail: no-reply.cas@gov.bc.ca
+  adminEmail: GHGRegulator@gov.bc.ca
   supportEmail: ggircs@gov.bc.ca
   enableDbMocks: false
 


### PR DESCRIPTION
https://youtrack.button.is/issue/GGIRCS-1557
https://youtrack.button.is/issue/GGIRCS-2015

- Update email contact depending on help location
- cleans up all env vars related to emails.

MOBILE:
<img width="410" alt="Screenshot 2021-04-19 at 4 30 17 PM" src="https://user-images.githubusercontent.com/35253/115316089-86acbd80-a12d-11eb-8207-dc4b37f43bc2.png">

DESKTOP:
<img width="1167" alt="Screenshot 2021-04-19 at 4 28 54 PM" src="https://user-images.githubusercontent.com/35253/115316097-89a7ae00-a12d-11eb-9303-a725b3c7a6e9.png">
