### PR TITLE
Fix: product sort by date crash

### DIFF
--- a/app/containers/Products/ProductListContainer.tsx
+++ b/app/containers/Products/ProductListContainer.tsx
@@ -23,7 +23,7 @@ interface Props {
 const filters: TableFilter[] = [
   new TextFilter('Product', 'product_name'),
   new DisplayOnlyFilter('Settings'),
-  new SortOnlyFilter('Modified (D/M/Y)', 'updated_at'),
+  new SortOnlyFilter('Modified (Y/M/D)', 'updated_at'),
   new NumberFilter('Benchmark', 'current_benchmark'),
   new NumberFilter('Eligibility Threshold', 'current_eligibility_threshold'),
   new YesNoFilter('Allocation of Emissions', 'requires_emission_allocation'),

--- a/app/containers/Products/ProductListContainer.tsx
+++ b/app/containers/Products/ProductListContainer.tsx
@@ -23,7 +23,7 @@ interface Props {
 const filters: TableFilter[] = [
   new TextFilter('Product', 'product_name'),
   new DisplayOnlyFilter('Settings'),
-  new SortOnlyFilter('Modified (D/M/Y)', 'date_modified'),
+  new SortOnlyFilter('Modified (D/M/Y)', 'updated_at'),
   new NumberFilter('Benchmark', 'current_benchmark'),
   new NumberFilter('Eligibility Threshold', 'current_eligibility_threshold'),
   new YesNoFilter('Allocation of Emissions', 'requires_emission_allocation'),

--- a/app/containers/Products/ProductRowItemContainer.tsx
+++ b/app/containers/Products/ProductRowItemContainer.tsx
@@ -203,7 +203,7 @@ export const ProductRowItemComponent: React.FunctionComponent<Props> = ({
             </Dropdown.Menu>
           </Dropdown>
         </td>
-        <td>{dateTimeFormat(product.updatedAt, 'days_numbered')}</td>
+        <td>{dateTimeFormat(product.updatedAt, 'date_year_first')}</td>
         <td>{currentBenchmark?.benchmark ?? null}</td>
         <td>{currentBenchmark?.eligibilityThreshold ?? null}</td>
         <td>{product.requiresEmissionAllocation ? 'Yes' : 'No'}</td>

--- a/app/pages/analyst/organisation-requests.tsx
+++ b/app/pages/analyst/organisation-requests.tsx
@@ -4,6 +4,7 @@ import {organisationRequestsQueryResponse} from 'organisationRequestsQuery.graph
 import DefaultLayout from 'layouts/default-layout';
 import OrganisationRequestsTable from 'containers/Admin/OrganisationRequestsTable';
 import {INCENTIVE_ANALYST, ADMIN_GROUP} from 'data/group-constants';
+import {DEFAULT_PAGE_SIZE} from 'components/FilterableTable/FilterableTablePagination';
 
 const ALLOWED_GROUPS = [INCENTIVE_ANALYST, ...ADMIN_GROUP];
 
@@ -44,6 +45,16 @@ class OrganisationRequests extends Component<Props> {
       }
     }
   `;
+
+  static async getInitialProps() {
+    return {
+      variables: {
+        order_by: 'OPERATOR_NAME_ASC',
+        pageSize: DEFAULT_PAGE_SIZE,
+        offset: 0
+      }
+    };
+  }
 
   render() {
     const {query} = this.props;

--- a/app/tests/unit/containers/Products/__snapshots__/productListContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Products/__snapshots__/productListContainer.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`ProductList should render the product list 1`] = `
         "isSortEnabled": true,
         "removeSearchHeader": undefined,
         "sortColumnName": "updated_at",
-        "title": "Modified (D/M/Y)",
+        "title": "Modified (Y/M/D)",
       },
       NumberFilter {
         "Component": [Function],

--- a/app/tests/unit/containers/Products/__snapshots__/productListContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Products/__snapshots__/productListContainer.test.tsx.snap
@@ -61,12 +61,12 @@ exports[`ProductList should render the product list 1`] = `
       },
       SortOnlyFilter {
         "Component": [Function],
-        "argName": "date_modified",
+        "argName": "updated_at",
         "castValue": [Function],
         "isSearchEnabled": false,
         "isSortEnabled": true,
         "removeSearchHeader": undefined,
-        "sortColumnName": "date_modified",
+        "sortColumnName": "updated_at",
         "title": "Modified (D/M/Y)",
       },
       NumberFilter {

--- a/app/tests/unit/containers/Products/__snapshots__/productRowItemContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Products/__snapshots__/productRowItemContainer.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`ProductList should match the previous snapshot 1`] = `
     <td
       className="jsx-3501624252"
     >
-      06-05-2020
+      2020-05-06
     </td>
     <td
       className="jsx-3501624252"


### PR DESCRIPTION
Product sorting bug:
The column to sort on was passed incorrectly to the filter component.
date_modified -> updated_at

Organisation request table bug:
Page was missing getInitialProps() so it wasn't setting the relay variables on first load