### PR TITLE
Update legacy review_step name from 'other' to 'application'

### DIFF
--- a/schema/deploy/tables/review_step_001.sql
+++ b/schema/deploy/tables/review_step_001.sql
@@ -1,0 +1,8 @@
+-- Deploy ggircs-portal:tables/review_step_001 to pg
+-- requires: tables/review_step
+
+begin;
+
+update ggircs_portal.review_step set step_name='application' where step_name='other';
+
+commit;

--- a/schema/revert/tables/review_step_001.sql
+++ b/schema/revert/tables/review_step_001.sql
@@ -1,0 +1,7 @@
+-- Revert ggircs-portal:tables/review_step_001 from pg
+
+begin;
+
+update ggircs_portal.review_step set step_name='other' where step_name='application';
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -307,3 +307,4 @@ queries/facility_application_by_reporting_year [queries/facility_application_by_
 tables/gas_001 [tables/gas] 2021-04-20T17:48:20Z Dylan Leard <dylan@button.is> # Migration: add is_ciip_emission column to gas table
 computed_columns/application_revision_total_ciip_emissions [tables/gas_001 views/ciip_emission] 2021-04-20T18:28:40Z Dylan Leard <dylan@button.is> # Add computed column that returns the total ciip emissions for an application revision
 computed_columns/application_revision_ciip_incentive [computed_columns/application_revision_ciip_incentive@v2.0.0] 2021-04-20T21:55:26Z Dylan Leard <dylan@button.is> # Migration: use ciip_total_emissions computed column to retrieve total facility emissions
+tables/review_step_001 [tables/review_step] 2021-04-23T18:50:16Z Kristen Cooke <kristen@button.is> # Migration: Change 'other' review step name to 'application'

--- a/schema/verify/tables/review_step_001.sql
+++ b/schema/verify/tables/review_step_001.sql
@@ -1,0 +1,7 @@
+-- Verify ggircs-portal:tables/review_step_001 on pg
+
+begin;
+
+select exists(select * from ggircs_portal.review_step where step_name='application');
+
+rollback;


### PR DESCRIPTION
...Again. Realized how it shows up as 'Other Review' in the review sidebar was awkward and confusing once I presented it in sprint review. But @matthieu-foucault had a brainwave to name it "application" so it shows up as "Application Review".

This is only relevant to pre-existing reviews created prior to this year.