### PR TITLE
refactor: remove deprecated trigger from new dev data

### DIFF
--- a/schema/data/dev/create_dev_applications.sql
+++ b/schema/data/dev/create_dev_applications.sql
@@ -2,7 +2,6 @@ begin;
 
   truncate ggircs_portal.application restart identity cascade;
 
-  alter table ggircs_portal.application disable trigger _send_draft_application_email;
   alter table ggircs_portal.application_revision_status disable trigger _status_change_email;
 
   -- Set a jwt token so that the created_by columns are not null on creation of application;
@@ -95,5 +94,7 @@ $$ language plpgsql volatile;
 select add_dev_apps(:num_apps);
 
 drop function add_dev_apps;
+
+alter table ggircs_portal.application_revision_status enable trigger _status_change_email;
 
 commit;


### PR DESCRIPTION
The dev data PR was being done in parallel with the 'remove _send_draft_email trigger' PR. They got merged back to back and a reference to the removed trigger was left in the dev data.

tldr: This fixes the broken develop branch