### PR TITLE
Re-enable review comment creation with simplified modal

### DIFF
--- a/app/components/Admin/AddReviewCommentModal.tsx
+++ b/app/components/Admin/AddReviewCommentModal.tsx
@@ -6,7 +6,7 @@ import {faLock, faEye} from '@fortawesome/free-solid-svg-icons';
 interface Props {
   show: boolean;
   title: string;
-  onSubmit: (detail: object) => void;
+  onSubmit: ({commentText: string, isInternalComment: boolean}) => void;
   onHide: () => void;
 }
 

--- a/app/components/Admin/AddReviewCommentModal.tsx
+++ b/app/components/Admin/AddReviewCommentModal.tsx
@@ -1,0 +1,103 @@
+import React, {useState} from 'react';
+import {Modal, Button, Form, FormCheck} from 'react-bootstrap';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import {faLock, faEye} from '@fortawesome/free-solid-svg-icons';
+
+interface Props {
+  show: boolean;
+  title: string;
+  onSubmit: (detail: object) => void;
+  onHide: () => void;
+}
+
+export const AddReviewCommentModal: React.FunctionComponent<Props> = ({
+  show,
+  title,
+  onSubmit,
+  onHide
+}) => {
+  const [isInternalComment, setIsInternalComment] = useState(false);
+  const [commentText, setCommentText] = useState('');
+
+  const clearForm = () => {
+    setIsInternalComment(false);
+    setCommentText('');
+  };
+  const handleHide = () => {
+    onHide();
+    clearForm();
+  };
+
+  return (
+    <Modal id="add-comment-modal" size="lg" show={show} onHide={handleHide}>
+      <Modal.Header closeButton>
+        <h2>{title}</h2>
+      </Modal.Header>
+      <Modal.Body>
+        <Form.Label>Comment:</Form.Label>
+        <Form.Control
+          as="textarea"
+          rows={3}
+          value={commentText}
+          onChange={(e) => setCommentText(e.target.value)}
+        />
+        <FormCheck>
+          <FormCheck.Label>
+            <FormCheck.Input
+              checked={isInternalComment}
+              onChange={(e) => setIsInternalComment(e.target.checked)}
+            />
+            Visible for <strong>internal</strong> use only
+          </FormCheck.Label>
+        </FormCheck>
+      </Modal.Body>
+      <Modal.Footer>
+        <span>
+          This comment will {isInternalComment && <strong>not</strong>} be
+          visible to the applicant.
+          <FontAwesomeIcon
+            id="visibility-icon"
+            icon={isInternalComment ? faLock : faEye}
+          />
+        </span>
+        <Button
+          id="submit"
+          onClick={() => {
+            if (commentText.trim().length > 0) {
+              onSubmit({commentText, isInternalComment});
+              clearForm();
+            }
+          }}
+        >
+          Add Comment
+        </Button>
+      </Modal.Footer>
+      <style jsx>{`
+        :global(.modal-header) {
+          background: #036;
+          color: #fff;
+        }
+        :global(button.close) {
+          color: #fff;
+        }
+        :global(#add-comment-modal .modal-body) {
+          padding: 1rem 2rem;
+        }
+        :global(#add-comment-modal .form-check) {
+          margin: 1rem 0 0 0;
+        }
+        :global(.form-check-label, .form-check-input) {
+          cursor: pointer;
+        }
+        :global(#visibility-icon) {
+          margin: 0 1em 0 0.5em;
+        }
+        h2 {
+          margin: 0;
+        }
+      `}</style>
+    </Modal>
+  );
+};
+
+export default AddReviewCommentModal;

