### PR TITLE
Remove defunct 'activate org access' button on localhost

### DIFF
--- a/app/containers/Organisations/Organisations.tsx
+++ b/app/containers/Organisations/Organisations.tsx
@@ -129,16 +129,6 @@ export const OrganisationsComponent: React.FunctionComponent<Props> = (
                 <h4 style={{fontWeight: 300, margin: '15px 0'}}>
                   {props.orgInput}{' '}
                 </h4>
-                {/* Dev-only button to automatically create approved user-organisation requests */}
-                {process.env.NODE_ENV === 'production' ? null : (
-                  <Button
-                    style={{marginRight: '15px'}}
-                    variant="success"
-                    onClick={async () => claimOrg(true)}
-                  >
-                    Activate Access
-                  </Button>
-                )}
                 <Button
                   style={{marginRight: '15px'}}
                   variant="primary"


### PR DESCRIPTION
This has long been defunct since the implementation of row-level security, and only serves to confuse new team members.

<img width="777" alt="Screen Shot 2021-05-20 at 5 49 07 PM" src="https://user-images.githubusercontent.com/5522075/119066071-cddbd780-b993-11eb-88a5-ccca045c73de.png">
