### PR TITLE
Initialize and enforce mandatory products on reporter side

### DIFF
--- a/app/components/Forms/SearchDropdownWidget.tsx
+++ b/app/components/Forms/SearchDropdownWidget.tsx
@@ -1,15 +1,10 @@
 import React, {useCallback} from 'react';
 import {WidgetProps} from '@rjsf/core';
+import Widgets from '@rjsf/core/dist/cjs/components/widgets';
 import SearchDropdown from 'components/SearchDropdown';
 
-const SearchDropdownWidget: React.FunctionComponent<WidgetProps> = ({
-  onChange,
-  schema,
-  id,
-  placeholder,
-  value,
-  onBlur
-}) => {
+const SearchDropdownWidget: React.FunctionComponent<WidgetProps> = (props) => {
+  const {onChange, schema, id, placeholder, value, onBlur, readonly} = props;
   const getOptions = useCallback(
     () =>
       schema.enum.map((e: string, index) => ({
@@ -36,6 +31,8 @@ const SearchDropdownWidget: React.FunctionComponent<WidgetProps> = ({
   const handleBlur = () => {
     onBlur(id, value);
   };
+
+  if (readonly) return <Widgets.SelectWidget {...props} />;
 
   return (
     <SearchDropdown

--- a/app/containers/Applications/ApplicationWizardStep.tsx
+++ b/app/containers/Applications/ApplicationWizardStep.tsx
@@ -34,15 +34,38 @@ const ApplicationWizardStep: React.FunctionComponent<Props> = ({
   if ((!formResult && !confirmationPage) || !applicationRevision) return null;
 
   const [isSaved, setSaved] = useState(true);
+  const cleanTempFormData = (formData) => {
+    // Remove a temp prop that really shouldn't be in formData (and which we don't want to save)
+    // if this is the ProductsArrayField:
+    if (!Array.isArray(formData)) return formData;
+    if (!formData.some((field) => '_tempHideRemoveButton' in field)) {
+      return formData;
+    }
+    const cleanedResult = formData.map((productField) => {
+      // Selectively copy only the fields to be saved
+      const cleanedResultField = {};
+      Object.keys(productField).forEach((key) => {
+        if (key !== '_tempHideRemoveButton')
+          cleanedResultField[key] = productField[key];
+      });
+      return cleanedResultField;
+    });
+    return cleanedResult;
+  };
   // Function: store the form result
   const storeResult = async (result) => {
     setSaved(false);
+    const cleanedResult = cleanTempFormData(result);
+    console.log(
+      'this is what will be saved (_tempHideRemoveButton should not be present): ',
+      cleanedResult
+    );
     const {environment} = relay;
     const variables = {
       input: {
         id: formResult.id,
         formResultPatch: {
-          formResult: result
+          formResult: cleanedResult
         }
       },
       messages: {

--- a/app/containers/Applications/ApplicationWizardStep.tsx
+++ b/app/containers/Applications/ApplicationWizardStep.tsx
@@ -34,32 +34,10 @@ const ApplicationWizardStep: React.FunctionComponent<Props> = ({
   if ((!formResult && !confirmationPage) || !applicationRevision) return null;
 
   const [isSaved, setSaved] = useState(true);
-  const cleanTempFormData = (formData) => {
-    // Remove a temp prop that really shouldn't be in formData (and which we don't want to save)
-    // if this is the ProductsArrayField:
-    if (!Array.isArray(formData)) return formData;
-    if (!formData.some((field) => '_tempHideRemoveButton' in field)) {
-      return formData;
-    }
-    const cleanedResult = formData.map((productField) => {
-      // Selectively copy only the fields to be saved
-      const cleanedResultField = {};
-      Object.keys(productField).forEach((key) => {
-        if (key !== '_tempHideRemoveButton')
-          cleanedResultField[key] = productField[key];
-      });
-      return cleanedResultField;
-    });
-    return cleanedResult;
-  };
+
   // Function: store the form result
   const storeResult = async (result) => {
     setSaved(false);
-    const cleanedResult = cleanTempFormData(result);
-    console.log(
-      'this is what will be saved (_tempHideRemoveButton should not be present): ',
-      cleanedResult
-    );
     const {environment} = relay;
     const variables = {
       input: {

--- a/app/containers/Applications/ApplicationWizardStep.tsx
+++ b/app/containers/Applications/ApplicationWizardStep.tsx
@@ -65,7 +65,7 @@ const ApplicationWizardStep: React.FunctionComponent<Props> = ({
       input: {
         id: formResult.id,
         formResultPatch: {
-          formResult: cleanedResult
+          formResult: result
         }
       },
       messages: {

--- a/app/containers/Forms/Form.tsx
+++ b/app/containers/Forms/Form.tsx
@@ -14,6 +14,7 @@ import FormArrayFieldTemplate from './FormArrayFieldTemplate';
 import FuelFields from './FuelField';
 import EmissionGasFields from './EmissionGasFields';
 import EmissionSourceFields from './EmissionSourceFields';
+import ProductsArrayField from './ProductsArrayField';
 import ProductField from './ProductField';
 import EmissionField from './EmissionField';
 import ProductRowIdField from './ProductRowIdField';
@@ -41,6 +42,7 @@ const CUSTOM_FIELDS = {
   fuel: (props) => <FuelFields query={props.formContext.query} {...props} />,
   emissionSource: EmissionSourceFields,
   emissionGas: EmissionGasFields,
+  ProductsArrayField,
   product: (props) => (
     <ProductField
       naicsCode={

--- a/app/containers/Forms/Form.tsx
+++ b/app/containers/Forms/Form.tsx
@@ -44,7 +44,7 @@ const CUSTOM_FIELDS = {
   emissionGas: EmissionGasFields,
   ProductsArrayField: (props) => (
     <ProductsArrayField
-      mandatoryProducts={
+      naicsProducts={
         props.formContext.ciipFormResult.applicationByApplicationId
           .latestDraftRevision.naicsCode
       }
@@ -259,7 +259,7 @@ export default createFragmentContainer(FormComponent, {
           naicsCode {
             ...ProductRowIdField_naicsCode
             ...ProductField_naicsCode
-            ...ProductsArrayField_mandatoryProducts
+            ...ProductsArrayField_naicsProducts
           }
         }
       }

--- a/app/containers/Forms/Form.tsx
+++ b/app/containers/Forms/Form.tsx
@@ -42,7 +42,15 @@ const CUSTOM_FIELDS = {
   fuel: (props) => <FuelFields query={props.formContext.query} {...props} />,
   emissionSource: EmissionSourceFields,
   emissionGas: EmissionGasFields,
-  ProductsArrayField,
+  ProductsArrayField: (props) => (
+    <ProductsArrayField
+      mandatoryProducts={
+        props.formContext.ciipFormResult.applicationByApplicationId
+          .latestDraftRevision.naicsCode
+      }
+      {...props}
+    />
+  ),
   product: (props) => (
     <ProductField
       naicsCode={
@@ -237,6 +245,7 @@ export default createFragmentContainer(FormComponent, {
   `,
   ciipFormResult: graphql`
     fragment Form_ciipFormResult on FormResult {
+      id
       formResult
       formJsonByFormId {
         name
@@ -250,6 +259,7 @@ export default createFragmentContainer(FormComponent, {
           naicsCode {
             ...ProductRowIdField_naicsCode
             ...ProductField_naicsCode
+            ...ProductsArrayField_mandatoryProducts
           }
         }
       }

--- a/app/containers/Forms/FormArrayFieldTemplate.tsx
+++ b/app/containers/Forms/FormArrayFieldTemplate.tsx
@@ -8,25 +8,29 @@ const FormArrayFieldTemplate: React.FunctionComponent<ArrayFieldTemplateProps> =
   onAddClick,
   uiSchema,
   idSchema,
-  className
+  className,
+  formData
 }) => {
+  console.log('template formData', formData);
   return (
     <div className={className}>
-      {items.map((element) => {
+      {items.map((element, i) => {
+        const shouldRenderRemoveButton =
+          element.hasRemove && !formData[i]._tempHideRemoveButton;
         return (
           <div key={element.index}>
             <Form.Row>
               {uiSchema.linkProduct ? (
-                <Col xs={12} md={element.hasRemove ? 6 : 9}>
+                <Col xs={12} md={shouldRenderRemoveButton ? 6 : 9}>
                   {element.children}
                 </Col>
               ) : (
-                <Col xs={12} md={element.hasRemove ? 11 : 12}>
+                <Col xs={12} md={shouldRenderRemoveButton ? 11 : 12}>
                   {element.children}
                 </Col>
               )}
 
-              {element.hasRemove && uiSchema.linkProduct && (
+              {shouldRenderRemoveButton && uiSchema.linkProduct && (
                 <Col
                   xs={12}
                   md={{span: 1, offset: 1}}
@@ -41,7 +45,7 @@ const FormArrayFieldTemplate: React.FunctionComponent<ArrayFieldTemplateProps> =
                   </Button>
                 </Col>
               )}
-              {element.hasRemove && !uiSchema.linkProduct && (
+              {shouldRenderRemoveButton && !uiSchema.linkProduct && (
                 <Col xs={12} md={1}>
                   <div className="remove-button-container">
                     <Button

--- a/app/containers/Forms/FormArrayFieldTemplate.tsx
+++ b/app/containers/Forms/FormArrayFieldTemplate.tsx
@@ -8,10 +8,8 @@ const FormArrayFieldTemplate: React.FunctionComponent<ArrayFieldTemplateProps> =
   onAddClick,
   uiSchema,
   idSchema,
-  className,
-  formData
+  className
 }) => {
-  console.log('template formData', formData);
   return (
     <div className={className}>
       {items.map((element) => {
@@ -21,12 +19,13 @@ const FormArrayFieldTemplate: React.FunctionComponent<ArrayFieldTemplateProps> =
         if (
           'ui:hasRemove' in elementProps.uiSchema &&
           'isFalse' in elementProps.uiSchema['ui:hasRemove']
-        )
+        ) {
           shouldRenderRemoveButton =
             shouldRenderRemoveButton &&
             !elementProps.formData[
               elementProps.uiSchema['ui:hasRemove'].isFalse
             ];
+        }
 
         return (
           <div key={element.index}>

--- a/app/containers/Forms/FormArrayFieldTemplate.tsx
+++ b/app/containers/Forms/FormArrayFieldTemplate.tsx
@@ -14,9 +14,20 @@ const FormArrayFieldTemplate: React.FunctionComponent<ArrayFieldTemplateProps> =
   console.log('template formData', formData);
   return (
     <div className={className}>
-      {items.map((element, i) => {
-        const shouldRenderRemoveButton =
-          element.hasRemove && !formData[i]._tempHideRemoveButton;
+      {items.map((element) => {
+        const elementProps = element.children.props;
+        let shouldRenderRemoveButton = element.hasRemove;
+
+        if (
+          'ui:hasRemove' in elementProps.uiSchema &&
+          'isFalse' in elementProps.uiSchema['ui:hasRemove']
+        )
+          shouldRenderRemoveButton =
+            shouldRenderRemoveButton &&
+            !elementProps.formData[
+              elementProps.uiSchema['ui:hasRemove'].isFalse
+            ];
+
         return (
           <div key={element.index}>
             <Form.Row>

--- a/app/containers/Forms/ProductField.tsx
+++ b/app/containers/Forms/ProductField.tsx
@@ -13,6 +13,7 @@ interface FormData {
   productEmissions?: number;
   requiresEmissionAllocation?: boolean;
   requiresProductAmount?: boolean;
+  isMandatory?: boolean;
 }
 
 interface Props extends FieldProps<FormData> {
@@ -28,16 +29,6 @@ export const ProductFieldComponent: React.FunctionComponent<Props> = (
   props
 ) => {
   const {formData, query, naicsCode, onChange} = props;
-
-  const matchedAllowableProduct = naicsCode.allowableProducts.edges.find(
-    (p) => p.node.productId === formData.productRowId
-  );
-  if (matchedAllowableProduct) {
-    // Avoids type error because the dynamically added temp property does not exist on formData:
-    // eslint-disable-next-line @typescript-eslint/dot-notation
-    formData['_tempHideRemoveButton'] =
-      matchedAllowableProduct?.node.isMandatory;
-  }
 
   const productIsPublished =
     query.allProducts.edges.some(
@@ -111,6 +102,7 @@ export const ProductFieldComponent: React.FunctionComponent<Props> = (
 
   return (
     <>
+      {formData.isMandatory && 'Mandatory Product'}
       {!productIsPublished && archivedAlert}
       {!productInNaicsCode && notInNaicsAlert}
       {!hasSelectableProducts && noProductsToSelect}

--- a/app/containers/Forms/ProductField.tsx
+++ b/app/containers/Forms/ProductField.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import {Alert} from 'react-bootstrap';
+import {Alert, OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {FieldProps} from '@rjsf/core';
 import ObjectField from '@rjsf/core/dist/cjs/components/fields/ObjectField';
 import {createFragmentContainer, graphql} from 'react-relay';
 import {ProductField_query} from 'ProductField_query.graphql';
 import {ProductField_naicsCode} from 'ProductField_naicsCode.graphql';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import {faInfoCircle} from '@fortawesome/free-solid-svg-icons';
 
 interface FormData {
   productRowId?: number;
@@ -98,15 +100,36 @@ export const ProductFieldComponent: React.FunctionComponent<Props> = (
     </Alert>
   );
 
+  const mandatoryProductLabel = (
+    <strong>
+      Mandatory Product
+      <OverlayTrigger
+        overlay={
+          <Tooltip id="required-product-tooltip" placement="top">
+            Based on the NAICS code entered in the Administrative Data section,
+            reporting this product is required.
+          </Tooltip>
+        }
+      >
+        <FontAwesomeIcon icon={faInfoCircle} />
+      </OverlayTrigger>
+    </strong>
+  );
+
   const disableField = !productIsPublished || !productInNaicsCode;
 
   return (
     <>
-      {formData.isMandatory && 'Mandatory Product'}
       {!productIsPublished && archivedAlert}
       {!productInNaicsCode && notInNaicsAlert}
       {!hasSelectableProducts && noProductsToSelect}
+      {formData.isMandatory && mandatoryProductLabel}
       <ObjectField {...props} disabled={disableField} onChange={handleChange} />
+      <style jsx>{`
+        :global(.svg-inline--fa.fa-info-circle) {
+          margin-left: 0.5em;
+        }
+      `}</style>
     </>
   );
 };

--- a/app/containers/Forms/ProductRowIdField.tsx
+++ b/app/containers/Forms/ProductRowIdField.tsx
@@ -60,7 +60,7 @@ export const ProductRowIdFieldComponent: React.FunctionComponent<Props> = (
       archivedProductNames: props.query.archived.edges.map(
         ({node}) => node.productName
       ),
-      productIdsByNaicsCode: props.naicsCode?.productsByNaicsCode.edges.map(
+      productIdsByNaicsCode: props.naicsCode?.productsByNaicsCode?.edges.map(
         ({node}) => node.rowId
       )
     }),

--- a/app/containers/Forms/ProductsArrayField.tsx
+++ b/app/containers/Forms/ProductsArrayField.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import {FieldProps} from '@rjsf/core';
+
+const ProductsArrayField: React.FunctionComponent<FieldProps> = (props) => {
+  const {ArrayField} = props.registry.fields;
+  return <ArrayField {...props} />;
+};
+
+export default ProductsArrayField;

--- a/app/containers/Forms/ProductsArrayField.tsx
+++ b/app/containers/Forms/ProductsArrayField.tsx
@@ -39,6 +39,7 @@ export const ProductsArrayFieldComponent: React.FunctionComponent<Props> = (
       ...productsToInitialize.map((edge) => {
         return {
           ...edge.node.productByProductId,
+          productUnits: edge.node.productByProductId.units,
           productRowId: edge.node.productByProductId.rowId,
           isMandatory: true
         };

--- a/app/containers/Forms/ProductsArrayField.tsx
+++ b/app/containers/Forms/ProductsArrayField.tsx
@@ -14,7 +14,6 @@ const ProductsArrayField: React.FunctionComponent<Props> = (props) => {
   const {ArrayField} = registry.fields;
 
   useEffect(() => {
-    console.log('effect!');
     const initializeFormResult = async (variables) => {
       await updateFormResultMutation(props.relay.environment, variables);
     };

--- a/app/containers/Forms/ProductsArrayField.tsx
+++ b/app/containers/Forms/ProductsArrayField.tsx
@@ -1,9 +1,86 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {FieldProps} from '@rjsf/core';
+import {createFragmentContainer, graphql, RelayProp} from 'react-relay';
+import {ProductsArrayField_mandatoryProducts} from 'ProductsArrayField_mandatoryProducts.graphql';
+import updateFormResultMutation from 'mutations/form/updateFormResultMutation';
 
-const ProductsArrayField: React.FunctionComponent<FieldProps> = (props) => {
-  const {ArrayField} = props.registry.fields;
+interface Props extends FieldProps {
+  mandatoryProducts: ProductsArrayField_mandatoryProducts;
+  relay: RelayProp;
+}
+
+const ProductsArrayField: React.FunctionComponent<Props> = (props) => {
+  const {mandatoryProducts, formContext, registry} = props;
+  const {ArrayField} = registry.fields;
+
+  useEffect(() => {
+    const initializeFormResult = async (variables) => {
+      await updateFormResultMutation(props.relay.environment, variables);
+    };
+    const productionFormResult = formContext.ciipFormResult.formResult;
+    const allMandatoryProductsInitialized = mandatoryProducts.productNaicsCodesByNaicsCodeId.edges.every(
+      (edge) => {
+        return productionFormResult.some(
+          (res) => res.rowId === edge.node.productByProductId.rowId
+        );
+      }
+    );
+    if (allMandatoryProductsInitialized) return;
+
+    const productsToInitialize = mandatoryProducts.productNaicsCodesByNaicsCodeId.edges.filter(
+      (edge) =>
+        !productionFormResult.some(
+          (res) => res.productRowId === edge.node.productByProductId.rowId
+        )
+    );
+    const initializedFormResult = productionFormResult.concat(
+      ...productsToInitialize.map((edge) => {
+        return {
+          ...edge.node.productByProductId,
+          productRowId: edge.node.productByProductId.rowId
+        };
+      })
+    );
+    const variables = {
+      input: {
+        id: formContext.ciipFormResult.id,
+        formResultPatch: {
+          formResult: initializedFormResult
+        }
+      }
+    };
+    if (productsToInitialize.length > 0) initializeFormResult(variables);
+  }, [mandatoryProducts]);
+
   return <ArrayField {...props} />;
 };
 
-export default ProductsArrayField;
+export default createFragmentContainer(ProductsArrayField, {
+  // NOTE: It would be more ideal to have a reusable "product" fragment shared between here (productByProductId) and in ProductField_query to sync the queried properties needed by the ProductField
+  mandatoryProducts: graphql`
+    fragment ProductsArrayField_mandatoryProducts on NaicsCode {
+      productNaicsCodesByNaicsCodeId(condition: {isMandatory: true}) {
+        edges {
+          node {
+            id
+            productByProductId {
+              rowId
+              units
+              productState
+              requiresEmissionAllocation
+              requiresProductAmount
+              isEnergyProduct
+              addPurchasedElectricityEmissions
+              addPurchasedHeatEmissions
+              subtractExportedElectricityEmissions
+              subtractExportedHeatEmissions
+              subtractGeneratedElectricityEmissions
+              subtractGeneratedHeatEmissions
+              addEmissionsFromEios
+            }
+          }
+        }
+      }
+    }
+  `
+});

--- a/app/containers/Forms/ProductsArrayField.tsx
+++ b/app/containers/Forms/ProductsArrayField.tsx
@@ -1,16 +1,16 @@
 import React, {useEffect} from 'react';
 import {FieldProps} from '@rjsf/core';
 import {createFragmentContainer, graphql, RelayProp} from 'react-relay';
-import {ProductsArrayField_mandatoryProducts} from 'ProductsArrayField_mandatoryProducts.graphql';
+import {ProductsArrayField_naicsProducts} from 'ProductsArrayField_naicsProducts.graphql';
 import updateFormResultMutation from 'mutations/form/updateFormResultMutation';
 
 interface Props extends FieldProps {
-  mandatoryProducts: ProductsArrayField_mandatoryProducts;
+  naicsProducts: ProductsArrayField_naicsProducts;
   relay: RelayProp;
 }
 
 const ProductsArrayField: React.FunctionComponent<Props> = (props) => {
-  const {mandatoryProducts, formContext, registry} = props;
+  const {naicsProducts, formContext, registry} = props;
   const {ArrayField} = registry.fields;
 
   useEffect(() => {
@@ -18,7 +18,7 @@ const ProductsArrayField: React.FunctionComponent<Props> = (props) => {
       await updateFormResultMutation(props.relay.environment, variables);
     };
     const productionFormResult = formContext.ciipFormResult.formResult;
-    const allMandatoryProductsInitialized = mandatoryProducts.productNaicsCodesByNaicsCodeId.edges.every(
+    const allMandatoryProductsInitialized = naicsProducts.mandatoryProducts.edges.every(
       (edge) => {
         return productionFormResult.some(
           (res) => res.rowId === edge.node.productByProductId.rowId
@@ -27,7 +27,7 @@ const ProductsArrayField: React.FunctionComponent<Props> = (props) => {
     );
     if (allMandatoryProductsInitialized) return;
 
-    const productsToInitialize = mandatoryProducts.productNaicsCodesByNaicsCodeId.edges.filter(
+    const productsToInitialize = naicsProducts.mandatoryProducts.edges.filter(
       (edge) =>
         !productionFormResult.some(
           (res) => res.productRowId === edge.node.productByProductId.rowId
@@ -50,16 +50,18 @@ const ProductsArrayField: React.FunctionComponent<Props> = (props) => {
       }
     };
     if (productsToInitialize.length > 0) initializeFormResult(variables);
-  }, [mandatoryProducts]);
+  }, [naicsProducts]);
 
   return <ArrayField {...props} />;
 };
 
 export default createFragmentContainer(ProductsArrayField, {
   // NOTE: It would be more ideal to have a reusable "product" fragment shared between here (productByProductId) and in ProductField_query to sync the queried properties needed by the ProductField
-  mandatoryProducts: graphql`
-    fragment ProductsArrayField_mandatoryProducts on NaicsCode {
-      productNaicsCodesByNaicsCodeId(condition: {isMandatory: true}) {
+  naicsProducts: graphql`
+    fragment ProductsArrayField_naicsProducts on NaicsCode {
+      mandatoryProducts: productNaicsCodesByNaicsCodeId(
+        condition: {isMandatory: true}
+      ) {
         edges {
           node {
             id

--- a/app/containers/Forms/ProductsArrayField.tsx
+++ b/app/containers/Forms/ProductsArrayField.tsx
@@ -9,7 +9,7 @@ interface Props extends FieldProps {
   relay: RelayProp;
 }
 
-const ProductsArrayField: React.FunctionComponent<Props> = (props) => {
+export const ProductsArrayField: React.FunctionComponent<Props> = (props) => {
   const {naicsProducts, formContext, registry} = props;
   const {ArrayField} = registry.fields;
 

--- a/app/containers/Forms/ProductsArrayField.tsx
+++ b/app/containers/Forms/ProductsArrayField.tsx
@@ -9,7 +9,9 @@ interface Props extends FieldProps {
   relay: RelayProp;
 }
 
-export const ProductsArrayField: React.FunctionComponent<Props> = (props) => {
+export const ProductsArrayFieldComponent: React.FunctionComponent<Props> = (
+  props
+) => {
   const {naicsProducts, formContext, registry} = props;
   const {ArrayField} = registry.fields;
 
@@ -56,7 +58,7 @@ export const ProductsArrayField: React.FunctionComponent<Props> = (props) => {
   return <ArrayField {...props} />;
 };
 
-export default createFragmentContainer(ProductsArrayField, {
+export default createFragmentContainer(ProductsArrayFieldComponent, {
   // NOTE: It would be more ideal to have a reusable "product" fragment shared between here (productByProductId) and in ProductField_query to sync the queried properties needed by the ProductField
   naicsProducts: graphql`
     fragment ProductsArrayField_naicsProducts on NaicsCode {

--- a/app/containers/Forms/ProductsArrayField.tsx
+++ b/app/containers/Forms/ProductsArrayField.tsx
@@ -37,10 +37,19 @@ export const ProductsArrayFieldComponent: React.FunctionComponent<Props> = (
       ) || [];
     const initializedFormResult = productionFormResult.concat(
       ...productsToInitialize.map((edge) => {
+        const {
+          rowId: productRowId,
+          units: productUnits,
+          requiresEmissionAllocation,
+          requiresProductAmount,
+          isEnergyProduct
+        } = edge.node.productByProductId;
         return {
-          ...edge.node.productByProductId,
-          productUnits: edge.node.productByProductId.units,
-          productRowId: edge.node.productByProductId.rowId,
+          requiresEmissionAllocation,
+          requiresProductAmount,
+          isEnergyProduct,
+          productUnits,
+          productRowId,
           isMandatory: true
         };
       })
@@ -72,17 +81,9 @@ export default createFragmentContainer(ProductsArrayFieldComponent, {
             productByProductId {
               rowId
               units
-              productState
               requiresEmissionAllocation
               requiresProductAmount
               isEnergyProduct
-              addPurchasedElectricityEmissions
-              addPurchasedHeatEmissions
-              subtractExportedElectricityEmissions
-              subtractExportedHeatEmissions
-              subtractGeneratedElectricityEmissions
-              subtractGeneratedHeatEmissions
-              addEmissionsFromEios
             }
           }
         }

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -69,7 +69,6 @@ export default class App extends NextApp<AppProps> {
         >
           <QueryRenderer
             environment={environment}
-            fetchPolicy="store-and-network"
             query={Component.query}
             variables={{
               ...variables,

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -69,6 +69,7 @@ export default class App extends NextApp<AppProps> {
         >
           <QueryRenderer
             environment={environment}
+            fetchPolicy="store-and-network"
             query={Component.query}
             variables={{
               ...variables,

--- a/app/tests/unit/containers/Forms/ProductField.test.tsx
+++ b/app/tests/unit/containers/Forms/ProductField.test.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {ProductFieldComponent} from 'containers/Forms/ProductField';
-import {ProductField_query} from '__generated__/ProductField_query.graphql';
+import {
+  ProductField_query,
+  CiipProductState
+} from '__generated__/ProductField_query.graphql';
 import {ProductField_naicsCode} from '__generated__/ProductField_naicsCode.graphql';
 import {createDefaultJsonSchemaFormProps} from 'tests/json-schema-utils';
 
-describe('The ProductionFields Component with published product matched to a naics code', () => {
+const getTestQuery = ({
+  noNaicsCode,
+  productState,
+  reportedProductIsAllowable
+}) => {
   const query: ProductField_query = {
     ' $refType': 'ProductField_query',
     allProducts: {
@@ -14,7 +21,7 @@ describe('The ProductionFields Component with published product matched to a nai
           node: {
             rowId: 1,
             units: 'bar',
-            productState: 'PUBLISHED',
+            productState: productState as CiipProductState,
             requiresEmissionAllocation: true,
             requiresProductAmount: true,
             isEnergyProduct: false,
@@ -32,233 +39,117 @@ describe('The ProductionFields Component with published product matched to a nai
   };
   const naicsCode: ProductField_naicsCode = {
     ' $refType': 'ProductField_naicsCode',
-    allProductsByNaicsCode: {
+    allowableProducts: {
       edges: [
         {
           node: {
-            rowId: 1,
-            productState: 'PUBLISHED'
+            productId: reportedProductIsAllowable ? 1 : 2,
+            isMandatory: false
           }
         }
       ]
     }
   };
-
-  const props = {
+  const withoutNaicsCode = {
     ...createDefaultJsonSchemaFormProps(),
-    formData: {
-      productRowId: 1,
-      productUnits: 'bar',
-      productEmissions: 123,
-      productAmount: 456,
-      requiresEmissionAllocation: true
-    },
-    query,
-    naicsCode
+    query
   };
+  return noNaicsCode
+    ? withoutNaicsCode
+    : {
+        ...withoutNaicsCode,
+        naicsCode
+      };
+};
 
+const getTestElement = ({
+  noNaicsCode = false,
+  includeFormData = true,
+  productState = 'PUBLISHED',
+  reportedProductIsAllowable = true
+}) => {
+  const data = getTestQuery({
+    noNaicsCode,
+    productState,
+    reportedProductIsAllowable
+  });
+  const formData = {
+    productRowId: 1,
+    productUnits: 'bar',
+    productEmissions: 123,
+    productAmount: 456,
+    requiresEmissionAllocation: true
+  };
+  return (
+    <ProductFieldComponent
+      {...data}
+      formData={includeFormData ? formData : {}}
+    />
+  );
+};
+
+describe('The ProductField with published product matched to a naics code', () => {
   it('should match the snapshot when rendering a product', () => {
-    const wrapper = shallow(<ProductFieldComponent {...props} />);
+    const wrapper = shallow(getTestElement({}));
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should not render any warnings', () => {
-    const wrapper = shallow(<ProductFieldComponent {...props} />);
+    const wrapper = shallow(getTestElement({}));
     expect(wrapper.exists('Alert')).toBe(false);
   });
 });
 
-describe('The ProductionFields Component with published product not matched to a naics code', () => {
-  const query: ProductField_query = {
-    ' $refType': 'ProductField_query',
-    allProducts: {
-      edges: [
-        {
-          node: {
-            rowId: 1,
-            units: 'bar',
-            productState: 'PUBLISHED',
-            requiresEmissionAllocation: true,
-            requiresProductAmount: true,
-            isEnergyProduct: false,
-            addPurchasedElectricityEmissions: false,
-            addPurchasedHeatEmissions: false,
-            subtractExportedElectricityEmissions: false,
-            subtractExportedHeatEmissions: false,
-            subtractGeneratedElectricityEmissions: false,
-            subtractGeneratedHeatEmissions: false,
-            addEmissionsFromEios: false
-          }
-        }
-      ]
-    }
-  };
-  const naicsCode: ProductField_naicsCode = {
-    ' $refType': 'ProductField_naicsCode',
-    allProductsByNaicsCode: {
-      edges: [
-        {
-          node: {
-            rowId: 2,
-            productState: 'PUBLISHED'
-          }
-        }
-      ]
-    }
-  };
-
-  const props = {
-    ...createDefaultJsonSchemaFormProps(),
-    formData: {
-      productRowId: 1,
-      productUnits: 'bar',
-      productEmissions: 123,
-      productAmount: 456,
-      requiresEmissionAllocation: true
-    },
-    query,
-    naicsCode
-  };
-
+describe('The ProductField with published product not matched to a naics code', () => {
   it('should match the snapshot when rendering a product not matched to a naics code', () => {
-    const wrapper = shallow(<ProductFieldComponent {...props} />);
+    const wrapper = shallow(
+      getTestElement({reportedProductIsAllowable: false})
+    );
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should render the not in naics code warning', () => {
-    const wrapper = shallow(<ProductFieldComponent {...props} />);
+    const wrapper = shallow(
+      getTestElement({reportedProductIsAllowable: false})
+    );
     expect(wrapper.find('Alert').text()).toContain(
       'Product or Service is not associated with the NAICS code'
     );
   });
 });
 
-describe('The ProductionFields Component with archived product matched to a naics code', () => {
-  const query: ProductField_query = {
-    ' $refType': 'ProductField_query',
-    allProducts: {
-      edges: [
-        {
-          node: {
-            rowId: 1,
-            units: 'bar',
-            productState: 'ARCHIVED',
-            requiresEmissionAllocation: true,
-            requiresProductAmount: true,
-            isEnergyProduct: false,
-            addPurchasedElectricityEmissions: false,
-            addPurchasedHeatEmissions: false,
-            subtractExportedElectricityEmissions: false,
-            subtractExportedHeatEmissions: false,
-            subtractGeneratedElectricityEmissions: false,
-            subtractGeneratedHeatEmissions: false,
-            addEmissionsFromEios: false
-          }
-        }
-      ]
-    }
-  };
-
-  const naicsCode: ProductField_naicsCode = {
-    ' $refType': 'ProductField_naicsCode',
-    allProductsByNaicsCode: {
-      edges: [
-        {
-          node: {
-            rowId: 1,
-            productState: 'ARCHIVED'
-          }
-        }
-      ]
-    }
-  };
-
-  const props = {
-    ...createDefaultJsonSchemaFormProps(),
-    formData: {
-      productRowId: 1,
-      productUnits: 'bar',
-      productEmissions: 123,
-      productAmount: 456,
-      requiresEmissionAllocation: true
-    },
-    query,
-    naicsCode
-  };
-
+describe('The ProductField with archived product matched to a naics code', () => {
   it('should match the snapshot when rendering an archived product', () => {
-    const wrapper = shallow(<ProductFieldComponent {...props} />);
+    const wrapper = shallow(getTestElement({productState: 'ARCHIVED'}));
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should not render the archived warning', () => {
-    const wrapper = shallow(<ProductFieldComponent {...props} />);
+  it('should render the archived warning', () => {
+    const wrapper = shallow(getTestElement({productState: 'ARCHIVED'}));
     expect(wrapper.find('Alert').text()).toContain(
       'Product or Service has been archived'
     );
   });
 });
 
-describe('The ProductionFields Component with archived product not matched to a naics code', () => {
-  const query: ProductField_query = {
-    ' $refType': 'ProductField_query',
-    allProducts: {
-      edges: [
-        {
-          node: {
-            rowId: 1,
-            units: 'bar',
-            productState: 'ARCHIVED',
-            requiresEmissionAllocation: true,
-            requiresProductAmount: true,
-            isEnergyProduct: false,
-            addPurchasedElectricityEmissions: false,
-            addPurchasedHeatEmissions: false,
-            subtractExportedElectricityEmissions: false,
-            subtractExportedHeatEmissions: false,
-            subtractGeneratedElectricityEmissions: false,
-            subtractGeneratedHeatEmissions: false,
-            addEmissionsFromEios: false
-          }
-        }
-      ]
-    }
-  };
-
-  const naicsCode: ProductField_naicsCode = {
-    ' $refType': 'ProductField_naicsCode',
-    allProductsByNaicsCode: {
-      edges: [
-        {
-          node: {
-            rowId: 2,
-            productState: 'ARCHIVED'
-          }
-        }
-      ]
-    }
-  };
-
-  const props = {
-    ...createDefaultJsonSchemaFormProps(),
-    formData: {
-      productRowId: 1,
-      productUnits: 'bar',
-      productEmissions: 123,
-      productAmount: 456,
-      requiresEmissionAllocation: true
-    },
-    query,
-    naicsCode
-  };
-
+describe('The ProductField with archived product not matched to a naics code', () => {
   it('should match the snapshot when rendering an archived product not matched to a naics code', () => {
-    const wrapper = shallow(<ProductFieldComponent {...props} />);
+    const wrapper = shallow(
+      getTestElement({
+        productState: 'ARCHIVED',
+        reportedProductIsAllowable: false
+      })
+    );
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should render the archived warning and the not in naics warning', () => {
-    const wrapper = shallow(<ProductFieldComponent {...props} />);
+    const wrapper = shallow(
+      getTestElement({
+        productState: 'ARCHIVED',
+        reportedProductIsAllowable: false
+      })
+    );
     expect(wrapper.find('Alert').at(0).text()).toContain(
       'Product or Service has been archived'
     );
@@ -268,27 +159,18 @@ describe('The ProductionFields Component with archived product not matched to a 
   });
 });
 
-describe('The ProductionFields Component with no naics code', () => {
-  const query: ProductField_query = {
-    ' $refType': 'ProductField_query',
-    allProducts: {
-      edges: []
-    }
-  };
-
-  const props = {
-    ...createDefaultJsonSchemaFormProps(),
-    formData: {},
-    query
-  };
-
+describe('The ProductField with no naics code', () => {
   it('should match the snapshot', () => {
-    const wrapper = shallow(<ProductFieldComponent {...props} />);
+    const wrapper = shallow(
+      getTestElement({noNaicsCode: true, includeFormData: false})
+    );
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should render the no products found warning', () => {
-    const wrapper = shallow(<ProductFieldComponent {...props} />);
+    const wrapper = shallow(
+      getTestElement({noNaicsCode: true, includeFormData: false})
+    );
     expect(wrapper.find('Alert').at(0).text()).toContain(
       'No products were found'
     );

--- a/app/tests/unit/containers/Forms/ProductsArrayField.test.tsx
+++ b/app/tests/unit/containers/Forms/ProductsArrayField.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {ProductsArrayField} from 'containers/Forms/ProductsArrayField';
+import {ProductsArrayFieldComponent as ProductsArrayField} from 'containers/Forms/ProductsArrayField';
 import {
   ProductsArrayField_naicsProducts,
   CiipProductState

--- a/app/tests/unit/containers/Forms/ProductsArrayField.test.tsx
+++ b/app/tests/unit/containers/Forms/ProductsArrayField.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {ProductsArrayField} from 'containers/Forms/ProductsArrayField';
+import {
+  ProductsArrayField_naicsProducts,
+  CiipProductState
+} from 'ProductsArrayField_naicsProducts.graphql';
+import {createDefaultJsonSchemaFormProps} from 'tests/json-schema-utils';
+
+const getTestQuery = () => {
+  return {
+    ' $refType': 'ProductsArrayField_naicsProducts',
+    mandatoryProducts: {
+      edges: [
+        {
+          node: {
+            id: 'abc',
+            productByProductId: {
+              rowId: 9,
+              units: 'GWH',
+              productState: 'PUBLISHED' as CiipProductState,
+              requiresEmissionAllocation: true,
+              requiresProductAmount: true,
+              isEnergyProduct: false,
+              addPurchasedElectricityEmissions: false,
+              addPurchasedHeatEmissions: false,
+              subtractExportedElectricityEmissions: false,
+              subtractExportedHeatEmissions: false,
+              subtractGeneratedElectricityEmissions: false,
+              subtractGeneratedHeatEmissions: false,
+              addEmissionsFromEios: false
+            }
+          }
+        }
+      ]
+    }
+  };
+};
+
+const getTestElement = ({noNaicsCode = false, relay = null}) => {
+  const data = getTestQuery();
+  return (
+    <ProductsArrayField
+      {...createDefaultJsonSchemaFormProps()}
+      naicsProducts={
+        noNaicsCode ? null : (data as ProductsArrayField_naicsProducts)
+      }
+      relay={relay}
+    />
+  );
+};
+
+describe('ProductsArrayField', () => {
+  it('no NAICS code specified', () => {
+    const wrapper = shallow(getTestElement({noNaicsCode: true}));
+    expect(wrapper.find('Relay(ProductField)').exists()).toBeFalse();
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('NAICS code specified, with allowable products', () => {
+    const wrapper = shallow(getTestElement({}));
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/app/tests/unit/containers/Forms/ProductsArrayField.test.tsx
+++ b/app/tests/unit/containers/Forms/ProductsArrayField.test.tsx
@@ -53,7 +53,6 @@ const getTestElement = ({noNaicsCode = false, relay = null}) => {
 describe('ProductsArrayField', () => {
   it('no NAICS code specified', () => {
     const wrapper = shallow(getTestElement({noNaicsCode: true}));
-    expect(wrapper.find('Relay(ProductField)').exists()).toBeFalse();
     expect(wrapper).toMatchSnapshot();
   });
   it('NAICS code specified, with allowable products', () => {

--- a/app/tests/unit/containers/Forms/__snapshots__/Form.test.tsx.snap
+++ b/app/tests/unit/containers/Forms/__snapshots__/Form.test.tsx.snap
@@ -94,6 +94,7 @@ exports[`The Form Component should match the snapshot 1`] = `
           Object {
             "AddCommentField": [Function],
             "NumberField": [Function],
+            "ProductsArrayField": [Function],
             "emission": [Function],
             "emissionCategoryRowId": [Function],
             "emissionGas": [Function],
@@ -814,6 +815,7 @@ exports[`The Form Component should not render an alert reminder to check the gui
           Object {
             "AddCommentField": [Function],
             "NumberField": [Function],
+            "ProductsArrayField": [Function],
             "emission": [Function],
             "emissionCategoryRowId": [Function],
             "emissionGas": [Function],
@@ -1544,6 +1546,7 @@ exports[`The Form Component should render alert reminder to check the guidance i
           Object {
             "AddCommentField": [Function],
             "NumberField": [Function],
+            "ProductsArrayField": [Function],
             "emission": [Function],
             "emissionCategoryRowId": [Function],
             "emissionGas": [Function],

--- a/app/tests/unit/containers/Forms/__snapshots__/ProductField.test.tsx.snap
+++ b/app/tests/unit/containers/Forms/__snapshots__/ProductField.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`The ProductionFields Component with archived product matched to a naics code should match the snapshot when rendering an archived product 1`] = `
+exports[`The ProductField with archived product matched to a naics code should match the snapshot when rendering an archived product 1`] = `
 <Fragment>
   <Alert
     closeLabel="Close alert"
@@ -48,12 +48,12 @@ exports[`The ProductionFields Component with archived product matched to a naics
     naicsCode={
       Object {
         " $refType": "ProductField_naicsCode",
-        "allProductsByNaicsCode": Object {
+        "allowableProducts": Object {
           "edges": Array [
             Object {
               "node": Object {
-                "productState": "ARCHIVED",
-                "rowId": 1,
+                "isMandatory": false,
+                "productId": 1,
               },
             },
           ],
@@ -136,10 +136,15 @@ exports[`The ProductionFields Component with archived product matched to a naics
     schema={Object {}}
     uiSchema={Object {}}
   />
+  <JSXStyle
+    id="849115727"
+  >
+    .svg-inline--fa.fa-info-circle{margin-left:0.5em;}
+  </JSXStyle>
 </Fragment>
 `;
 
-exports[`The ProductionFields Component with archived product not matched to a naics code should match the snapshot when rendering an archived product not matched to a naics code 1`] = `
+exports[`The ProductField with archived product not matched to a naics code should match the snapshot when rendering an archived product not matched to a naics code 1`] = `
 <Fragment>
   <Alert
     closeLabel="Close alert"
@@ -211,12 +216,12 @@ exports[`The ProductionFields Component with archived product not matched to a n
     naicsCode={
       Object {
         " $refType": "ProductField_naicsCode",
-        "allProductsByNaicsCode": Object {
+        "allowableProducts": Object {
           "edges": Array [
             Object {
               "node": Object {
-                "productState": "ARCHIVED",
-                "rowId": 2,
+                "isMandatory": false,
+                "productId": 2,
               },
             },
           ],
@@ -299,10 +304,15 @@ exports[`The ProductionFields Component with archived product not matched to a n
     schema={Object {}}
     uiSchema={Object {}}
   />
+  <JSXStyle
+    id="849115727"
+  >
+    .svg-inline--fa.fa-info-circle{margin-left:0.5em;}
+  </JSXStyle>
 </Fragment>
 `;
 
-exports[`The ProductionFields Component with no naics code should match the snapshot 1`] = `
+exports[`The ProductField with no naics code should match the snapshot 1`] = `
 <Fragment>
   <Alert
     closeLabel="Close alert"
@@ -346,7 +356,25 @@ exports[`The ProductionFields Component with no naics code should match the snap
       Object {
         " $refType": "ProductField_query",
         "allProducts": Object {
-          "edges": Array [],
+          "edges": Array [
+            Object {
+              "node": Object {
+                "addEmissionsFromEios": false,
+                "addPurchasedElectricityEmissions": false,
+                "addPurchasedHeatEmissions": false,
+                "isEnergyProduct": false,
+                "productState": "PUBLISHED",
+                "requiresEmissionAllocation": true,
+                "requiresProductAmount": true,
+                "rowId": 1,
+                "subtractExportedElectricityEmissions": false,
+                "subtractExportedHeatEmissions": false,
+                "subtractGeneratedElectricityEmissions": false,
+                "subtractGeneratedHeatEmissions": false,
+                "units": "bar",
+              },
+            },
+          ],
         },
       }
     }
@@ -397,10 +425,15 @@ exports[`The ProductionFields Component with no naics code should match the snap
     schema={Object {}}
     uiSchema={Object {}}
   />
+  <JSXStyle
+    id="849115727"
+  >
+    .svg-inline--fa.fa-info-circle{margin-left:0.5em;}
+  </JSXStyle>
 </Fragment>
 `;
 
-exports[`The ProductionFields Component with published product matched to a naics code should match the snapshot when rendering a product 1`] = `
+exports[`The ProductField with published product matched to a naics code should match the snapshot when rendering a product 1`] = `
 <Fragment>
   <ObjectField
     autofocus={false}
@@ -424,12 +457,12 @@ exports[`The ProductionFields Component with published product matched to a naic
     naicsCode={
       Object {
         " $refType": "ProductField_naicsCode",
-        "allProductsByNaicsCode": Object {
+        "allowableProducts": Object {
           "edges": Array [
             Object {
               "node": Object {
-                "productState": "PUBLISHED",
-                "rowId": 1,
+                "isMandatory": false,
+                "productId": 1,
               },
             },
           ],
@@ -512,10 +545,15 @@ exports[`The ProductionFields Component with published product matched to a naic
     schema={Object {}}
     uiSchema={Object {}}
   />
+  <JSXStyle
+    id="849115727"
+  >
+    .svg-inline--fa.fa-info-circle{margin-left:0.5em;}
+  </JSXStyle>
 </Fragment>
 `;
 
-exports[`The ProductionFields Component with published product not matched to a naics code should match the snapshot when rendering a product not matched to a naics code 1`] = `
+exports[`The ProductField with published product not matched to a naics code should match the snapshot when rendering a product not matched to a naics code 1`] = `
 <Fragment>
   <Alert
     closeLabel="Close alert"
@@ -563,12 +601,12 @@ exports[`The ProductionFields Component with published product not matched to a 
     naicsCode={
       Object {
         " $refType": "ProductField_naicsCode",
-        "allProductsByNaicsCode": Object {
+        "allowableProducts": Object {
           "edges": Array [
             Object {
               "node": Object {
-                "productState": "PUBLISHED",
-                "rowId": 2,
+                "isMandatory": false,
+                "productId": 2,
               },
             },
           ],
@@ -651,5 +689,10 @@ exports[`The ProductionFields Component with published product not matched to a 
     schema={Object {}}
     uiSchema={Object {}}
   />
+  <JSXStyle
+    id="849115727"
+  >
+    .svg-inline--fa.fa-info-circle{margin-left:0.5em;}
+  </JSXStyle>
 </Fragment>
 `;

--- a/app/tests/unit/containers/Forms/__snapshots__/ProductsArrayField.test.tsx.snap
+++ b/app/tests/unit/containers/Forms/__snapshots__/ProductsArrayField.test.tsx.snap
@@ -1,0 +1,161 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProductsArrayField NAICS code specified, with allowable products 1`] = `
+<ArrayField
+  autofocus={false}
+  disabled={false}
+  errorSchema={Object {}}
+  formContext={Object {}}
+  formData={null}
+  idSchema={
+    Object {
+      "$id": "myField",
+    }
+  }
+  naicsProducts={
+    Object {
+      " $refType": "ProductsArrayField_naicsProducts",
+      "mandatoryProducts": Object {
+        "edges": Array [
+          Object {
+            "node": Object {
+              "id": "abc",
+              "productByProductId": Object {
+                "addEmissionsFromEios": false,
+                "addPurchasedElectricityEmissions": false,
+                "addPurchasedHeatEmissions": false,
+                "isEnergyProduct": false,
+                "productState": "PUBLISHED",
+                "requiresEmissionAllocation": true,
+                "requiresProductAmount": true,
+                "rowId": 9,
+                "subtractExportedElectricityEmissions": false,
+                "subtractExportedHeatEmissions": false,
+                "subtractGeneratedElectricityEmissions": false,
+                "subtractGeneratedHeatEmissions": false,
+                "units": "GWH",
+              },
+            },
+          },
+        ],
+      },
+    }
+  }
+  name=""
+  onBlur={[MockFunction]}
+  onChange={[MockFunction]}
+  readonly={false}
+  registry={
+    Object {
+      "definitions": Object {},
+      "fields": Object {
+        "AnyOfField": [Function],
+        "ArrayField": [Function],
+        "BooleanField": [Function],
+        "DescriptionField": [Function],
+        "NullField": [Function],
+        "NumberField": [Function],
+        "ObjectField": [Function],
+        "OneOfField": [Function],
+        "SchemaField": [Function],
+        "StringField": [Function],
+        "TitleField": [Function],
+        "UnsupportedField": [Function],
+      },
+      "formContext": Object {},
+      "rootSchema": Object {},
+      "widgets": Object {
+        "AltDateTimeWidget": [Function],
+        "AltDateWidget": [Function],
+        "BaseInput": [Function],
+        "CheckboxWidget": [Function],
+        "CheckboxesWidget": [Function],
+        "ColorWidget": [Function],
+        "DateTimeWidget": [Function],
+        "DateWidget": [Function],
+        "EmailWidget": [Function],
+        "FileWidget": [Function],
+        "HiddenWidget": [Function],
+        "PasswordWidget": [Function],
+        "RadioWidget": [Function],
+        "RangeWidget": [Function],
+        "SelectWidget": [Function],
+        "TextWidget": [Function],
+        "TextareaWidget": [Function],
+        "URLWidget": [Function],
+        "UpDownWidget": [Function],
+      },
+    }
+  }
+  relay={null}
+  required={false}
+  schema={Object {}}
+  uiSchema={Object {}}
+/>
+`;
+
+exports[`ProductsArrayField no NAICS code specified 1`] = `
+<ArrayField
+  autofocus={false}
+  disabled={false}
+  errorSchema={Object {}}
+  formContext={Object {}}
+  formData={null}
+  idSchema={
+    Object {
+      "$id": "myField",
+    }
+  }
+  naicsProducts={null}
+  name=""
+  onBlur={[MockFunction]}
+  onChange={[MockFunction]}
+  readonly={false}
+  registry={
+    Object {
+      "definitions": Object {},
+      "fields": Object {
+        "AnyOfField": [Function],
+        "ArrayField": [Function],
+        "BooleanField": [Function],
+        "DescriptionField": [Function],
+        "NullField": [Function],
+        "NumberField": [Function],
+        "ObjectField": [Function],
+        "OneOfField": [Function],
+        "SchemaField": [Function],
+        "StringField": [Function],
+        "TitleField": [Function],
+        "UnsupportedField": [Function],
+      },
+      "formContext": Object {},
+      "rootSchema": Object {},
+      "widgets": Object {
+        "AltDateTimeWidget": [Function],
+        "AltDateWidget": [Function],
+        "BaseInput": [Function],
+        "CheckboxWidget": [Function],
+        "CheckboxesWidget": [Function],
+        "ColorWidget": [Function],
+        "DateTimeWidget": [Function],
+        "DateWidget": [Function],
+        "EmailWidget": [Function],
+        "FileWidget": [Function],
+        "HiddenWidget": [Function],
+        "PasswordWidget": [Function],
+        "RadioWidget": [Function],
+        "RangeWidget": [Function],
+        "SelectWidget": [Function],
+        "TextWidget": [Function],
+        "TextareaWidget": [Function],
+        "URLWidget": [Function],
+        "UpDownWidget": [Function],
+      },
+    }
+  }
+  relay={null}
+  required={false}
+  schema={Object {}}
+  uiSchema={Object {}}
+/>
+`;

--- a/schema/data/prod/form_json/production.json
+++ b/schema/data/prod/form_json/production.json
@@ -87,6 +87,7 @@
   "uiSchema": {
     "ui:add-text": "Add a Product",
     "ui:remove-text": "Remove Product",
+    "ui:field": "ProductsArrayField",
     "items": {
       "comments": {
         "ui:field": "AddCommentField",

--- a/schema/data/prod/form_json/production.json
+++ b/schema/data/prod/form_json/production.json
@@ -30,6 +30,35 @@
         },
 
         "dependencies": {
+          "isMandatory": {
+            "oneOf": [
+              {
+                "properties": {
+                  "productRowId": {
+                    "title": "Product or Service",
+                    "type": "integer"
+                  },
+                  "isMandatory": {
+                    "const": false
+                  }
+                },
+                "required": ["productRowId"]
+              },
+              {
+                "properties": {
+                  "productRowId": {
+                    "title": "Product or Service",
+                    "type": "integer",
+                    "readOnly": true
+                  },
+                  "isMandatory": {
+                    "const": true
+                  }
+                },
+                "required": ["productRowId"]
+              }
+            ]
+          },
           "requiresEmissionAllocation": {
             "oneOf": [
               {
@@ -80,9 +109,9 @@
           }
         },
         "required": [
-          "productRowId",
           "requiresEmissionAllocation",
-          "requiresProductAmount"
+          "requiresProductAmount",
+          "productRowId"
         ]
       }
     }

--- a/schema/data/prod/form_json/production.json
+++ b/schema/data/prod/form_json/production.json
@@ -23,6 +23,9 @@
           },
           "isEnergyProduct": {
             "type": "boolean"
+          },
+          "isMandatory": {
+            "type": "boolean"
           }
         },
 
@@ -89,6 +92,9 @@
     "ui:remove-text": "Remove Product",
     "ui:field": "ProductsArrayField",
     "items": {
+      "ui:hasRemove": {
+        "isFalse": "isMandatory"
+      },
       "comments": {
         "ui:field": "AddCommentField",
         "ui:options": {
@@ -124,7 +130,8 @@
       },
       "requiresEmissionAllocation": { "ui:widget": "hidden" },
       "requiresProductAmount": { "ui:widget": "hidden" },
-      "isEnergyProduct": { "ui:widget": "hidden" }
+      "isEnergyProduct": { "ui:widget": "hidden" },
+      "isMandatory": { "ui:widget": "hidden" }
     }
   }
 }


### PR DESCRIPTION
- If a NAICS code has been set in the Administrative Data section, any mandatory products are initialized in the Production section.
- Adds custom ProductsArrayField to accomplish this by mutating the formResult on load
- "Remove product" button is overridden on a per-item basis for mandatory products

[GGIRCS-2288](https://youtrack.button.is/issue/GGIRCS-2288)