### PR TITLE
chore: add sysdig links/monitoring to shipit

### DIFF
--- a/shipit.dontdeployme.yml
+++ b/shipit.dontdeployme.yml
@@ -1,3 +1,17 @@
+dependencies:
+  override: []
+deploy:
+  override:
+    - echo 'Not to be deployed'
 review:
+  checklist: []
   monitoring:
     - iframe: https://app.sysdigcloud.com/#/dashboards/222088?last=3600
+      width: 400
+      height: 300
+ci:
+  hide:
+    - "ci/circleci: release/release_approval"
+links:
+  PVC_usage: https://app.sysdigcloud.com/#/dashboards/224524?last=3600
+  Health_overview: https://app.sysdigcloud.com/#/dashboards/225040?last=3600

--- a/shipit.dontdeployme.yml
+++ b/shipit.dontdeployme.yml
@@ -1,0 +1,3 @@
+review:
+  monitoring:
+    - iframe: https://app.sysdigcloud.com/#/dashboards/222088?last=3600

--- a/shipit.dontdeployme.yml
+++ b/shipit.dontdeployme.yml
@@ -7,8 +7,8 @@ review:
   checklist: []
   monitoring:
     - iframe: https://app.sysdigcloud.com/#/dashboards/222088?last=3600
-      width: 400
-      height: 300
+      width: 1200
+      height: 800
 ci:
   hide:
     - "ci/circleci: release/release_approval"

--- a/shipit.prod.yml
+++ b/shipit.prod.yml
@@ -2,9 +2,12 @@ dependencies:
   override: []
 deploy:
   override:
-    - echo 'Not to be deployed'
+    - git submodule update --init
+    - make install:
+        timeout: 2460
 review:
-  checklist: []
+  checklist:
+    - Is today not Friday?
   monitoring:
     - iframe: https://app.sysdigcloud.com/#/dashboards/222088?last=3600
       width: 1200

--- a/shipit.prod.yml
+++ b/shipit.prod.yml
@@ -13,7 +13,7 @@ review:
       width: 1200
       height: 800
 ci:
-  hide:
+  require:
     - "ci/circleci: release/release_approval"
 links:
   PVC_usage: https://app.sysdigcloud.com/#/dashboards/224524?last=3600

--- a/shipit.yml
+++ b/shipit.yml
@@ -7,8 +7,6 @@ deploy:
         timeout: 2460
 review:
   checklist: []
-  monitoring:
-    - iframe: https://app.sysdigcloud.com/#/dashboards/222088?last=3600
 ci:
   hide:
     - "ci/circleci: release/release_approval"

--- a/shipit.yml
+++ b/shipit.yml
@@ -7,6 +7,11 @@ deploy:
         timeout: 2460
 review:
   checklist: []
+  monitoring:
+    - iframe: https://app.sysdigcloud.com/#/dashboards/222088?last=3600
 ci:
   hide:
     - "ci/circleci: release/release_approval"
+links:
+  PVC_usage: https://app.sysdigcloud.com/#/dashboards/224524?last=3600
+  Health_overview: https://app.sysdigcloud.com/#/dashboards/225040?last=3600


### PR DESCRIPTION
I think the iframe will have an issue unless we make the dashboard public in sysdig?