--- a/app/components/Admin/AddReviewCommentModal.tsx
+++ b/app/components/Admin/AddReviewCommentModal.tsx
@@ -29,18 +29,26 @@ export const AddReviewCommentModal: React.FunctionComponent<Props> = ({
   };
 
   return (
-    <Modal id="add-comment-modal" size="lg" show={show} onHide={handleHide}>
+    <Modal
+      id="add-comment-modal"
+      size="lg"
+      show={show}
+      onHide={handleHide}
+      aria-labelledby="add-comment-title"
+    >
       <Modal.Header closeButton>
-        <h2>{title}</h2>
+        <h2 id="add-comment-title">{title}</h2>
       </Modal.Header>
       <Modal.Body>
-        <Form.Label>Comment:</Form.Label>
-        <Form.Control
-          as="textarea"
-          rows={3}
-          value={commentText}
-          onChange={(e) => setCommentText(e.target.value)}
-        />
+        <Form.Group controlId="comment">
+          <Form.Label>Comment:</Form.Label>
+          <Form.Control
+            as="textarea"
+            rows={3}
+            value={commentText}
+            onChange={(e) => setCommentText(e.target.value)}
+          />
+        </Form.Group>
         <FormCheck>
           <FormCheck.Label>
             <FormCheck.Input

--- a/app/containers/Admin/ApplicationReview/ReviewSidebar.tsx
+++ b/app/containers/Admin/ApplicationReview/ReviewSidebar.tsx
@@ -275,6 +275,7 @@ export const ReviewSidebar: React.FunctionComponent<Props> = ({
         </Button>
         {!isFinalized && !applicationReviewStep?.isComplete && (
           <Button
+            id="new-comment"
             variant="primary"
             onClick={() => setShowAddCommentModal(true)}
           >

--- a/app/containers/Admin/ApplicationReview/ReviewSidebar.tsx
+++ b/app/containers/Admin/ApplicationReview/ReviewSidebar.tsx
@@ -4,13 +4,16 @@ import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faCheck, faLock} from '@fortawesome/free-solid-svg-icons';
 import {graphql, createFragmentContainer, RelayProp} from 'react-relay';
 import {ReviewSidebar_applicationReviewStep} from '__generated__/ReviewSidebar_applicationReviewStep.graphql';
+import {createReviewCommentMutationVariables} from '__generated__/createReviewCommentMutation.graphql';
 import ReviewComment from 'components/Admin/ReviewComment';
+import createReviewCommentMutation from 'mutations/application_review_step/createReviewCommentMutation';
 import updateReviewCommentMutation from 'mutations/application_review_step/updateReviewCommentMutation';
 import deleteReviewCommentMutation from 'mutations/application_review_step/deleteReviewCommentMutation';
 import updateApplicationReviewStepMutation from 'mutations/application_review_step/updateApplicationReviewStepMutation';
 import {nowMoment} from 'functions/formatDates';
 import {capitalize} from 'lib/text-transforms';
 import GenericConfirmationModal from 'components/GenericConfirmationModal';
+import AddReviewCommentModal from 'components/Admin/AddReviewCommentModal';
 
 interface Props {
   onClose: () => void;
@@ -32,6 +35,7 @@ export const ReviewSidebar: React.FunctionComponent<Props> = ({
     showUnresolvedCommentsModal,
     setShowUnresolvedCommentsModal
   ] = useState(false);
+  const [showAddCommentModal, setShowAddCommentModal] = useState(false);
   const toggleResolved = () => setShowingResolved((current) => !current);
   const reviewStepName = capitalize(
     applicationReviewStep?.reviewStepByReviewStepId?.stepName
@@ -191,6 +195,27 @@ export const ReviewSidebar: React.FunctionComponent<Props> = ({
     </GenericConfirmationModal>
   );
 
+  const handleAddReviewComment = async ({commentText, isInternalComment}) => {
+    const commentType = isInternalComment ? 'internal' : 'general';
+    const {environment} = relay;
+    const variables = {
+      input: {
+        reviewComment: {
+          applicationReviewStepId: applicationReviewStep.rowId,
+          commentType: commentType.toUpperCase(),
+          description: commentText
+        }
+      }
+    };
+    await createReviewCommentMutation(
+      environment,
+      variables as createReviewCommentMutationVariables,
+      applicationReviewStep.id,
+      `ReviewSidebar_${commentType}Comments`
+    );
+    setShowAddCommentModal(false);
+  };
+
   return (
     <div id="sidebar" className="col-md-5 col-lg-4 col-xxl-3">
       <button
@@ -249,10 +274,21 @@ export const ReviewSidebar: React.FunctionComponent<Props> = ({
           {`${showingResolved ? 'Hide' : 'Show'} resolved comments`}
         </Button>
         {!isFinalized && !applicationReviewStep?.isComplete && (
-          <Button variant="primary">+ New Comment</Button>
+          <Button
+            variant="primary"
+            onClick={() => setShowAddCommentModal(true)}
+          >
+            + New Comment
+          </Button>
         )}
       </div>
       {showUnresolvedCommentsModal && confirmCommentsResolvedModal}
+      <AddReviewCommentModal
+        title={`Add comment to ${reviewStepName} Review`}
+        show={showAddCommentModal}
+        onSubmit={handleAddReviewComment}
+        onHide={() => setShowAddCommentModal(false)}
+      />
       <style jsx>{`
         #sidebar {
           position: fixed;
@@ -274,6 +310,9 @@ export const ReviewSidebar: React.FunctionComponent<Props> = ({
           background: none;
         }
         h2 {
+          margin: 0;
+        }
+        #sidebar h2:first-of-type {
           margin: 15px 0;
           text-align: center;
         }
@@ -341,6 +380,7 @@ export default createFragmentContainer(ReviewSidebar, {
   applicationReviewStep: graphql`
     fragment ReviewSidebar_applicationReviewStep on ApplicationReviewStep {
       id
+      rowId
       isComplete
       reviewStepByReviewStepId {
         stepName

--- a/app/tests/unit/components/Admin/AddReviewCommentModal.test.tsx
+++ b/app/tests/unit/components/Admin/AddReviewCommentModal.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import {act} from 'react-dom/test-utils';
+import {shallow, mount} from 'enzyme';
+import {AddReviewCommentModal} from 'components/Admin/AddReviewCommentModal';
+
+const getTestElement = ({
+  show = true,
+  title = '',
+  onSubmit = () => {},
+  onHide = () => {}
+}) => {
+  return (
+    <AddReviewCommentModal
+      show={show}
+      title={title}
+      onSubmit={onSubmit}
+      onHide={onHide}
+    />
+  );
+};
+
+describe('Add Review Comment modal', () => {
+  it('matches the last accepted snapshot ("internal" left unchecked)', () => {
+    const wrapper = shallow(getTestElement({}));
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('renders a Bootstrap modal', () => {
+    const wrapper = shallow(getTestElement({}));
+    expect(wrapper.find('Modal').exists()).toBeTrue();
+  });
+  it('passes the `show` prop to the Bootstrap modal', () => {
+    const shown = shallow(getTestElement({show: true}));
+    expect(shown.find('Modal').prop('show')).toBeTrue();
+    const hidden = shallow(getTestElement({show: false}));
+    expect(hidden.find('Modal').prop('show')).toBeFalse();
+  });
+  it('renders the `title` prop as a heading', () => {
+    const title = 'Test Title';
+    const wrapper = shallow(getTestElement({title}));
+    expect(wrapper.find('ModalHeader').text()).toInclude(title);
+  });
+  it('clicking "Add Comment" fires the `onSubmit` prop, only if comment is not empty', () => {
+    const testComment = 'Typing a test comment';
+    const spy = jest.fn();
+    const wrapper = mount(getTestElement({onSubmit: spy}));
+    const textarea = wrapper.find('Modal').first().find('textarea');
+    const button = wrapper.find('Button#submit');
+    expect(button.exists()).toBeTrue();
+    expect(spy).not.toHaveBeenCalled();
+    button.simulate('click');
+    expect(spy).not.toHaveBeenCalled();
+    // Fill the form as the user would, before attempting to reset:
+    act(() => {
+      textarea.simulate('change', {target: {value: testComment}});
+    });
+    expect(textarea.text()).toEqual(testComment);
+    button.simulate('click');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+  it('closing the Bootstrap modal fires the `onHide` prop', () => {
+    const spy = jest.fn();
+    const wrapper = shallow(getTestElement({onHide: spy}));
+    const modalOnHide: () => void = wrapper.find('Modal').prop('onHide');
+    expect(spy).not.toHaveBeenCalled();
+    modalOnHide();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+  it('closing the Bootstrap modal clears the form', () => {
+    const testComment = 'Typing a test comment';
+    const wrapper = mount(getTestElement({}));
+    const textarea = wrapper.find('Modal').first().find('textarea');
+
+    // Fill the form as the user would, before attempting to reset:
+    act(() => {
+      textarea.simulate('change', {target: {value: testComment}});
+    });
+    expect(textarea.text()).toEqual(testComment);
+    const modalOnHide: () => void = wrapper
+      .find('Modal#add-comment-modal')
+      .first()
+      .prop('onHide');
+    act(() => {
+      modalOnHide();
+    });
+    expect(textarea.text()).toEqual('');
+  });
+});

--- a/app/tests/unit/components/Admin/__snapshots__/AddReviewCommentModal.test.tsx.snap
+++ b/app/tests/unit/components/Admin/__snapshots__/AddReviewCommentModal.test.tsx.snap
@@ -1,0 +1,115 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Add Review Comment modal matches the last accepted snapshot ("internal" left unchecked) 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  dialogAs={
+    Object {
+      "$$typeof": Symbol(react.forward_ref),
+      "displayName": "ModalDialog",
+      "render": [Function],
+    }
+  }
+  enforceFocus={true}
+  id="add-comment-modal"
+  keyboard={true}
+  onHide={[Function]}
+  restoreFocus={true}
+  show={true}
+  size="lg"
+>
+  <ModalHeader
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <h2
+      className="jsx-3493496686"
+    />
+  </ModalHeader>
+  <ModalBody>
+    <FormLabel
+      column={false}
+      srOnly={false}
+    >
+      Comment:
+    </FormLabel>
+    <FormControl
+      as="textarea"
+      onChange={[Function]}
+      rows={3}
+      value=""
+    />
+    <FormCheck>
+      <FormCheckLabel>
+        <FormCheckInput
+          checked={false}
+          onChange={[Function]}
+        />
+        Visible for 
+        <strong
+          className="jsx-3493496686"
+        >
+          internal
+        </strong>
+         use only
+      </FormCheckLabel>
+    </FormCheck>
+  </ModalBody>
+  <ModalFooter>
+    <span
+      className="jsx-3493496686"
+    >
+      This comment will 
+       be visible to the applicant.
+      <FontAwesomeIcon
+        border={false}
+        className=""
+        fixedWidth={false}
+        flip={null}
+        icon={
+          Object {
+            "icon": Array [
+              576,
+              512,
+              Array [],
+              "f06e",
+              "M572.52 241.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400a144 144 0 1 1 144-144 143.93 143.93 0 0 1-144 144zm0-240a95.31 95.31 0 0 0-25.31 3.79 47.85 47.85 0 0 1-66.9 66.9A95.78 95.78 0 1 0 288 160z",
+            ],
+            "iconName": "eye",
+            "prefix": "fas",
+          }
+        }
+        id="visibility-icon"
+        inverse={false}
+        listItem={false}
+        mask={null}
+        pull={null}
+        pulse={false}
+        rotation={null}
+        size={null}
+        spin={false}
+        swapOpacity={false}
+        symbol={false}
+        title=""
+        transform={null}
+      />
+    </span>
+    <Button
+      active={false}
+      disabled={false}
+      id="submit"
+      onClick={[Function]}
+      variant="primary"
+    >
+      Add Comment
+    </Button>
+  </ModalFooter>
+  <JSXStyle
+    id="3493496686"
+  >
+    .modal-header{background:#036;color:#fff;}button.close{color:#fff;}#add-comment-modal .modal-body{padding:1rem 2rem;}#add-comment-modal .form-check{margin:1rem 0 0 0;}.form-check-label,.form-check-input{cursor:pointer;}#visibility-icon{margin:0 1em 0 0.5em;}h2.jsx-3493496686{margin:0;}
+  </JSXStyle>
+</Modal>
+`;

--- a/app/tests/unit/components/Admin/__snapshots__/AddReviewCommentModal.test.tsx.snap
+++ b/app/tests/unit/components/Admin/__snapshots__/AddReviewCommentModal.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Add Review Comment modal matches the last accepted snapshot ("internal" left unchecked) 1`] = `
 <Modal
   animation={true}
+  aria-labelledby="add-comment-title"
   autoFocus={true}
   backdrop={true}
   dialogAs={
@@ -26,21 +27,26 @@ exports[`Add Review Comment modal matches the last accepted snapshot ("internal"
   >
     <h2
       className="jsx-3493496686"
+      id="add-comment-title"
     />
   </ModalHeader>
   <ModalBody>
-    <FormLabel
-      column={false}
-      srOnly={false}
+    <FormGroup
+      controlId="comment"
     >
-      Comment:
-    </FormLabel>
-    <FormControl
-      as="textarea"
-      onChange={[Function]}
-      rows={3}
-      value=""
-    />
+      <FormLabel
+        column={false}
+        srOnly={false}
+      >
+        Comment:
+      </FormLabel>
+      <FormControl
+        as="textarea"
+        onChange={[Function]}
+        rows={3}
+        value=""
+      />
+    </FormGroup>
     <FormCheck>
       <FormCheckLabel>
         <FormCheckInput

--- a/app/tests/unit/containers/Admin/ApplicationReview/ReviewSidebar.test.tsx
+++ b/app/tests/unit/containers/Admin/ApplicationReview/ReviewSidebar.test.tsx
@@ -352,6 +352,29 @@ describe('ReviewSidebar', () => {
     modalOnHide();
     expect(r.find('AddReviewCommentModal').prop('show')).toBeFalse();
   });
+  it('saves new review comments and adds them to the application review step', () => {
+    const commentText = 'this is a test comment';
+    const isInternalComment = false;
+    const spy = jest.spyOn(
+      require('mutations/application_review_step/createReviewCommentMutation'),
+      'default'
+    );
+    const relay = {environment: null};
+    const r = shallow(
+      <ReviewSidebar
+        isFinalized={false}
+        applicationReviewStep={
+          applicationReviewStep() as ReviewSidebar_applicationReviewStep
+        }
+        onClose={() => {}}
+        relay={relay as any}
+      />
+    );
+    expect(spy).not.toHaveBeenCalled();
+    const modalOnSubmit = r.find('AddReviewCommentModal').prop('onSubmit');
+    modalOnSubmit({commentText, isInternalComment});
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
   it('sets the title for the add comments modal based on the selected review step', () => {
     const relay = {environment: null};
     const data1 = {

--- a/app/tests/unit/containers/Admin/ApplicationReview/ReviewSidebar.test.tsx
+++ b/app/tests/unit/containers/Admin/ApplicationReview/ReviewSidebar.test.tsx
@@ -10,7 +10,7 @@ const applicationReviewStep = () => {
     rowId: 4,
     isComplete: false,
     reviewStepByReviewStepId: {
-      stepName: 'Technical'
+      stepName: 'technical'
     },
     generalComments: {
       edges: []
@@ -330,5 +330,63 @@ describe('ReviewSidebar', () => {
         .find('Button')
         .filterWhere((n) => n.text() === 'Mark this review step complete')
     ).toBeTruthy();
+  });
+  it('toggles a modal for adding review comments', () => {
+    const relay = {environment: null};
+    const r = shallow(
+      <ReviewSidebar
+        isFinalized={false}
+        applicationReviewStep={
+          applicationReviewStep() as ReviewSidebar_applicationReviewStep
+        }
+        onClose={() => {}}
+        relay={relay as any}
+      />
+    );
+    expect(r.find('AddReviewCommentModal').prop('show')).toBeFalse();
+    r.find('Button#new-comment').simulate('click');
+    expect(r.find('AddReviewCommentModal').prop('show')).toBeTrue();
+    const modalOnHide: () => void = r
+      .find('AddReviewCommentModal')
+      .prop('onHide');
+    modalOnHide();
+    expect(r.find('AddReviewCommentModal').prop('show')).toBeFalse();
+  });
+  it('sets the title for the add comments modal based on the selected review step', () => {
+    const relay = {environment: null};
+    const data1 = {
+      ...applicationReviewStep(),
+      reviewStepByReviewStepId: {
+        stepName: 'technical'
+      }
+    };
+    const data2 = {
+      ...applicationReviewStep(),
+      reviewStepByReviewStepId: {
+        stepName: 'random'
+      }
+    };
+    const r1 = shallow(
+      <ReviewSidebar
+        isFinalized={false}
+        applicationReviewStep={data1 as ReviewSidebar_applicationReviewStep}
+        onClose={() => {}}
+        relay={relay as any}
+      />
+    );
+    const r2 = shallow(
+      <ReviewSidebar
+        isFinalized={false}
+        applicationReviewStep={data2 as ReviewSidebar_applicationReviewStep}
+        onClose={() => {}}
+        relay={relay as any}
+      />
+    );
+    expect(
+      r1.find('AddReviewCommentModal').prop('title').includes('Technical')
+    ).toBeTrue();
+    expect(
+      r2.find('AddReviewCommentModal').prop('title').includes('Random')
+    ).toBeTrue();
   });
 });

--- a/app/tests/unit/containers/Admin/ApplicationReview/ReviewSidebar.test.tsx
+++ b/app/tests/unit/containers/Admin/ApplicationReview/ReviewSidebar.test.tsx
@@ -7,6 +7,7 @@ const applicationReviewStep = () => {
   return {
     ' $refType': 'ReviewSidebar_applicationReviewStep',
     id: 'abc',
+    rowId: 4,
     isComplete: false,
     reviewStepByReviewStepId: {
       stepName: 'Technical'

--- a/app/tests/unit/containers/Admin/ApplicationReview/__snapshots__/ReviewSidebar.test.tsx.snap
+++ b/app/tests/unit/containers/Admin/ApplicationReview/__snapshots__/ReviewSidebar.test.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`ReviewSidebar should match the last accepted snapshot (no comments) 1`] = `
 <div
-  className="jsx-3598414504 col-md-5 col-lg-4 col-xxl-3"
+  className="jsx-4131948494 col-md-5 col-lg-4 col-xxl-3"
   id="sidebar"
 >
   <button
     aria-label="Close Technical Review"
-    className="jsx-3598414504"
+    className="jsx-4131948494"
     id="close"
     onClick={[Function]}
     type="button"
@@ -15,7 +15,7 @@ exports[`ReviewSidebar should match the last accepted snapshot (no comments) 1`]
     ×
   </button>
   <h2
-    className="jsx-3598414504"
+    className="jsx-4131948494"
   >
     Technical
      Review
@@ -74,33 +74,33 @@ exports[`ReviewSidebar should match the last accepted snapshot (no comments) 1`]
     Mark this review step completed
   </Button>
   <div
-    className="jsx-3598414504"
+    className="jsx-4131948494"
     id="scrollable-comments"
     tabIndex={0}
   >
     <h3
-      className="jsx-3598414504"
+      className="jsx-4131948494"
       id="general-comments-label"
     >
       General Comments
        
       <small
-        className="jsx-3598414504"
+        className="jsx-4131948494"
       >
         <em
-          className="jsx-3598414504"
+          className="jsx-4131948494"
         >
           (Visible to applicant)
         </em>
       </small>
     </h3>
     <p
-      className="jsx-3598414504 empty-comments"
+      className="jsx-4131948494 empty-comments"
     >
       No general comments to show.
     </p>
     <h3
-      className="jsx-3598414504"
+      className="jsx-4131948494"
       id="internal-comments-label"
     >
       Internal Comments 
@@ -137,23 +137,23 @@ exports[`ReviewSidebar should match the last accepted snapshot (no comments) 1`]
       />
        
       <small
-        className="jsx-3598414504"
+        className="jsx-4131948494"
       >
         <em
-          className="jsx-3598414504"
+          className="jsx-4131948494"
         >
           (Not visible to applicant)
         </em>
       </small>
     </h3>
     <p
-      className="jsx-3598414504 empty-comments"
+      className="jsx-4131948494 empty-comments"
     >
       No internal comments to show.
     </p>
   </div>
   <div
-    className="jsx-3598414504"
+    className="jsx-4131948494"
     id="button-footer"
   >
     <Button
@@ -172,11 +172,18 @@ exports[`ReviewSidebar should match the last accepted snapshot (no comments) 1`]
     <Button
       active={false}
       disabled={false}
+      onClick={[Function]}
       variant="primary"
     >
       + New Comment
     </Button>
   </div>
+  <AddReviewCommentModal
+    onHide={[Function]}
+    onSubmit={[Function]}
+    show={false}
+    title="Add comment to Technical Review"
+  />
   <JSXStyle
     dynamic={
       Array [
@@ -184,21 +191,21 @@ exports[`ReviewSidebar should match the last accepted snapshot (no comments) 1`]
         68,
       ]
     }
-    id="3059376100"
+    id="3782189477"
   >
-    #sidebar.__jsx-style-dynamic-selector{position:fixed;top:68px;right:0;height:calc(100% - 68px);background:#f7f7f7;border:1px solid transparent;border-left-color:#dfdfdf;padding:0 1.5em;}#close.__jsx-style-dynamic-selector{font-size:2.2rem;position:absolute;top:0;left:1rem;cursor:pointer;border:none;background:none;}h2.__jsx-style-dynamic-selector{margin:15px 0;text-align:center;}h3.__jsx-style-dynamic-selector{font-size:1em;font-weight:bold;margin:5px 0 15px 0;}h3.__jsx-style-dynamic-selector:not(:first-of-type){margin-top:2em;}#scrollable-comments.__jsx-style-dynamic-selector{overflow-y:scroll;height:calc(100% - 108px - 2.4rem - 53px);margin:1.2rem 0;padding:0.7rem;border-radius:4px;}#scrollable-comments.__jsx-style-dynamic-selector:hover{box-shadow:inset 0 0px 7px -1px #999;}#scrollable-comments.__jsx-style-dynamic-selector::-webkit-scrollbar{-webkit-appearance:none;width:8px;}#scrollable-comments.__jsx-style-dynamic-selector::-webkit-scrollbar-thumb{border-radius:4px;background-color:rgba(0,0,0,0.5);box-shadow:0 0 1px rgba(255,255,255,0.5);}#button-footer.__jsx-style-dynamic-selector{position:absolute;bottom:0;margin-bottom:15px;width:calc(100% - 3em);display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-pack:justify;-webkit-justify-content:space-between;-ms-flex-pack:justify;justify-content:space-between;}.mark-incomplete.__jsx-style-dynamic-selector{line-height:1;font-size:0.9em;text-align:center;margin:35px 0;}h3.__jsx-style-dynamic-selector~ul.__jsx-style-dynamic-selector,h3.__jsx-style-dynamic-selector~p.__jsx-style-dynamic-selector{padding-left:0.3em;}ul.__jsx-style-dynamic-selector:last-of-type{margin:0;}.empty-comments.__jsx-style-dynamic-selector{font-style:italic;font-size:0.9em;margin-bottom:0;line-height:1.5;color:#666;}
+    #sidebar.__jsx-style-dynamic-selector{position:fixed;top:68px;right:0;height:calc(100% - 68px);background:#f7f7f7;border:1px solid transparent;border-left-color:#dfdfdf;padding:0 1.5em;}#close.__jsx-style-dynamic-selector{font-size:2.2rem;position:absolute;top:0;left:1rem;cursor:pointer;border:none;background:none;}h2.__jsx-style-dynamic-selector{margin:0;}#sidebar.__jsx-style-dynamic-selector h2.__jsx-style-dynamic-selector:first-of-type{margin:15px 0;text-align:center;}h3.__jsx-style-dynamic-selector{font-size:1em;font-weight:bold;margin:5px 0 15px 0;}h3.__jsx-style-dynamic-selector:not(:first-of-type){margin-top:2em;}#scrollable-comments.__jsx-style-dynamic-selector{overflow-y:scroll;height:calc(100% - 108px - 2.4rem - 53px);margin:1.2rem 0;padding:0.7rem;border-radius:4px;}#scrollable-comments.__jsx-style-dynamic-selector:hover{box-shadow:inset 0 0px 7px -1px #999;}#scrollable-comments.__jsx-style-dynamic-selector::-webkit-scrollbar{-webkit-appearance:none;width:8px;}#scrollable-comments.__jsx-style-dynamic-selector::-webkit-scrollbar-thumb{border-radius:4px;background-color:rgba(0,0,0,0.5);box-shadow:0 0 1px rgba(255,255,255,0.5);}#button-footer.__jsx-style-dynamic-selector{position:absolute;bottom:0;margin-bottom:15px;width:calc(100% - 3em);display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-pack:justify;-webkit-justify-content:space-between;-ms-flex-pack:justify;justify-content:space-between;}.mark-incomplete.__jsx-style-dynamic-selector{line-height:1;font-size:0.9em;text-align:center;margin:35px 0;}h3.__jsx-style-dynamic-selector~ul.__jsx-style-dynamic-selector,h3.__jsx-style-dynamic-selector~p.__jsx-style-dynamic-selector{padding-left:0.3em;}ul.__jsx-style-dynamic-selector:last-of-type{margin:0;}.empty-comments.__jsx-style-dynamic-selector{font-style:italic;font-size:0.9em;margin-bottom:0;line-height:1.5;color:#666;}
   </JSXStyle>
 </div>
 `;
 
 exports[`ReviewSidebar should match the last accepted snapshot (review finalized, decision has been made) 1`] = `
 <div
-  className="jsx-3598414504 col-md-5 col-lg-4 col-xxl-3"
+  className="jsx-4131948494 col-md-5 col-lg-4 col-xxl-3"
   id="sidebar"
 >
   <button
     aria-label="Close Technical Review"
-    className="jsx-3598414504"
+    className="jsx-4131948494"
     id="close"
     onClick={[Function]}
     type="button"
@@ -206,39 +213,39 @@ exports[`ReviewSidebar should match the last accepted snapshot (review finalized
     ×
   </button>
   <h2
-    className="jsx-3598414504"
+    className="jsx-4131948494"
   >
     Technical
      Review
   </h2>
   <div
-    className="jsx-3598414504"
+    className="jsx-4131948494"
     id="scrollable-comments"
     tabIndex={0}
   >
     <h3
-      className="jsx-3598414504"
+      className="jsx-4131948494"
       id="general-comments-label"
     >
       General Comments
        
       <small
-        className="jsx-3598414504"
+        className="jsx-4131948494"
       >
         <em
-          className="jsx-3598414504"
+          className="jsx-4131948494"
         >
           (Visible to applicant)
         </em>
       </small>
     </h3>
     <p
-      className="jsx-3598414504 empty-comments"
+      className="jsx-4131948494 empty-comments"
     >
       No general comments to show.
     </p>
     <h3
-      className="jsx-3598414504"
+      className="jsx-4131948494"
       id="internal-comments-label"
     >
       Internal Comments 
@@ -275,23 +282,23 @@ exports[`ReviewSidebar should match the last accepted snapshot (review finalized
       />
        
       <small
-        className="jsx-3598414504"
+        className="jsx-4131948494"
       >
         <em
-          className="jsx-3598414504"
+          className="jsx-4131948494"
         >
           (Not visible to applicant)
         </em>
       </small>
     </h3>
     <p
-      className="jsx-3598414504 empty-comments"
+      className="jsx-4131948494 empty-comments"
     >
       No internal comments to show.
     </p>
   </div>
   <div
-    className="jsx-3598414504"
+    className="jsx-4131948494"
     id="button-footer"
   >
     <Button
@@ -308,6 +315,12 @@ exports[`ReviewSidebar should match the last accepted snapshot (review finalized
       Show resolved comments
     </Button>
   </div>
+  <AddReviewCommentModal
+    onHide={[Function]}
+    onSubmit={[Function]}
+    show={false}
+    title="Add comment to Technical Review"
+  />
   <JSXStyle
     dynamic={
       Array [
@@ -315,21 +328,21 @@ exports[`ReviewSidebar should match the last accepted snapshot (review finalized
         68,
       ]
     }
-    id="3059376100"
+    id="3782189477"
   >
-    #sidebar.__jsx-style-dynamic-selector{position:fixed;top:68px;right:0;height:calc(100% - 68px);background:#f7f7f7;border:1px solid transparent;border-left-color:#dfdfdf;padding:0 1.5em;}#close.__jsx-style-dynamic-selector{font-size:2.2rem;position:absolute;top:0;left:1rem;cursor:pointer;border:none;background:none;}h2.__jsx-style-dynamic-selector{margin:15px 0;text-align:center;}h3.__jsx-style-dynamic-selector{font-size:1em;font-weight:bold;margin:5px 0 15px 0;}h3.__jsx-style-dynamic-selector:not(:first-of-type){margin-top:2em;}#scrollable-comments.__jsx-style-dynamic-selector{overflow-y:scroll;height:calc(100% - 108px - 2.4rem - 53px);margin:1.2rem 0;padding:0.7rem;border-radius:4px;}#scrollable-comments.__jsx-style-dynamic-selector:hover{box-shadow:inset 0 0px 7px -1px #999;}#scrollable-comments.__jsx-style-dynamic-selector::-webkit-scrollbar{-webkit-appearance:none;width:8px;}#scrollable-comments.__jsx-style-dynamic-selector::-webkit-scrollbar-thumb{border-radius:4px;background-color:rgba(0,0,0,0.5);box-shadow:0 0 1px rgba(255,255,255,0.5);}#button-footer.__jsx-style-dynamic-selector{position:absolute;bottom:0;margin-bottom:15px;width:calc(100% - 3em);display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-pack:justify;-webkit-justify-content:space-between;-ms-flex-pack:justify;justify-content:space-between;}.mark-incomplete.__jsx-style-dynamic-selector{line-height:1;font-size:0.9em;text-align:center;margin:35px 0;}h3.__jsx-style-dynamic-selector~ul.__jsx-style-dynamic-selector,h3.__jsx-style-dynamic-selector~p.__jsx-style-dynamic-selector{padding-left:0.3em;}ul.__jsx-style-dynamic-selector:last-of-type{margin:0;}.empty-comments.__jsx-style-dynamic-selector{font-style:italic;font-size:0.9em;margin-bottom:0;line-height:1.5;color:#666;}
+    #sidebar.__jsx-style-dynamic-selector{position:fixed;top:68px;right:0;height:calc(100% - 68px);background:#f7f7f7;border:1px solid transparent;border-left-color:#dfdfdf;padding:0 1.5em;}#close.__jsx-style-dynamic-selector{font-size:2.2rem;position:absolute;top:0;left:1rem;cursor:pointer;border:none;background:none;}h2.__jsx-style-dynamic-selector{margin:0;}#sidebar.__jsx-style-dynamic-selector h2.__jsx-style-dynamic-selector:first-of-type{margin:15px 0;text-align:center;}h3.__jsx-style-dynamic-selector{font-size:1em;font-weight:bold;margin:5px 0 15px 0;}h3.__jsx-style-dynamic-selector:not(:first-of-type){margin-top:2em;}#scrollable-comments.__jsx-style-dynamic-selector{overflow-y:scroll;height:calc(100% - 108px - 2.4rem - 53px);margin:1.2rem 0;padding:0.7rem;border-radius:4px;}#scrollable-comments.__jsx-style-dynamic-selector:hover{box-shadow:inset 0 0px 7px -1px #999;}#scrollable-comments.__jsx-style-dynamic-selector::-webkit-scrollbar{-webkit-appearance:none;width:8px;}#scrollable-comments.__jsx-style-dynamic-selector::-webkit-scrollbar-thumb{border-radius:4px;background-color:rgba(0,0,0,0.5);box-shadow:0 0 1px rgba(255,255,255,0.5);}#button-footer.__jsx-style-dynamic-selector{position:absolute;bottom:0;margin-bottom:15px;width:calc(100% - 3em);display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-pack:justify;-webkit-justify-content:space-between;-ms-flex-pack:justify;justify-content:space-between;}.mark-incomplete.__jsx-style-dynamic-selector{line-height:1;font-size:0.9em;text-align:center;margin:35px 0;}h3.__jsx-style-dynamic-selector~ul.__jsx-style-dynamic-selector,h3.__jsx-style-dynamic-selector~p.__jsx-style-dynamic-selector{padding-left:0.3em;}ul.__jsx-style-dynamic-selector:last-of-type{margin:0;}.empty-comments.__jsx-style-dynamic-selector{font-style:italic;font-size:0.9em;margin-bottom:0;line-height:1.5;color:#666;}
   </JSXStyle>
 </div>
 `;
 
 exports[`ReviewSidebar should match the last accepted snapshot (with comments) 1`] = `
 <div
-  className="jsx-3598414504 col-md-5 col-lg-4 col-xxl-3"
+  className="jsx-4131948494 col-md-5 col-lg-4 col-xxl-3"
   id="sidebar"
 >
   <button
     aria-label="Close Technical Review"
-    className="jsx-3598414504"
+    className="jsx-4131948494"
     id="close"
     onClick={[Function]}
     type="button"
@@ -337,7 +350,7 @@ exports[`ReviewSidebar should match the last accepted snapshot (with comments) 1
     ×
   </button>
   <h2
-    className="jsx-3598414504"
+    className="jsx-4131948494"
   >
     Technical
      Review
@@ -396,21 +409,21 @@ exports[`ReviewSidebar should match the last accepted snapshot (with comments) 1
     Mark this review step completed
   </Button>
   <div
-    className="jsx-3598414504"
+    className="jsx-4131948494"
     id="scrollable-comments"
     tabIndex={0}
   >
     <h3
-      className="jsx-3598414504"
+      className="jsx-4131948494"
       id="general-comments-label"
     >
       General Comments
        
       <small
-        className="jsx-3598414504"
+        className="jsx-4131948494"
       >
         <em
-          className="jsx-3598414504"
+          className="jsx-4131948494"
         >
           (Visible to applicant)
         </em>
@@ -418,7 +431,7 @@ exports[`ReviewSidebar should match the last accepted snapshot (with comments) 1
     </h3>
     <ul
       aria-labelledby="general-comments-label"
-      className="jsx-3598414504"
+      className="jsx-4131948494"
     >
       <ReviewComment
         createdAt="2021-04-08T03:01:35.585Z"
@@ -433,7 +446,7 @@ exports[`ReviewSidebar should match the last accepted snapshot (with comments) 1
       />
     </ul>
     <h3
-      className="jsx-3598414504"
+      className="jsx-4131948494"
       id="internal-comments-label"
     >
       Internal Comments 
@@ -470,10 +483,10 @@ exports[`ReviewSidebar should match the last accepted snapshot (with comments) 1
       />
        
       <small
-        className="jsx-3598414504"
+        className="jsx-4131948494"
       >
         <em
-          className="jsx-3598414504"
+          className="jsx-4131948494"
         >
           (Not visible to applicant)
         </em>
@@ -481,7 +494,7 @@ exports[`ReviewSidebar should match the last accepted snapshot (with comments) 1
     </h3>
     <ul
       aria-labelledby="internal-comments-label"
-      className="jsx-3598414504"
+      className="jsx-4131948494"
     >
       <ReviewComment
         createdAt="2021-04-08T03:01:35.585Z"
@@ -497,7 +510,7 @@ exports[`ReviewSidebar should match the last accepted snapshot (with comments) 1
     </ul>
   </div>
   <div
-    className="jsx-3598414504"
+    className="jsx-4131948494"
     id="button-footer"
   >
     <Button
@@ -516,11 +529,18 @@ exports[`ReviewSidebar should match the last accepted snapshot (with comments) 1
     <Button
       active={false}
       disabled={false}
+      onClick={[Function]}
       variant="primary"
     >
       + New Comment
     </Button>
   </div>
+  <AddReviewCommentModal
+    onHide={[Function]}
+    onSubmit={[Function]}
+    show={false}
+    title="Add comment to Technical Review"
+  />
   <JSXStyle
     dynamic={
       Array [
@@ -528,9 +548,9 @@ exports[`ReviewSidebar should match the last accepted snapshot (with comments) 1
         68,
       ]
     }
-    id="3059376100"
+    id="3782189477"
   >
-    #sidebar.__jsx-style-dynamic-selector{position:fixed;top:68px;right:0;height:calc(100% - 68px);background:#f7f7f7;border:1px solid transparent;border-left-color:#dfdfdf;padding:0 1.5em;}#close.__jsx-style-dynamic-selector{font-size:2.2rem;position:absolute;top:0;left:1rem;cursor:pointer;border:none;background:none;}h2.__jsx-style-dynamic-selector{margin:15px 0;text-align:center;}h3.__jsx-style-dynamic-selector{font-size:1em;font-weight:bold;margin:5px 0 15px 0;}h3.__jsx-style-dynamic-selector:not(:first-of-type){margin-top:2em;}#scrollable-comments.__jsx-style-dynamic-selector{overflow-y:scroll;height:calc(100% - 108px - 2.4rem - 53px);margin:1.2rem 0;padding:0.7rem;border-radius:4px;}#scrollable-comments.__jsx-style-dynamic-selector:hover{box-shadow:inset 0 0px 7px -1px #999;}#scrollable-comments.__jsx-style-dynamic-selector::-webkit-scrollbar{-webkit-appearance:none;width:8px;}#scrollable-comments.__jsx-style-dynamic-selector::-webkit-scrollbar-thumb{border-radius:4px;background-color:rgba(0,0,0,0.5);box-shadow:0 0 1px rgba(255,255,255,0.5);}#button-footer.__jsx-style-dynamic-selector{position:absolute;bottom:0;margin-bottom:15px;width:calc(100% - 3em);display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-pack:justify;-webkit-justify-content:space-between;-ms-flex-pack:justify;justify-content:space-between;}.mark-incomplete.__jsx-style-dynamic-selector{line-height:1;font-size:0.9em;text-align:center;margin:35px 0;}h3.__jsx-style-dynamic-selector~ul.__jsx-style-dynamic-selector,h3.__jsx-style-dynamic-selector~p.__jsx-style-dynamic-selector{padding-left:0.3em;}ul.__jsx-style-dynamic-selector:last-of-type{margin:0;}.empty-comments.__jsx-style-dynamic-selector{font-style:italic;font-size:0.9em;margin-bottom:0;line-height:1.5;color:#666;}
+    #sidebar.__jsx-style-dynamic-selector{position:fixed;top:68px;right:0;height:calc(100% - 68px);background:#f7f7f7;border:1px solid transparent;border-left-color:#dfdfdf;padding:0 1.5em;}#close.__jsx-style-dynamic-selector{font-size:2.2rem;position:absolute;top:0;left:1rem;cursor:pointer;border:none;background:none;}h2.__jsx-style-dynamic-selector{margin:0;}#sidebar.__jsx-style-dynamic-selector h2.__jsx-style-dynamic-selector:first-of-type{margin:15px 0;text-align:center;}h3.__jsx-style-dynamic-selector{font-size:1em;font-weight:bold;margin:5px 0 15px 0;}h3.__jsx-style-dynamic-selector:not(:first-of-type){margin-top:2em;}#scrollable-comments.__jsx-style-dynamic-selector{overflow-y:scroll;height:calc(100% - 108px - 2.4rem - 53px);margin:1.2rem 0;padding:0.7rem;border-radius:4px;}#scrollable-comments.__jsx-style-dynamic-selector:hover{box-shadow:inset 0 0px 7px -1px #999;}#scrollable-comments.__jsx-style-dynamic-selector::-webkit-scrollbar{-webkit-appearance:none;width:8px;}#scrollable-comments.__jsx-style-dynamic-selector::-webkit-scrollbar-thumb{border-radius:4px;background-color:rgba(0,0,0,0.5);box-shadow:0 0 1px rgba(255,255,255,0.5);}#button-footer.__jsx-style-dynamic-selector{position:absolute;bottom:0;margin-bottom:15px;width:calc(100% - 3em);display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-pack:justify;-webkit-justify-content:space-between;-ms-flex-pack:justify;justify-content:space-between;}.mark-incomplete.__jsx-style-dynamic-selector{line-height:1;font-size:0.9em;text-align:center;margin:35px 0;}h3.__jsx-style-dynamic-selector~ul.__jsx-style-dynamic-selector,h3.__jsx-style-dynamic-selector~p.__jsx-style-dynamic-selector{padding-left:0.3em;}ul.__jsx-style-dynamic-selector:last-of-type{margin:0;}.empty-comments.__jsx-style-dynamic-selector{font-style:italic;font-size:0.9em;margin-bottom:0;line-height:1.5;color:#666;}
   </JSXStyle>
 </div>
 `;

--- a/app/tests/unit/containers/Admin/ApplicationReview/__snapshots__/ReviewSidebar.test.tsx.snap
+++ b/app/tests/unit/containers/Admin/ApplicationReview/__snapshots__/ReviewSidebar.test.tsx.snap
@@ -172,6 +172,7 @@ exports[`ReviewSidebar should match the last accepted snapshot (no comments) 1`]
     <Button
       active={false}
       disabled={false}
+      id="new-comment"
       onClick={[Function]}
       variant="primary"
     >
@@ -529,6 +530,7 @@ exports[`ReviewSidebar should match the last accepted snapshot (with comments) 1
     <Button
       active={false}
       disabled={false}
+      id="new-comment"
       onClick={[Function]}
       variant="primary"
     >

--- a/app/tests/unit/mutations/application_review_step/createReviewCommentMutation.test.ts
+++ b/app/tests/unit/mutations/application_review_step/createReviewCommentMutation.test.ts
@@ -1,0 +1,80 @@
+import fs from 'fs';
+import path from 'path';
+import EasyGraphQLTester from 'easygraphql-tester';
+import {mutation} from 'mutations/application_review_step/createReviewCommentMutation';
+
+const schemaCode = fs.readFileSync(
+  path.join(__dirname, '../../../../server', 'schema.graphql'),
+  'utf8'
+);
+
+const mutationString = (mutation as any).default.params.text;
+
+describe('updateApplicationReviewStepMutation', () => {
+  let tester;
+  beforeEach(() => {
+    tester = new EasyGraphQLTester(schemaCode);
+  });
+  it('Should throw an error if input is missing', () => {
+    let error;
+    try {
+      tester.mock(mutationString);
+    } catch (error_) {
+      error = error_;
+    }
+
+    expect(error.message).toEqual(
+      'Variable "$input" of required type "CreateReviewCommentInput!" was not provided.'
+    );
+  });
+  it('Should throw an error if a variable is missing', () => {
+    let error;
+    try {
+      tester.mock(mutationString, {
+        input: {
+          reviewComment: {
+            commentType: 'GENERAL',
+            description: 'here is a comment'
+          }
+        }
+      });
+    } catch (error_) {
+      error = error_;
+    }
+
+    expect(error.message).toEqual(
+      'Variable "$input" got invalid value { commentType: "GENERAL", description: "here is a comment" } at "input.reviewComment"; Field applicationReviewStepId of required type Int! was not provided.'
+    );
+  });
+  it('Should return id(string) if valid', () => {
+    const test = tester.mock(mutationString, {
+      input: {
+        reviewComment: {
+          applicationReviewStepId: 1
+        }
+      }
+    });
+
+    expect(test).toBeDefined();
+    expect(typeof test.data.createReviewComment.reviewCommentEdge.node.id).toBe(
+      'string'
+    );
+  });
+  it('Should return the comment details if valid', () => {
+    const test = tester.mock(mutationString, {
+      input: {
+        reviewComment: {
+          applicationReviewStepId: 1,
+          description: 'comment',
+          commentType: 'GENERAL'
+        }
+      }
+    });
+
+    expect(test).toBeDefined();
+    const returnedNode = test.data.createReviewComment.reviewCommentEdge.node;
+    expect(typeof returnedNode.id).toBe('string');
+    expect(returnedNode.createdAt).toBeDefined();
+    expect(returnedNode.resolved).toBeDefined();
+  });
+});


### PR DESCRIPTION
- 'New Comment' button in review sidebar opens simplified modal to write a comment and add it to the selected review step
- Checkbox defines the comment type, aka. intended audience for the comment (`general` for applicants to see, or for `internal` use only)
- Visibility indicator confirms who can see the comment before completing the action
- Comment is saved and associated to the review step to which it was added
[GGIRCS-2194](https://youtrack.button.is/issue/GGIRCS-2194)

<img width="834" alt="Screen Shot 2021-04-26 at 8 48 07 AM" src="https://user-images.githubusercontent.com/5522075/116112220-37eeae80-a66c-11eb-850c-5008ac293aa2.png">
<img width="823" alt="Screen Shot 2021-04-26 at 8 48 17 AM" src="https://user-images.githubusercontent.com/5522075/116112242-3c1acc00-a66c-11eb-946a-c54c389fcf67.png">