### PR TITLE
Fix: show legacy form json

### DIFF
--- a/schema/data/dev/form_result.sql
+++ b/schema/data/dev/form_result.sql
@@ -703,7 +703,7 @@ begin;
     temp_row record;
   begin
     for temp_row in
-      select row_number() over () as index, form_id from ggircs_portal.ciip_application_wizard
+      select row_number() over () as index, form_id from ggircs_portal.ciip_application_wizard where is_active=true
     loop
       update ggircs_portal.form_result
         set form_result = (select dummy_result from dummy_results where id = temp_row.index)
@@ -713,7 +713,7 @@ begin;
       raise notice 'Form Result(version_number 1): % has been updated', (select name from ggircs_portal.form_json where id = temp_row.form_id);
       -- New set of form_results for diffing
       update ggircs_portal.form_result
-        set form_result = (select dummy_result from dummy_results where id = (temp_row.index + (select count(form_id) from ggircs_portal.ciip_application_wizard)))
+        set form_result = (select dummy_result from dummy_results where id = (temp_row.index + (select count(form_id) from ggircs_portal.ciip_application_wizard where is_active=true)))
         where form_id = temp_row.form_id
         and application_id in (1, 3)
         and version_number = 2;

--- a/schema/data/prod/ciip_application_wizard.sql
+++ b/schema/data/prod/ciip_application_wizard.sql
@@ -1,15 +1,15 @@
 begin;
 
-truncate table ggircs_portal.ciip_application_wizard;
-
 with rows as (
 insert into ggircs_portal.ciip_application_wizard
-  (form_id, form_position)
+  (form_id, form_position, is_active)
 values
-  ((select id from ggircs_portal.form_json where slug='admin-2020'), 0),
-  ((select id from ggircs_portal.form_json where slug='emission'), 1),
-  ((select id from ggircs_portal.form_json where slug='fuel'), 2),
-  ((select id from ggircs_portal.form_json where slug='production'), 3)
+  ((select id from ggircs_portal.form_json where slug='admin-2020'), 0, true),
+  ((select id from ggircs_portal.form_json where slug='emission'), 1, true),
+  ((select id from ggircs_portal.form_json where slug='fuel'), 2, true),
+  ((select id from ggircs_portal.form_json where slug='production'), 3, true),
+  ((select id from ggircs_portal.form_json where slug='admin'), 0, false)
+on conflict(form_id) do update set form_position=excluded.form_position, is_active=excluded.is_active
 returning 1
 ) select 'Inserted ' || count(*) || ' rows into ggircs_portal.ciip_application_wizard' from rows;
 

--- a/schema/test/unit/computed_columns/application_ordered_form_results_test.sql
+++ b/schema/test/unit/computed_columns/application_ordered_form_results_test.sql
@@ -1,0 +1,64 @@
+set client_min_messages to warning;
+create extension if not exists pgtap;
+reset client_min_messages;
+
+begin;
+select plan(3);
+
+select has_function(
+  'ggircs_portal', 'application_ordered_form_results',
+  'Function application_ordered_form_results should exist'
+);
+
+-- Init tests
+truncate ggircs_portal.organisation restart identity cascade;
+do $$
+  declare disable_triggers json;
+  begin
+    disable_triggers := '
+      {
+        "application_revision_status": ["_status_change_email"],
+        "ciip_user": ["_welcome_email"],
+        "form_result": ["_100_timestamps"]
+      }
+    ';
+    perform test_helper.modify_triggers('disable', disable_triggers);
+  end;
+$$;
+
+select test_helper.mock_open_window();
+select test_helper.create_test_users();
+select test_helper.create_applications(2, True, True);
+
+-- Set admin form_result with application_id=2 to point to a deprecated form_json
+update ggircs_portal.form_result set form_id=1 where application_id=2 and form_id=5;
+
+select id, application_id, form_id from ggircs_portal.form_result;
+
+select id, slug from ggircs_portal.form_json;
+select * from ggircs_portal.ciip_application_wizard;
+
+with record as (select row(application.*)::ggircs_portal.application from ggircs_portal.application where id=2)
+    select form_id from ggircs_portal.application_ordered_form_results((select * from record), '1') order by form_id;
+
+
+select results_eq (
+  $$
+    with record as (select row(application.*)::ggircs_portal.application from ggircs_portal.application where id=2)
+    select form_id from ggircs_portal.application_ordered_form_results((select * from record), '1');
+  $$,
+    ARRAY[1,2,3,4],
+  'application_ordered_form_results retrieves all form results with a deprecated form_json'
+);
+
+select results_eq (
+  $$
+    with record as (select row(application.*)::ggircs_portal.application from ggircs_portal.application where id=1)
+    select form_id from ggircs_portal.application_ordered_form_results((select * from record), '1');
+  $$,
+    ARRAY[5,2,3,4],
+  'application_ordered_form_results retrieves all form results with active form_json'
+);
+
+select finish();
+rollback;

--- a/schema/test/unit/computed_columns/application_ordered_form_results_test.sql
+++ b/schema/test/unit/computed_columns/application_ordered_form_results_test.sql
@@ -33,15 +33,6 @@ select test_helper.create_applications(2, True, True);
 -- Set admin form_result with application_id=2 to point to a deprecated form_json
 update ggircs_portal.form_result set form_id=1 where application_id=2 and form_id=5;
 
-select id, application_id, form_id from ggircs_portal.form_result;
-
-select id, slug from ggircs_portal.form_json;
-select * from ggircs_portal.ciip_application_wizard;
-
-with record as (select row(application.*)::ggircs_portal.application from ggircs_portal.application where id=2)
-    select form_id from ggircs_portal.application_ordered_form_results((select * from record), '1') order by form_id;
-
-
 select results_eq (
   $$
     with record as (select row(application.*)::ggircs_portal.application from ggircs_portal.application where id=2)


### PR DESCRIPTION
- Adds a pgTap test for `application_ordered_form_results()`
- Updates `data/prod/ciip_application_wizard` to use `on conflict` instead of `truncate..` & adds the inactive `admin` legacy form_json
- Small fixes to dev data to use the `is_active` column when creating dev form results