### PR TITLE
Updated application disclaimer text before submission

### DIFF
--- a/app/components/Application/ScrollableApplicationDisclaimer.tsx
+++ b/app/components/Application/ScrollableApplicationDisclaimer.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import {Card} from 'react-bootstrap';
+import LegalDisclaimerText from 'components/LegalDisclaimerText';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import {faExternalLinkAlt} from '@fortawesome/free-solid-svg-icons';
+
+const ScrollableApplicationDisclaimer: React.FunctionComponent = () => {
+  return (
+    <>
+      <Card.Body>
+        <Card.Title className="blue">
+          CIIP Application Disclaimer
+          <small>
+            <a href="/resources/application-disclaimer" target="_blank">
+              (<FontAwesomeIcon icon={faExternalLinkAlt} />
+              expand)
+            </a>
+          </small>
+        </Card.Title>
+        <Card>
+          <div tabIndex={0} id="disclaimer-text" className="show-scrollbar">
+            <Card.Body>
+              <LegalDisclaimerText />
+            </Card.Body>
+          </div>
+        </Card>
+      </Card.Body>
+      <style jsx>{`
+        #disclaimer-text {
+          max-height: 19.2em;
+          background: #eee;
+          overflow-y: scroll;
+        }
+        .show-scrollbar::-webkit-scrollbar {
+          -webkit-appearance: none;
+          width: 8px;
+        }
+        .show-scrollbar::-webkit-scrollbar-thumb {
+          border-radius: 4px;
+          background-color: rgba(0, 0, 0, 0.5);
+          box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
+        }
+        small {
+          margin-left: 0.5em;
+        }
+      `}</style>
+    </>
+  );
+};
+
+export default ScrollableApplicationDisclaimer;

--- a/app/components/LegalDisclaimerText.tsx
+++ b/app/components/LegalDisclaimerText.tsx
@@ -1,83 +1,58 @@
 import React from 'react';
