### PR TITLE
chore: remove bad parenthesis in helm template

### DIFF
--- a/helm/cas-ciip-portal/templates/cronJobs/cron-deploy-data.yaml
+++ b/helm/cas-ciip-portal/templates/cronJobs/cron-deploy-data.yaml
@@ -69,7 +69,7 @@ spec:
                 - -c
                 - |
                   set -euo pipefail;
-                  if [[ "$(NAMESPACE)" == *-dev  ]]; then
+                  if [[ "$NAMESPACE" == *-dev  ]]; then
                   schema/data/deploy-data.sh --oc-project=$(NAMESPACE) --app-count 10;
                   else
                   schema/data/deploy-data.sh -r --oc-project=$(NAMESPACE);


### PR DESCRIPTION
same as in cas-ggircs repo, parenthesis need to be removed
"$(NAMESPACE)" --> "$NAMESPACE"