### PR TITLE
Convert style of dynamic toast messages to be like Bootstrap Alerts

### DIFF
--- a/app/components/helpers/Toaster.tsx
+++ b/app/components/helpers/Toaster.tsx
@@ -2,7 +2,42 @@ import React from 'react';
 import {ToastContainer} from 'react-toastify';
 
 export const Toaster: React.FunctionComponent = () => {
-  return <ToastContainer limit={3} />;
+  return (
+    <>
+      <ToastContainer limit={3} />
+      <style jsx>{`
+        :global(.Toastify__toast) {
+          display: block;
+          padding: 1rem 1.25rem;
+        }
+        :global(.Toastify__toast-body) {
+          padding: 0;
+        }
+        :global(.toastalert-error) {
+          background-color: #f8d7da;
+          border: 1px solid #d2adb1;
+          color: #721c24;
+        }
+        :global(.toastalert-success) {
+          background-color: #d4edda;
+          color: #155724;
+          border: 1px solid #9cc7a6;
+        }
+        :global(.Toastify__close-button) {
+          position: absolute;
+          top: 0.5rem;
+          right: 0.7rem;
+        }
+        :global(.Toastify__close-button--default) {
+          opacity: 1;
+          color: currentColor;
+        }
+        :global(.Toastify__progress-bar--default) {
+          background: currentColor;
+        }
+      `}</style>
+    </>
+  );
 };
 
 export default Toaster;