+import getConfig from 'next/config';
 
 const LegalDisclaimerText: React.FunctionComponent = () => {
+  const adminEmail = getConfig()?.publicRuntimeConfig.ADMIN_EMAIL;
   return (
     <>
       <p>In this application:</p>
       <ol id="glossary">
         <li>
           (a) &quot;CIIP&quot; means the{' '}
-          <a href="https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3">
+          <a
+            href="https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             CleanBC Industrial Incentive Program;
           </a>
         </li>
         <li>
-          (b) &quot;Certifying Official&quot; means the person who approves this
-          application on behalf of the Operator;
-        </li>
-        <li>
-          (c) &quot;GGIRCA&quot; means{' '}
+          (b) &quot;GGIRCA&quot; means{' '}
           <em>Greenhouse Gas Industrial Reporting and Control Act</em>;
         </li>
         <li>
-          (d) &quot;Operator&quot; means the person identified as responsible
+          (c) &quot;Operator&quot; means the person identified as responsible
           for the Reporting Operation;
         </li>
         <li>
-          (e) &quot;Province&quot; means Her Majesty the Queen in Right of
+          (d) &quot;Province&quot; means Her Majesty the Queen in Right of
           British Columbia;
         </li>
         <li>
-          (f) &quot;Reporting Operation&quot; means the industrial operation
+          (e) &quot;Reporting Operation&quot; means the industrial operation
           identified in the application;
         </li>
         <li>
-          (g) &quot;Representative&quot; means the individual completing this
+          (f) &quot;Representative&quot; means the individual completing this
           application on behalf of the Operator.
         </li>
       </ol>
       <p>
-        By approving and submitting this application, the Certifying Official
-        and Representative agree as follows:
+        By submitting this application, the Representative agrees as follows:
       </p>
       <ol id="consents">
         <li>
-          The Certifying Official warrants and represents that the Certifying
-          Official has the authority to, on behalf of the Operator, enter into
-          the following terms and provide the following consents and
-          certifications.
+          The Representative warrants and represents that the Representative has
+          the authority to, on behalf of the Operator, provide the following
+          consents and confirmations.
         </li>
         <li>
-          The Certifying Official and Operator certify that Certifying Official
-          has reviewed the information being submitted, and has exercised due
-          diligence to ensure that the information is true and complete, and
-          that, to the best of the Certifying Official&apos;s knowledge, the
-          information submitted herein is accurate and based on reasonable
-          estimates using available data.
-        </li>
-        <li>
-          The Operator agrees to repay any incentive amounts erroneously paid or
-          which, upon audit or review by the Province of British Columbia, are
-          determined by the Province to be either inconsistent with{' '}
-          <a href="https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3">
-            CIIP Rules
-          </a>{' '}
-          or not supported by evidence related to fuel usage and tax paid, and
-          acknowledges that any repayment amount may be deducted from a
-          following year&apos;s incentive payment, or other payments due to the
-          Operator from the Province.
-        </li>
-        <li>
-          The Operator consents to the release by the Province&apos;s Ministry
-          of Finance, to the Ministry of Environment and Climate Change
-          Strategy, of information collected in the Operator&apos;s carbon tax
-          account(s), and if applicable, other required taxpayer information
-          about the Operator, whether supplied by the Operator or by a third
-          party, for the purpose of administering GGIRCA. This consent is
-          specific to information relating to the two taxation years (April 1st
-          to March 31st) prior to the year of this consent and the current
-          taxation year and is effective on the date the Representative submits
-          this form. The consent will remain in effect for one year.
+          The Representative confirms that they have reviewed the information
+          being submitted, and have exercised due diligence to ensure that the
+          information is true and complete, and that, to the best of the
+          Representative&apos;s knowledge, the information submitted herein is
+          accurate and based on reasonable estimates using available data.
         </li>
         <li>
           The Operator consents to the release, by government employees
@@ -99,42 +74,21 @@ const LegalDisclaimerText: React.FunctionComponent = () => {
           in effect for one year.
         </li>
         <li>
-          The Operator consents to the release, by the Province&apos;s Ministry
-          of Environment and Climate Change Strategy to the Ministry of Finance,
-          of information contained in this application or in emission reports
-          made under GGIRCA and submitted in relation to the Reporting
-          Operation, for the purposes of administering the CleanBC Program for
-          Industry. This consent is specific to this application and to the
-          emission reports made in respect of the three reporting periods prior
-          to the submission of this application. This consent will remain in
-          effect for one year.
-        </li>
-        <li>
-          The Operator acknowledges that information provided by the Ministry of
-          Environment and Climate Change Strategy to the Ministry of Finance may
-          be used for the purposes of administering and enforcing the{' '}
-          <em>Carbon Tax Act</em>.
-        </li>
-        <li>
           All information for which consent has been granted will be subject to
           government policies, directives and standards relating to the
           confidentiality of information.
         </li>
         <li>
-          The Operator may at any time withdraw its consent under paragraph{' '}
-          <strong>d</strong> by submitting a withdrawal of consent in a form
-          specified by the Province&apos;s Fuel and Carbon Tax Section. Forms
-          may be obtained by submitting a request in writing to the Fuel and
-          Carbon Tax Section, Consumer Taxation Programs Branch, Ministry of
-          Finance, PO Box 9447 Stn Prov Govt, Victoria BC V8W 9V7.
-        </li>
-        <li>
           The Operator may at any time withdraw its consent under paragraphs{' '}
-          <strong>e</strong>, <strong>f</strong>, or <strong>g</strong> by
-          submitting a withdrawal of consent in a form specified by the director
-          appointed under GGIRCA. Forms may be obtained by submitting an email
-          request to{' '}
-          <a href="mailto:ghgregulator@gov.bc.ca">ghgregulator@gov.bc.ca</a>.
+          <strong>c</strong> or <strong>d</strong> by submitting a withdrawal of
+          consent in a form specified by the director appointed under GGIRCA.
+          Forms may be obtained by submitting an email request to{' '}
+          <a
+            href={`mailto:${adminEmail}?subject=CIIP: Request for consent withdrawal forms`}
+          >
+            {adminEmail}
+          </a>
+          .
         </li>
         <style jsx global>{`
           ol#glossary {

--- a/app/containers/Applications/ApplicationWizardConfirmation.tsx
+++ b/app/containers/Applications/ApplicationWizardConfirmation.tsx
@@ -8,6 +8,7 @@ import {ApplicationWizardConfirmation_applicationRevision} from 'ApplicationWiza
 import ApplicationDetailsContainer from './ApplicationDetailsContainer';
 import ApplicationOverrideJustification from 'components/Application/ApplicationOverrideJustification';
 import {FormJson} from 'next-env';
+import ScrollableApplicationDisclaimer from 'components/Application/ScrollableApplicationDisclaimer';
 
 /*
  * The ApplicationWizardConfirmation renders a summary of the data submitted in the application,
@@ -112,13 +113,38 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
               <h2>Before you submit</h2>
             </Card.Header>
             <Card.Body>
-              By submitting the application the applicant agrees that the
-              information contained on this application, or information
-              contained in emission reports under the Greenhouse Gas Industrial
-              Reporting and Control Act, may be disclosed to British Columbia
-              government employees, contractors and agencies for the purpose of
-              administering the CleanBC Program for Industry or the Greenhouse
-              Gas Industrial Reporting and Control Act.
+              <p>
+                Thank you for reviewing your application to the CleanBC
+                Industrial Incentive Program.
+              </p>
+              <p>
+                Your application is almost complete. Prior to submitting your
+                application, please review and accept the following terms below.
+              </p>
+              <p>
+                By submitting the application you agree that the information
+                contained in this application, or information contained in
+                emissions reports submitted under the{' '}
+                <a
+                  href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <em>Greenhouse Gas Industrial Reporting and Control Act</em>
+                </a>
+                , may be disclosed to British Columbia government employees,
+                contractors and agencies for the purpose of administering the
+                CleanBC Program for Industry or the{' '}
+                <a
+                  href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <em>Greenhouse Gas Industrial Reporting and Control Act</em>
+                </a>
+                .
+              </p>
+              <ScrollableApplicationDisclaimer />
             </Card.Body>
           </Card>
           <br />

--- a/app/containers/Applications/ApplicationWizardConfirmation.tsx
+++ b/app/containers/Applications/ApplicationWizardConfirmation.tsx
@@ -126,7 +126,7 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
                 contained in this application, or information contained in
                 emissions reports submitted under the{' '}
                 <a
-                  href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+                  href="https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -136,7 +136,7 @@ export const ApplicationWizardConfirmationComponent: React.FunctionComponent<Pro
                 contractors and agencies for the purpose of administering the
                 CleanBC Program for Industry or the{' '}
                 <a
-                  href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+                  href="https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/app/containers/Organisations/Organisations.tsx
+++ b/app/containers/Organisations/Organisations.tsx
@@ -71,11 +71,11 @@ export const OrganisationsComponent: React.FunctionComponent<Props> = (
         <Card.Body>
           Operator, Operation Representative, and Reporting Operation are
           defined in the{' '}
-          <a href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01">
+          <a href="https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01">
             Greenhouse Gas Industrial Reporting and Control Act
           </a>{' '}
           and{' '}
-          <a href="http://www.bclaws.ca/civix/document/id/lc/statreg/249_2015">
+          <a href="https://www.bclaws.ca/civix/document/id/lc/statreg/249_2015">
             Greenhouse Gas Emission Reporting Regulation
           </a>
           .
@@ -154,11 +154,11 @@ export const OrganisationsComponent: React.FunctionComponent<Props> = (
                     submitted by the Operator of the Reporting Operation or, if
                     there is more than one Operator, the Designated Operator as
                     defined by the{' '}
-                    <Alert.Link href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01">
+                    <Alert.Link href="https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01">
                       Greenhouse Gas Industrial Reporting and Control Act
                     </Alert.Link>{' '}
                     and{' '}
-                    <Alert.Link href="http://www.bclaws.ca/civix/document/id/lc/statreg/249_2015">
+                    <Alert.Link href="https://www.bclaws.ca/civix/document/id/lc/statreg/249_2015">
                       Greenhouse Gas Emission Reporting Regulation
                     </Alert.Link>
                     . Other representatives of the Reporting Operation may

--- a/app/pages/resources/copyright.tsx
+++ b/app/pages/resources/copyright.tsx
@@ -67,7 +67,7 @@ class Copyright extends Component<Props> {
           <p>
             For the reproduction of provincial legislation found on the{' '}
             <a
-              href="http://www.bclaws.ca/"
+              href="https://www.bclaws.ca/"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -75,7 +75,7 @@ class Copyright extends Component<Props> {
             </a>
             , permission is subject to the terms of the{' '}
             <a
-              href="http://www.bclaws.ca/standards/2014/QP-License_1.0.html"
+              href="https://www.bclaws.ca/standards/2014/QP-License_1.0.html"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -108,7 +108,7 @@ class Copyright extends Component<Props> {
           <p>
             For the reproduction of materials found in the{' '}
             <a
-              href="http://catalogue.data.gov.bc.ca/"
+              href="https://catalogue.data.gov.bc.ca/"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/app/pages/resources/privacy.tsx
+++ b/app/pages/resources/privacy.tsx
@@ -36,7 +36,7 @@ class Privacy extends Component<Props> {
             personal information in accordance with the{' '}
             <em>
               <a
-                href="http://www.bclaws.ca/Recon/document/ID/freeside/96165_00"
+                href="https://www.bclaws.ca/Recon/document/ID/freeside/96165_00"
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -193,7 +193,7 @@ class Privacy extends Component<Props> {
             audit log is retained for 2 years. Information collected or created
             by the Government of B.C. is maintained in accordance with{' '}
             <a
-              href="http://www.gov.bc.ca/citz/iao/records_mgmt/"
+              href="https://www.gov.bc.ca/citz/iao/records_mgmt/"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/app/tests/unit/components/Application/ScrollableApplicationDisclaimer.test.tsx
+++ b/app/tests/unit/components/Application/ScrollableApplicationDisclaimer.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import ScrollableApplicationDisclaimer from 'components/Application/ScrollableApplicationDisclaimer';
+
+describe('Scrollable application disclaimer', () => {
+  it('should match the last snapshot', () => {
+    const render = shallow(<ScrollableApplicationDisclaimer />);
+    expect(render).toMatchSnapshot();
+  });
+});

--- a/app/tests/unit/components/Application/__snapshots__/ScrollableApplicationDisclaimer.test.tsx.snap
+++ b/app/tests/unit/components/Application/__snapshots__/ScrollableApplicationDisclaimer.test.tsx.snap
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scrollable application disclaimer should match the last snapshot 1`] = `
+<Fragment>
+  <CardBody>
+    <CardTitle
+      className="blue"
+    >
+      CIIP Application Disclaimer
+      <small
+        className="jsx-1928048576"
+      >
+        <a
+          className="jsx-1928048576"
+          href="/resources/application-disclaimer"
+          target="_blank"
+        >
+          (
+          <FontAwesomeIcon
+            border={false}
+            className=""
+            fixedWidth={false}
+            flip={null}
+            icon={
+              Object {
+                "icon": Array [
+                  512,
+                  512,
+                  Array [],
+                  "f35d",
+                  "M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z",
+                ],
+                "iconName": "external-link-alt",
+                "prefix": "fas",
+              }
+            }
+            inverse={false}
+            listItem={false}
+            mask={null}
+            pull={null}
+            pulse={false}
+            rotation={null}
+            size={null}
+            spin={false}
+            swapOpacity={false}
+            symbol={false}
+            title=""
+            transform={null}
+          />
+          expand)
+        </a>
+      </small>
+    </CardTitle>
+    <Card
+      body={false}
+    >
+      <div
+        className="jsx-1928048576 show-scrollbar"
+        id="disclaimer-text"
+        tabIndex={0}
+      >
+        <CardBody>
+          <LegalDisclaimerText />
+        </CardBody>
+      </div>
+    </Card>
+  </CardBody>
+  <JSXStyle
+    id="1928048576"
+  >
+    #disclaimer-text.jsx-1928048576{max-height:19.2em;background:#eee;overflow-y:scroll;}.show-scrollbar.jsx-1928048576::-webkit-scrollbar{-webkit-appearance:none;width:8px;}.show-scrollbar.jsx-1928048576::-webkit-scrollbar-thumb{border-radius:4px;background-color:rgba(0,0,0,0.5);box-shadow:0 0 1px rgba(255,255,255,0.5);}small.jsx-1928048576{margin-left:0.5em;}
+  </JSXStyle>
+</Fragment>
+`;

--- a/app/tests/unit/components/__snapshots__/LegalDisclaimerText.test.tsx.snap
+++ b/app/tests/unit/components/__snapshots__/LegalDisclaimerText.test.tsx.snap
@@ -13,15 +13,14 @@ exports[`LegalDisclaimerText Component should match the last snapshot 1`] = `
        
       <a
         href="https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         CleanBC Industrial Incentive Program;
       </a>
     </li>
     <li>
-      (b) "Certifying Official" means the person who approves this application on behalf of the Operator;
-    </li>
-    <li>
-      (c) "GGIRCA" means
+      (b) "GGIRCA" means
        
       <em>
         Greenhouse Gas Industrial Reporting and Control Act
@@ -29,20 +28,20 @@ exports[`LegalDisclaimerText Component should match the last snapshot 1`] = `
       ;
     </li>
     <li>
-      (d) "Operator" means the person identified as responsible for the Reporting Operation;
+      (c) "Operator" means the person identified as responsible for the Reporting Operation;
     </li>
     <li>
-      (e) "Province" means Her Majesty the Queen in Right of British Columbia;
+      (d) "Province" means Her Majesty the Queen in Right of British Columbia;
     </li>
     <li>
-      (f) "Reporting Operation" means the industrial operation identified in the application;
+      (e) "Reporting Operation" means the industrial operation identified in the application;
     </li>
     <li>
-      (g) "Representative" means the individual completing this application on behalf of the Operator.
+      (f) "Representative" means the individual completing this application on behalf of the Operator.
     </li>
   </ol>
   <p>
-    By approving and submitting this application, the Certifying Official and Representative agree as follows:
+    By submitting this application, the Representative agrees as follows:
   </p>
   <ol
     className="jsx-3350969095"
@@ -51,31 +50,12 @@ exports[`LegalDisclaimerText Component should match the last snapshot 1`] = `
     <li
       className="jsx-3350969095"
     >
-      The Certifying Official warrants and represents that the Certifying Official has the authority to, on behalf of the Operator, enter into the following terms and provide the following consents and certifications.
+      The Representative warrants and represents that the Representative has the authority to, on behalf of the Operator, provide the following consents and confirmations.
     </li>
     <li
       className="jsx-3350969095"
     >
-      The Certifying Official and Operator certify that Certifying Official has reviewed the information being submitted, and has exercised due diligence to ensure that the information is true and complete, and that, to the best of the Certifying Official's knowledge, the information submitted herein is accurate and based on reasonable estimates using available data.
-    </li>
-    <li
-      className="jsx-3350969095"
-    >
-      The Operator agrees to repay any incentive amounts erroneously paid or which, upon audit or review by the Province of British Columbia, are determined by the Province to be either inconsistent with
-       
-      <a
-        className="jsx-3350969095"
-        href="https://www2.gov.bc.ca/gov/content?id=6F748A4DD83447C59B8B9361882FF9A3"
-      >
-        CIIP Rules
-      </a>
-       
-      or not supported by evidence related to fuel usage and tax paid, and acknowledges that any repayment amount may be deducted from a following year's incentive payment, or other payments due to the Operator from the Province.
-    </li>
-    <li
-      className="jsx-3350969095"
-    >
-      The Operator consents to the release by the Province's Ministry of Finance, to the Ministry of Environment and Climate Change Strategy, of information collected in the Operator's carbon tax account(s), and if applicable, other required taxpayer information about the Operator, whether supplied by the Operator or by a third party, for the purpose of administering GGIRCA. This consent is specific to information relating to the two taxation years (April 1st to March 31st) prior to the year of this consent and the current taxation year and is effective on the date the Representative submits this form. The consent will remain in effect for one year.
+      The Representative confirms that they have reviewed the information being submitted, and have exercised due diligence to ensure that the information is true and complete, and that, to the best of the Representative's knowledge, the information submitted herein is accurate and based on reasonable estimates using available data.
     </li>
     <li
       className="jsx-3350969095"
@@ -90,36 +70,7 @@ exports[`LegalDisclaimerText Component should match the last snapshot 1`] = `
     <li
       className="jsx-3350969095"
     >
-      The Operator consents to the release, by the Province's Ministry of Environment and Climate Change Strategy to the Ministry of Finance, of information contained in this application or in emission reports made under GGIRCA and submitted in relation to the Reporting Operation, for the purposes of administering the CleanBC Program for Industry. This consent is specific to this application and to the emission reports made in respect of the three reporting periods prior to the submission of this application. This consent will remain in effect for one year.
-    </li>
-    <li
-      className="jsx-3350969095"
-    >
-      The Operator acknowledges that information provided by the Ministry of Environment and Climate Change Strategy to the Ministry of Finance may be used for the purposes of administering and enforcing the
-       
-      <em
-        className="jsx-3350969095"
-      >
-        Carbon Tax Act
-      </em>
-      .
-    </li>
-    <li
-      className="jsx-3350969095"
-    >
       All information for which consent has been granted will be subject to government policies, directives and standards relating to the confidentiality of information.
-    </li>
-    <li
-      className="jsx-3350969095"
-    >
-      The Operator may at any time withdraw its consent under paragraph
-       
-      <strong
-        className="jsx-3350969095"
-      >
-        d
-      </strong>
-       by submitting a withdrawal of consent in a form specified by the Province's Fuel and Carbon Tax Section. Forms may be obtained by submitting a request in writing to the Fuel and Carbon Tax Section, Consumer Taxation Programs Branch, Ministry of Finance, PO Box 9447 Stn Prov Govt, Victoria BC V8W 9V7.
     </li>
     <li
       className="jsx-3350969095"
@@ -129,28 +80,20 @@ exports[`LegalDisclaimerText Component should match the last snapshot 1`] = `
       <strong
         className="jsx-3350969095"
       >
-        e
+        c
       </strong>
-      , 
+       or 
       <strong
         className="jsx-3350969095"
       >
-        f
-      </strong>
-      , or 
-      <strong
-        className="jsx-3350969095"
-      >
-        g
+        d
       </strong>
        by submitting a withdrawal of consent in a form specified by the director appointed under GGIRCA. Forms may be obtained by submitting an email request to
        
       <a
         className="jsx-3350969095"
-        href="mailto:ghgregulator@gov.bc.ca"
-      >
-        ghgregulator@gov.bc.ca
-      </a>
+        href="mailto:undefined?subject=CIIP: Request for consent withdrawal forms"
+      />
       .
     </li>
     <JSXStyle

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationWizardConfirmation.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationWizardConfirmation.test.tsx.snap
@@ -106,7 +106,50 @@ exports[`The Confirmation Component should not render the validation alert if th
       </h2>
     </CardHeader>
     <CardBody>
-      By submitting the application the applicant agrees that the information contained on this application, or information contained in emission reports under the Greenhouse Gas Industrial Reporting and Control Act, may be disclosed to British Columbia government employees, contractors and agencies for the purpose of administering the CleanBC Program for Industry or the Greenhouse Gas Industrial Reporting and Control Act.
+      <p
+        className="jsx-1284301984"
+      >
+        Thank you for reviewing your application to the CleanBC Industrial Incentive Program.
+      </p>
+      <p
+        className="jsx-1284301984"
+      >
+        Your application is almost complete. Prior to submitting your application, please review and accept the following terms below.
+      </p>
+      <p
+        className="jsx-1284301984"
+      >
+        By submitting the application you agree that the information contained in this application, or information contained in emissions reports submitted under the
+         
+        <a
+          className="jsx-1284301984"
+          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <em
+            className="jsx-1284301984"
+          >
+            Greenhouse Gas Industrial Reporting and Control Act
+          </em>
+        </a>
+        , may be disclosed to British Columbia government employees, contractors and agencies for the purpose of administering the CleanBC Program for Industry or the
+         
+        <a
+          className="jsx-1284301984"
+          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <em
+            className="jsx-1284301984"
+          >
+            Greenhouse Gas Industrial Reporting and Control Act
+          </em>
+        </a>
+        .
+      </p>
+      <ScrollableApplicationDisclaimer />
     </CardBody>
   </Card>
   <br
@@ -268,7 +311,50 @@ exports[`The Confirmation Component should render the override justification com
       </h2>
     </CardHeader>
     <CardBody>
-      By submitting the application the applicant agrees that the information contained on this application, or information contained in emission reports under the Greenhouse Gas Industrial Reporting and Control Act, may be disclosed to British Columbia government employees, contractors and agencies for the purpose of administering the CleanBC Program for Industry or the Greenhouse Gas Industrial Reporting and Control Act.
+      <p
+        className="jsx-1284301984"
+      >
+        Thank you for reviewing your application to the CleanBC Industrial Incentive Program.
+      </p>
+      <p
+        className="jsx-1284301984"
+      >
+        Your application is almost complete. Prior to submitting your application, please review and accept the following terms below.
+      </p>
+      <p
+        className="jsx-1284301984"
+      >
+        By submitting the application you agree that the information contained in this application, or information contained in emissions reports submitted under the
+         
+        <a
+          className="jsx-1284301984"
+          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <em
+            className="jsx-1284301984"
+          >
+            Greenhouse Gas Industrial Reporting and Control Act
+          </em>
+        </a>
+        , may be disclosed to British Columbia government employees, contractors and agencies for the purpose of administering the CleanBC Program for Industry or the
+         
+        <a
+          className="jsx-1284301984"
+          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <em
+            className="jsx-1284301984"
+          >
+            Greenhouse Gas Industrial Reporting and Control Act
+          </em>
+        </a>
+        .
+      </p>
+      <ScrollableApplicationDisclaimer />
     </CardBody>
   </Card>
   <br
@@ -422,7 +508,50 @@ exports[`The Confirmation Component should render the override justification com
       </h2>
     </CardHeader>
     <CardBody>
-      By submitting the application the applicant agrees that the information contained on this application, or information contained in emission reports under the Greenhouse Gas Industrial Reporting and Control Act, may be disclosed to British Columbia government employees, contractors and agencies for the purpose of administering the CleanBC Program for Industry or the Greenhouse Gas Industrial Reporting and Control Act.
+      <p
+        className="jsx-1284301984"
+      >
+        Thank you for reviewing your application to the CleanBC Industrial Incentive Program.
+      </p>
+      <p
+        className="jsx-1284301984"
+      >
+        Your application is almost complete. Prior to submitting your application, please review and accept the following terms below.
+      </p>
+      <p
+        className="jsx-1284301984"
+      >
+        By submitting the application you agree that the information contained in this application, or information contained in emissions reports submitted under the
+         
+        <a
+          className="jsx-1284301984"
+          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <em
+            className="jsx-1284301984"
+          >
+            Greenhouse Gas Industrial Reporting and Control Act
+          </em>
+        </a>
+        , may be disclosed to British Columbia government employees, contractors and agencies for the purpose of administering the CleanBC Program for Industry or the
+         
+        <a
+          className="jsx-1284301984"
+          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <em
+            className="jsx-1284301984"
+          >
+            Greenhouse Gas Industrial Reporting and Control Act
+          </em>
+        </a>
+        .
+      </p>
+      <ScrollableApplicationDisclaimer />
     </CardBody>
   </Card>
   <br
@@ -616,7 +745,50 @@ exports[`The Confirmation Component should render the validation alert if there 
       </h2>
     </CardHeader>
     <CardBody>
-      By submitting the application the applicant agrees that the information contained on this application, or information contained in emission reports under the Greenhouse Gas Industrial Reporting and Control Act, may be disclosed to British Columbia government employees, contractors and agencies for the purpose of administering the CleanBC Program for Industry or the Greenhouse Gas Industrial Reporting and Control Act.
+      <p
+        className="jsx-1284301984"
+      >
+        Thank you for reviewing your application to the CleanBC Industrial Incentive Program.
+      </p>
+      <p
+        className="jsx-1284301984"
+      >
+        Your application is almost complete. Prior to submitting your application, please review and accept the following terms below.
+      </p>
+      <p
+        className="jsx-1284301984"
+      >
+        By submitting the application you agree that the information contained in this application, or information contained in emissions reports submitted under the
+         
+        <a
+          className="jsx-1284301984"
+          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <em
+            className="jsx-1284301984"
+          >
+            Greenhouse Gas Industrial Reporting and Control Act
+          </em>
+        </a>
+        , may be disclosed to British Columbia government employees, contractors and agencies for the purpose of administering the CleanBC Program for Industry or the
+         
+        <a
+          className="jsx-1284301984"
+          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <em
+            className="jsx-1284301984"
+          >
+            Greenhouse Gas Industrial Reporting and Control Act
+          </em>
+        </a>
+        .
+      </p>
+      <ScrollableApplicationDisclaimer />
     </CardBody>
   </Card>
   <br
@@ -875,7 +1047,50 @@ exports[`The Confirmation Component shows the "submit application" button when t
       </h2>
     </CardHeader>
     <CardBody>
-      By submitting the application the applicant agrees that the information contained on this application, or information contained in emission reports under the Greenhouse Gas Industrial Reporting and Control Act, may be disclosed to British Columbia government employees, contractors and agencies for the purpose of administering the CleanBC Program for Industry or the Greenhouse Gas Industrial Reporting and Control Act.
+      <p
+        className="jsx-1284301984"
+      >
+        Thank you for reviewing your application to the CleanBC Industrial Incentive Program.
+      </p>
+      <p
+        className="jsx-1284301984"
+      >
+        Your application is almost complete. Prior to submitting your application, please review and accept the following terms below.
+      </p>
+      <p
+        className="jsx-1284301984"
+      >
+        By submitting the application you agree that the information contained in this application, or information contained in emissions reports submitted under the
+         
+        <a
+          className="jsx-1284301984"
+          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <em
+            className="jsx-1284301984"
+          >
+            Greenhouse Gas Industrial Reporting and Control Act
+          </em>
+        </a>
+        , may be disclosed to British Columbia government employees, contractors and agencies for the purpose of administering the CleanBC Program for Industry or the
+         
+        <a
+          className="jsx-1284301984"
+          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <em
+            className="jsx-1284301984"
+          >
+            Greenhouse Gas Industrial Reporting and Control Act
+          </em>
+        </a>
+        .
+      </p>
+      <ScrollableApplicationDisclaimer />
     </CardBody>
   </Card>
   <br

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationWizardConfirmation.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationWizardConfirmation.test.tsx.snap
@@ -123,7 +123,7 @@ exports[`The Confirmation Component should not render the validation alert if th
          
         <a
           className="jsx-1284301984"
-          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          href="https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -137,7 +137,7 @@ exports[`The Confirmation Component should not render the validation alert if th
          
         <a
           className="jsx-1284301984"
-          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          href="https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -328,7 +328,7 @@ exports[`The Confirmation Component should render the override justification com
          
         <a
           className="jsx-1284301984"
-          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          href="https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -342,7 +342,7 @@ exports[`The Confirmation Component should render the override justification com
          
         <a
           className="jsx-1284301984"
-          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          href="https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -525,7 +525,7 @@ exports[`The Confirmation Component should render the override justification com
          
         <a
           className="jsx-1284301984"
-          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          href="https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -539,7 +539,7 @@ exports[`The Confirmation Component should render the override justification com
          
         <a
           className="jsx-1284301984"
-          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          href="https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -762,7 +762,7 @@ exports[`The Confirmation Component should render the validation alert if there 
          
         <a
           className="jsx-1284301984"
-          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          href="https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -776,7 +776,7 @@ exports[`The Confirmation Component should render the validation alert if there 
          
         <a
           className="jsx-1284301984"
-          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          href="https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -1064,7 +1064,7 @@ exports[`The Confirmation Component shows the "submit application" button when t
          
         <a
           className="jsx-1284301984"
-          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          href="https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -1078,7 +1078,7 @@ exports[`The Confirmation Component shows the "submit application" button when t
          
         <a
           className="jsx-1284301984"
-          href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+          href="https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
           rel="noopener noreferrer"
           target="_blank"
         >

--- a/app/tests/unit/containers/Organisation/__snapshots__/Organisations.test.tsx.snap
+++ b/app/tests/unit/containers/Organisation/__snapshots__/Organisations.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Organisations should render no organisations if the user has not reques
       Operator, Operation Representative, and Reporting Operation are defined in the
        
       <a
-        href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+        href="https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
       >
         Greenhouse Gas Industrial Reporting and Control Act
       </a>
@@ -18,7 +18,7 @@ exports[`Organisations should render no organisations if the user has not reques
       and
        
       <a
-        href="http://www.bclaws.ca/civix/document/id/lc/statreg/249_2015"
+        href="https://www.bclaws.ca/civix/document/id/lc/statreg/249_2015"
       >
         Greenhouse Gas Emission Reporting Regulation
       </a>
@@ -70,7 +70,7 @@ exports[`Organisations should render no organisations if the user has not reques
               The CleanBC Industrial Incentive Program application must be submitted by the Operator of the Reporting Operation or, if there is more than one Operator, the Designated Operator as defined by the
                
               <AlertLink
-                href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+                href="https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
               >
                 Greenhouse Gas Industrial Reporting and Control Act
               </AlertLink>
@@ -78,7 +78,7 @@ exports[`Organisations should render no organisations if the user has not reques
               and
                
               <AlertLink
-                href="http://www.bclaws.ca/civix/document/id/lc/statreg/249_2015"
+                href="https://www.bclaws.ca/civix/document/id/lc/statreg/249_2015"
               >
                 Greenhouse Gas Emission Reporting Regulation
               </AlertLink>
@@ -173,7 +173,7 @@ exports[`Organisations should render the user's requested organisations 1`] = `
       Operator, Operation Representative, and Reporting Operation are defined in the
        
       <a
-        href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+        href="https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
       >
         Greenhouse Gas Industrial Reporting and Control Act
       </a>
@@ -181,7 +181,7 @@ exports[`Organisations should render the user's requested organisations 1`] = `
       and
        
       <a
-        href="http://www.bclaws.ca/civix/document/id/lc/statreg/249_2015"
+        href="https://www.bclaws.ca/civix/document/id/lc/statreg/249_2015"
       >
         Greenhouse Gas Emission Reporting Regulation
       </a>
@@ -290,7 +290,7 @@ exports[`Organisations should render the user's requested organisations 1`] = `
               The CleanBC Industrial Incentive Program application must be submitted by the Operator of the Reporting Operation or, if there is more than one Operator, the Designated Operator as defined by the
                
               <AlertLink
-                href="http://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
+                href="https://www.bclaws.ca/civix/document/id/complete/statreg/14029_01"
               >
                 Greenhouse Gas Industrial Reporting and Control Act
               </AlertLink>
@@ -298,7 +298,7 @@ exports[`Organisations should render the user's requested organisations 1`] = `
               and
                
               <AlertLink
-                href="http://www.bclaws.ca/civix/document/id/lc/statreg/249_2015"
+                href="https://www.bclaws.ca/civix/document/id/lc/statreg/249_2015"
               >
                 Greenhouse Gas Emission Reporting Regulation
               </AlertLink>

--- a/app/tests/unit/pages/resources/__snapshots__/copyright.test.tsx.snap
+++ b/app/tests/unit/pages/resources/__snapshots__/copyright.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`BCGov core copyright page matches the last accepted Snapshot 1`] = `
       For the reproduction of provincial legislation found on the
        
       <a
-        href="http://www.bclaws.ca/"
+        href="https://www.bclaws.ca/"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -61,7 +61,7 @@ exports[`BCGov core copyright page matches the last accepted Snapshot 1`] = `
       , permission is subject to the terms of the
        
       <a
-        href="http://www.bclaws.ca/standards/2014/QP-License_1.0.html"
+        href="https://www.bclaws.ca/standards/2014/QP-License_1.0.html"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -94,7 +94,7 @@ exports[`BCGov core copyright page matches the last accepted Snapshot 1`] = `
       For the reproduction of materials found in the
        
       <a
-        href="http://catalogue.data.gov.bc.ca/"
+        href="https://catalogue.data.gov.bc.ca/"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/app/tests/unit/pages/resources/__snapshots__/privacy.test.tsx.snap
+++ b/app/tests/unit/pages/resources/__snapshots__/privacy.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`BCGov core privacy page matches the last accepted Snapshot 1`] = `
        
       <em>
         <a
-          href="http://www.bclaws.ca/Recon/document/ID/freeside/96165_00"
+          href="https://www.bclaws.ca/Recon/document/ID/freeside/96165_00"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -132,7 +132,7 @@ exports[`BCGov core privacy page matches the last accepted Snapshot 1`] = `
       Some cookies will remain on your computer for only as long as your browser remains open, or until you delete them off your computer. Other cookies will remain on your computer so that you may be recognized when you return to the website. These cookies will expire no later than 18 months from when they are first placed on your computer. Information collected as a part of a cookie or a security audit log is retained for 2 years. Information collected or created by the Government of B.C. is maintained in accordance with
        
       <a
-        href="http://www.gov.bc.ca/citz/iao/records_mgmt/"
+        href="https://www.gov.bc.ca/citz/iao/records_mgmt/"
         rel="noopener noreferrer"
         target="_blank"
       >


### PR DESCRIPTION
- Updates the legal text component for the application disclaimer
- Adds a scrollable area to display the legal disclaimer just before submission, with new paragraph text above the legal disclaimer
  * this also updates the text on the page shown at `/resources/application-disclaimer` (which is currently only linked from the "expand" link on the scrollable area)
  * links to GGIRCA and the expanded disclaimer page open in a new tab
  * `adminEmail` runtime variable is used for the email address at the end

**Incidental:**
- Updates all external links sitewide to use https:// instead of http:// where supported
  * necessary to please SonarCloud for the bclaws website linked in the legal disclaimer, so I did them all at once

[GGIRCS-2244](https://youtrack.button.is/issue/GGIRCS-2244)