### PR TITLE
feat: change names of ciip application tab titles

### DIFF
--- a/app/containers/Forms/ProductField.tsx
+++ b/app/containers/Forms/ProductField.tsx
@@ -86,15 +86,15 @@ export const ProductFieldComponent: React.FunctionComponent<Props> = (
       <strong>Warning:</strong> This Product or Service is not associated with
       the NAICS code reported in this application. Please review the guidance
       documents for a list of the valid products for this sector or verify the
-      NAICS code reported in the administrative data is correct.
+      NAICS code reported in the Administrative Data is correct.
     </Alert>
   );
 
   const noProductsToSelect = (
     <Alert variant="danger">
       <strong>Warning:</strong> No products were found matching the reported
-      NAICS code. Please verify the NAICS code reported in the administrative
-      data.
+      NAICS code. Please verify the NAICS code reported in the Administrative
+      Data.
     </Alert>
   );
 

--- a/app/containers/Forms/ProductField.tsx
+++ b/app/containers/Forms/ProductField.tsx
@@ -86,14 +86,14 @@ export const ProductFieldComponent: React.FunctionComponent<Props> = (
       <strong>Warning:</strong> This Product or Service is not associated with
       the NAICS code reported in this application. Please review the guidance
       documents for a list of the valid products for this sector or verify the
-      NAICS code reported in the Administration data is correct.
+      NAICS code reported in the administrative data is correct.
     </Alert>
   );
 
   const noProductsToSelect = (
     <Alert variant="danger">
       <strong>Warning:</strong> No products were found matching the reported
-      NAICS code. Please verify the NAICS code reported in the Administration
+      NAICS code. Please verify the NAICS code reported in the administrative
       data.
     </Alert>
   );