--- a/app/components/helpers/Toaster.tsx
+++ b/app/components/helpers/Toaster.tsx
@@ -33,7 +33,7 @@ export const Toaster: React.FunctionComponent = () => {
           color: currentColor;
         }
         :global(.Toastify__progress-bar--default) {
-          background: currentColor;
+          background: transparent;
         }
       `}</style>
     </>

--- a/app/containers/Applications/ApplicationWizardStep.tsx
+++ b/app/containers/Applications/ApplicationWizardStep.tsx
@@ -47,7 +47,7 @@ const ApplicationWizardStep: React.FunctionComponent<Props> = ({
         }
       },
       messages: {
-        failure: 'An error occured while saving your form.'
+        failure: 'An error occurred while saving your form.'
       }
     };
     await updateFormResultMutation(environment, variables);

--- a/app/containers/Products/ProductCreatorContainer.tsx
+++ b/app/containers/Products/ProductCreatorContainer.tsx
@@ -14,13 +14,11 @@ import HeaderWidget from 'components/HeaderWidget';
 interface Props {
   relay: RelayProp;
   toggleShowCreateForm: (...args: any[]) => void;
-  toggleShowProductCreatedToast: (...args: any[]) => void;
 }
 
 export const ProductCreator: React.FunctionComponent<Props> = ({
   relay,
-  toggleShowCreateForm,
-  toggleShowProductCreatedToast
+  toggleShowCreateForm
 }) => {
   const saveProduct = async (e: IChangeEvent) => {
     const variables = {
@@ -45,13 +43,14 @@ export const ProductCreator: React.FunctionComponent<Props> = ({
             e.formData.subtractGeneratedHeatEmissions,
           requiresProductAmount: e.formData.requiresProductAmount
         }
+      },
+      messages: {
+        success: 'Product created successfully.'
       }
     };
     const {environment} = relay;
-    const response = await createProductMutation(environment, variables);
+    await createProductMutation(environment, variables);
     toggleShowCreateForm();
-    if (response.createProduct) toggleShowProductCreatedToast(true);
-    else console.log(response);
   };
 
   return (

--- a/app/mutations/BaseMutation.ts
+++ b/app/mutations/BaseMutation.ts
@@ -75,9 +75,9 @@ export default class BaseMutation<T extends BaseMutationType = never> {
             reject(error);
             if (failureMessage) {
               toast(failureMessage, {
-                className: 'mutation-toast Toastify__toast--error',
+                className: 'toastalert-error',
                 autoClose: false,
-                position: 'bottom-right',
+                position: 'top-center',
                 // Don't show duplicate errors if the same mutation fails several times in a row
                 toastId: mutationName
               });
@@ -91,9 +91,9 @@ export default class BaseMutation<T extends BaseMutationType = never> {
             errors ? reject(errors) : resolve(response);
             if (successMessage) {
               toast(successMessage, {
-                className: 'mutation-toast Toastify__toast--success',
+                className: 'toastalert-success',
                 autoClose: 5000,
-                position: 'bottom-right'
+                position: 'top-center'
               });
             }
           }

--- a/app/pages/admin/products-benchmarks.tsx
+++ b/app/pages/admin/products-benchmarks.tsx
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import {graphql} from 'react-relay';
-import {Row, Col, Button, Toast} from 'react-bootstrap';
+import {Row, Col, Button} from 'react-bootstrap';
 import {productsBenchmarksQueryResponse} from 'productsBenchmarksQuery.graphql';
 import DefaultLayout from 'layouts/default-layout';
 import ProductCreatorContainer from 'containers/Products/ProductCreatorContainer';
@@ -52,8 +52,7 @@ class ProductsBenchmarks extends Component<Props> {
   state = {
     formData: {formId: '', formJson: ''},
     mode: 'view',
-    expandCreateForm: false,
-    showProductCreatedToast: false
+    expandCreateForm: false
   };
 
   static async getInitialProps() {
@@ -65,10 +64,6 @@ class ProductsBenchmarks extends Component<Props> {
       }
     };
   }
-
-  toggleShowProductCreatedToast = (show: boolean) => {
-    this.setState({showProductCreatedToast: show});
-  };
 
   toggleShowCreateForm = () => {
     const expanded = this.state.expandCreateForm;
@@ -111,28 +106,10 @@ class ProductsBenchmarks extends Component<Props> {
         titleControls={newProductButton}
       >
         <Row>
-          <Col md={{span: 4, offset: 4}}>
-            <Toast
-              autohide
-              show={this.state.showProductCreatedToast}
-              delay={4000}
-              onClose={() => this.toggleShowProductCreatedToast(false)}
-            >
-              <Toast.Body style={{textAlign: 'center', color: 'green'}}>
-                Product created successfully!
-              </Toast.Body>
-            </Toast>
-            <br />
-          </Col>
-        </Row>
-        <Row>
           <Col>
             {this.state.expandCreateForm && (
               <ProductCreatorContainer
                 toggleShowCreateForm={this.toggleShowCreateForm}
-                toggleShowProductCreatedToast={
-                  this.toggleShowProductCreatedToast
-                }
               />
             )}
             <ProductListContainer query={query} />

--- a/app/static/base.css
+++ b/app/static/base.css
@@ -47,15 +47,3 @@
   display: inline-block;
   width: 30%;
 }
-.mutation-toast.Toastify__toast {
-  padding-left: 15px;
-}
-.mutation-toast .Toastify__toast-body {
-  color: white;
-}
-.mutation-toast.Toastify__toast--success {
-  background: #49b34c;
-}
-.mutation-toast .Toastify__progress-bar--default {
-  background: #add059;
-}


### PR DESCRIPTION
- Refactors the styling of the react-toastify toaster used in BaseMutation to appear similar to Bootstrap Alerts, which we use for static user messaging
  - top center placement
- Converts the `/admin/products-benchmarks` page to use the BaseMutation success message instead of [yet another](https://react-bootstrap.netlify.app/components/toasts/) different Toast

[GGIRCS-1639](https://youtrack.button.is/issue/GGIRCS-1639)

<img width="1440" alt="Screen Shot 2021-05-21 at 12 29 48 PM" src="https://user-images.githubusercontent.com/5522075/119194491-00d7a700-ba38-11eb-8384-955c03df7c6a.png">
<img width="1440" alt="Screen Shot 2021-05-21 at 12 58 01 PM" src="https://user-images.githubusercontent.com/5522075/119194497-046b2e00-ba38-11eb-8ac0-072a41c106c7.png">