--- a/app/cypress/integration/accessibility/reporter-all-pages-accessibility.spec.js
+++ b/app/cypress/integration/accessibility/reporter-all-pages-accessibility.spec.js
@@ -40,7 +40,7 @@ describe('When logged in as a reporter', () => {
     const formId = window.btoa('["form_jsons",5]');
     cy.visit(`/reporter/application/${applicationId}?formId=${formId}`);
     cy.get('#page-content');
-    cy.contains('Administration');
+    cy.contains('Administrative Data');
     cy.injectAxe();
     cy.get('#page-content');
     cy.checkA11y();
@@ -52,7 +52,7 @@ describe('When logged in as a reporter', () => {
     const formId = window.btoa('["form_jsons",2]');
     cy.visit(`/reporter/application/${applicationId}?formId=${formId}`);
     cy.get('#page-content');
-    cy.contains('Emission');
+    cy.contains('SWRS Onsite Emissions');
     cy.injectAxe();
     cy.get('#page-content');
     cy.checkA11y();
@@ -64,7 +64,7 @@ describe('When logged in as a reporter', () => {
     const formId = window.btoa('["form_jsons",3]');
     cy.visit(`/reporter/application/${applicationId}?formId=${formId}`);
     cy.get('#page-content');
-    cy.contains('Fuel');
+    cy.contains('Fuels');
     cy.injectAxe();
     cy.get('#page-content');
     cy.checkA11y();
@@ -76,7 +76,7 @@ describe('When logged in as a reporter', () => {
     const formId = window.btoa('["form_jsons",4]');
     cy.visit(`/reporter/application/${applicationId}?formId=${formId}`);
     cy.get('#page-content');
-    cy.contains('Production');
+    cy.contains('Production and Emissions Allocation');
     cy.injectAxe();
     cy.get('#page-content');
     cy.checkA11y();

--- a/app/cypress/integration/analyst-diffing.spec.js
+++ b/app/cypress/integration/analyst-diffing.spec.js
@@ -17,10 +17,10 @@ describe('When reviewing a submitted application as an analyst', () => {
     cy.get('#dropdown-old').contains('Version 1');
     cy.get('#dropdown-new').contains('current');
     cy.get('.admin-2020')
-      .get('#administration-data_operator_name-diffFrom')
+      .get('#administrative-data_operator_name-diffFrom')
       .contains('Changed_0');
     cy.get('.admin-2020')
-      .get('#administration-data_operator_name-diffTo')
+      .get('#administrative-data_operator_name-diffTo')
       .contains('Changed_5');
     cy.get('.emission').get('.diffFrom').contains('6');
     cy.get('.emission').get('.diffTo').contains('11');

--- a/app/cypress/integration/application-form-validation.spec.js
+++ b/app/cypress/integration/application-form-validation.spec.js
@@ -104,10 +104,10 @@ describe('When viewing an application in draft as a reporter', () => {
 
     cy.visit(summaryPageUrl);
 
-    cy.get('#administration-data_comments').contains(comment);
+    cy.get('#administrative-data_comments').contains(comment);
 
     // Format error messages for should be explicit
-    cy.get('#administration-data_operator_naics ~div .text-danger').contains(
+    cy.get('#administrative-data_operator_naics ~div .text-danger').contains(
       'is a required property'
     );
     cy.get('.admin-2020 > .collapse').contains(

--- a/app/cypress/integration/application-form-validation.spec.js
+++ b/app/cypress/integration/application-form-validation.spec.js
@@ -151,9 +151,9 @@ describe('When viewing an application in draft as a reporter', () => {
 
     cy.get('div.card-header').contains('Form input saved');
     cy.contains('Continue').click();
-    cy.get('#page-content h1').contains('Emission');
+    cy.get('#page-content h1').contains('SWRS Onsite Emissions');
     cy.visit(summaryPageUrl);
-    cy.contains('Administration Data');
+    cy.contains('Administrative Data');
     cy.get('.admin-2020.summary-card').happoScreenshot({
       component: 'Admin Summary Card',
       variant: 'no errors'

--- a/app/cypress/integration/override-justification.spec.js
+++ b/app/cypress/integration/override-justification.spec.js
@@ -73,7 +73,7 @@ describe('When an application does not have errors', () => {
 
   it('The override justification box should not appear', () => {
     cy.mockLogin('reporter');
-    const applicationId = window.btoa('["applications", 2]');
+    const applicationId = window.btoa('["applications",2]');
     cy.visit(`/reporter/application/${applicationId}?confirmationPage=true`);
     cy.url().should('include', '/reporter/application');
     cy.get('.btn').contains('Submit Application');

--- a/app/cypress/integration/override-justification.spec.js
+++ b/app/cypress/integration/override-justification.spec.js
@@ -80,7 +80,7 @@ describe('When an application does not have errors', () => {
     cy.get('.override-accordion > .btn').should('not.exist');
   });
 
-  it('the justification should be automatically deleted if no more errors exist', () => {
+  it('The justification should be automatically deleted if no more errors exist', () => {
     cy.mockLogin('reporter');
     const applicationId = window.btoa('["applications",2]');
     cy.visit(`/reporter/application/${applicationId}?confirmationPage=true`);
@@ -104,7 +104,7 @@ describe('When an application does not have errors', () => {
     cy.get('.card-header').contains('Form input saved');
 
     cy.get('.nav-guide > :nth-child(5)').click();
-    cy.get('#administration-data_operator_name').should('contain', 'whoops');
+    cy.get('#administrative-data_operator_name').should('contain', 'whoops');
     cy.get('.override-accordion > .btn').should('not.exist');
     cy.get(':nth-child(1) > .nav-link').click();
     cy.get('#root_operator_name').clear();

--- a/app/tests/unit/containers/Forms/__snapshots__/ProductField.test.tsx.snap
+++ b/app/tests/unit/containers/Forms/__snapshots__/ProductField.test.tsx.snap
@@ -187,7 +187,7 @@ exports[`The ProductionFields Component with archived product not matched to a n
     <strong>
       Warning:
     </strong>
-     This Product or Service is not associated with the NAICS code reported in this application. Please review the guidance documents for a list of the valid products for this sector or verify the NAICS code reported in the Administration data is correct.
+     This Product or Service is not associated with the NAICS code reported in this application. Please review the guidance documents for a list of the valid products for this sector or verify the NAICS code reported in the administrative data is correct.
   </Alert>
   <ObjectField
     autofocus={false}
@@ -326,7 +326,7 @@ exports[`The ProductionFields Component with no naics code should match the snap
     <strong>
       Warning:
     </strong>
-     No products were found matching the reported NAICS code. Please verify the NAICS code reported in the Administration data.
+     No products were found matching the reported NAICS code. Please verify the NAICS code reported in the administrative data.
   </Alert>
   <ObjectField
     autofocus={false}
@@ -539,7 +539,7 @@ exports[`The ProductionFields Component with published product not matched to a 
     <strong>
       Warning:
     </strong>
-     This Product or Service is not associated with the NAICS code reported in this application. Please review the guidance documents for a list of the valid products for this sector or verify the NAICS code reported in the Administration data is correct.
+     This Product or Service is not associated with the NAICS code reported in this application. Please review the guidance documents for a list of the valid products for this sector or verify the NAICS code reported in the administrative data is correct.
   </Alert>
   <ObjectField
     autofocus={false}

--- a/app/tests/unit/containers/Forms/__snapshots__/ProductField.test.tsx.snap
+++ b/app/tests/unit/containers/Forms/__snapshots__/ProductField.test.tsx.snap
@@ -187,7 +187,7 @@ exports[`The ProductionFields Component with archived product not matched to a n
     <strong>
       Warning:
     </strong>
-     This Product or Service is not associated with the NAICS code reported in this application. Please review the guidance documents for a list of the valid products for this sector or verify the NAICS code reported in the administrative data is correct.
+     This Product or Service is not associated with the NAICS code reported in this application. Please review the guidance documents for a list of the valid products for this sector or verify the NAICS code reported in the Administrative Data is correct.
   </Alert>
   <ObjectField
     autofocus={false}
@@ -326,7 +326,7 @@ exports[`The ProductionFields Component with no naics code should match the snap
     <strong>
       Warning:
     </strong>
-     No products were found matching the reported NAICS code. Please verify the NAICS code reported in the administrative data.
+     No products were found matching the reported NAICS code. Please verify the NAICS code reported in the Administrative Data.
   </Alert>
   <ObjectField
     autofocus={false}
@@ -539,7 +539,7 @@ exports[`The ProductionFields Component with published product not matched to a 
     <strong>
       Warning:
     </strong>
-     This Product or Service is not associated with the NAICS code reported in this application. Please review the guidance documents for a list of the valid products for this sector or verify the NAICS code reported in the administrative data is correct.
+     This Product or Service is not associated with the NAICS code reported in this application. Please review the guidance documents for a list of the valid products for this sector or verify the NAICS code reported in the Administrative Data is correct.
   </Alert>
   <ObjectField
     autofocus={false}

--- a/schema/data/prod/form_json.sql
+++ b/schema/data/prod/form_json.sql
@@ -21,15 +21,15 @@ with rows as (
 insert into ggircs_portal.form_json
   (name, slug, short_name, description, form_json, prepopulate_from_swrs, prepopulate_from_ciip, form_result_init_function, default_form_result)
 values
-  ('Administration Data', 'admin', 'Admin data', 'Admin description',
+  ('Administrative Data', 'admin', 'Admin data', 'Admin description',
   (select json_data from administration), true, true, 'init_application_administration_form_result', '{}'),
-  ('Emission', 'emission', 'Emission', 'Emission description',
+  ('SWRS Onsite Emissions', 'emission', 'Emission', 'Emission description',
   (select json_data from emission), true, false, 'init_application_emission_form_result', '{}'),
-  ('Fuel','fuel', 'Fuel', 'Fuel description',
+  ('Fuels','fuel', 'Fuel', 'Fuel description',
   (select json_data from fuel), true, false, 'init_application_fuel_form_result', '[]'),
-  ('Production', 'production', 'Production', 'Production description',
+  ('Production and Emissions Allocation', 'production', 'Production', 'Production description',
   (select json_data from production), false, false, null, '[]'),
-  ('Administration Data', 'admin-2020', 'Admin data', 'Admin description',
+  ('Administrative Data', 'admin-2020', 'Admin data', 'Admin description',
   (select json_data from administration_2020), true, true, 'init_application_administration_form_result', '{}')
 on conflict(slug) do update
 set name=excluded.name,


### PR DESCRIPTION
https://youtrack.button.is/issue/GGIRCS-1361

Tab “Administration Data” and its heading:

- Rename tab and heading to “Administrative Data”
- Rename heading “Operational Representative” to “Operation Representative”
- Rename heading “Operational Representative Mailing Address” to “Operation Representative Mailing Address”

Tab “Emission” and its heading:

- Rename tab and heading to “SWRS Onsite Emissions”.

Tab “Fuel” and its heading:

- Rename tab and heading to “Fuels”.

Tab “Production” and its heading:

- Rename tab and heading to “Production and Emissions Allocation”.


![localhost_3004_reporter_application_WyJhcHBsaWNhdGlvbnMiLDFd_applicationId=WyJhcHBsaWNhdGlvbnMiLDFd formId=WyJmb3JtX2pzb25zIiw1XQ%3D%3D confirmationPage=false](https://user-images.githubusercontent.com/35253/118862586-c1bc2100-b892-11eb-9bda-b01704909c19.png)
