### PR TITLE
Bugfixes: Prevent "Resume" button flash on Revise + show version number when viewing submitted

### DIFF
--- a/app/pages/reporter/application/[applicationId]/version/[versionNumber]/view.tsx
+++ b/app/pages/reporter/application/[applicationId]/version/[versionNumber]/view.tsx
@@ -153,12 +153,15 @@ class ViewApplication extends Component<Props> {
       <div>
         Application ID: {application?.rowId}
         <br />
-        {thisVersion > 1 && (
-          <>
-            Version: {application?.latestDraftRevision.versionNumber}
-            <br />
-          </>
-        )}
+        {
+          // @ts-ignore
+          this.state.newerDraftExists && (
+            <>
+              Version: {thisVersion}
+              <br />
+            </>
+          )
+        }
         BC GHG ID: {application?.facilityByFacilityId.bcghgid}
       </div>
     );

--- a/app/pages/reporter/application/[applicationId]/version/[versionNumber]/view.tsx
+++ b/app/pages/reporter/application/[applicationId]/version/[versionNumber]/view.tsx
@@ -72,7 +72,18 @@ class ViewApplication extends Component<Props> {
     }
   `;
 
-  state = {newerDraftExists: undefined};
+  constructor(props) {
+    super(props);
+    const latestSubmittedRevision =
+      props.query.application?.latestSubmittedRevision?.versionNumber;
+    const latestDraftRevision =
+      props.query.application?.latestDraftRevision?.versionNumber;
+    // Disabling in order to initialize state based on props:
+    // eslint-disable-next-line react/state-in-constructor
+    this.state = {
+      newerDraftExists: latestDraftRevision > latestSubmittedRevision
+    };
+  }
 
   render() {
     const {session} = this.props.query;
@@ -102,18 +113,9 @@ class ViewApplication extends Component<Props> {
 
     const thisVersion = Number(router.query.versionNumber);
     const latestSubmittedRevision =
-      application.latestSubmittedRevision?.versionNumber;
-    const latestDraftRevision = application.latestDraftRevision?.versionNumber;
+      application?.latestSubmittedRevision?.versionNumber;
 
     const newerSubmissionExists = latestSubmittedRevision > thisVersion;
-    if (this.state.newerDraftExists === undefined) {
-      this.setState((state) => {
-        return {
-          ...state,
-          newerDraftExists: latestDraftRevision > latestSubmittedRevision
-        };;
-      });
-    }
     const latestSubmissionHref = getViewApplicationPageRoute(
       router.query.applicationId.toString(),
       latestSubmittedRevision
@@ -149,15 +151,15 @@ class ViewApplication extends Component<Props> {
 
     const applicationInfo = (
       <div>
-        Application ID: {application.rowId}
+        Application ID: {application?.rowId}
         <br />
         {thisVersion > 1 && (
           <>
-            Version: {application.latestDraftRevision.versionNumber}
+            Version: {application?.latestDraftRevision.versionNumber}
             <br />
           </>
         )}
-        BC GHG ID: {application.facilityByFacilityId.bcghgid}
+        BC GHG ID: {application?.facilityByFacilityId.bcghgid}
       </div>
     );
 
@@ -184,21 +186,26 @@ class ViewApplication extends Component<Props> {
                 >
                   {changesRequested &&
                     !newerSubmissionExists &&
+                    // @ts-ignore
                     !this.state.newerDraftExists && (
                       <ReviseApplicationButton
                         application={query.application}
                       />
                     )}
-                  {this.state.newerDraftExists &&
-                    !newerSubmissionExists &&
-                    resumeLatestDraftButton}
+                  {
+                    // @ts-ignore
+                    this.state.newerDraftExists &&
+                      !newerSubmissionExists &&
+                      resumeLatestDraftButton
+                  }
                 </ApplicationDecision>
               </>
             )}
             <ApplicationDetails
               query={query}
+              diffQuery={null}
               applicationRevision={
-                application.applicationRevisionByStringVersionNumber
+                application?.applicationRevisionByStringVersionNumber
               }
               review={false}
               liveValidate={false}

--- a/app/pages/reporter/application/[applicationId]/version/[versionNumber]/view.tsx
+++ b/app/pages/reporter/application/[applicationId]/version/[versionNumber]/view.tsx
@@ -72,6 +72,8 @@ class ViewApplication extends Component<Props> {
     }
   `;
 
+  state = {newerDraftExists: undefined};
+
   render() {
     const {session} = this.props.query;
     const {query, router} = this.props;
@@ -104,8 +106,14 @@ class ViewApplication extends Component<Props> {
     const latestDraftRevision = application.latestDraftRevision?.versionNumber;
 
     const newerSubmissionExists = latestSubmittedRevision > thisVersion;
-    const newerDraftExists = latestDraftRevision > latestSubmittedRevision;
-
+    if (this.state.newerDraftExists === undefined) {
+      this.setState((state) => {
+        return {
+          ...state,
+          newerDraftExists: latestDraftRevision > latestSubmittedRevision
+        };;
+      });
+    }
     const latestSubmissionHref = getViewApplicationPageRoute(
       router.query.applicationId.toString(),
       latestSubmittedRevision
@@ -176,12 +184,12 @@ class ViewApplication extends Component<Props> {
                 >
                   {changesRequested &&
                     !newerSubmissionExists &&
-                    !newerDraftExists && (
+                    !this.state.newerDraftExists && (
                       <ReviseApplicationButton
                         application={query.application}
                       />
                     )}
-                  {newerDraftExists &&
+                  {this.state.newerDraftExists &&
                     !newerSubmissionExists &&
                     resumeLatestDraftButton}
                 </ApplicationDecision>

--- a/app/pages/reporter/application/[applicationId]/version/[versionNumber]/view.tsx
+++ b/app/pages/reporter/application/[applicationId]/version/[versionNumber]/view.tsx
@@ -107,6 +107,7 @@ class ViewApplication extends Component<Props> {
     const thisVersion = Number(router.query.versionNumber);
     const latestSubmittedRevision =
       application?.latestSubmittedRevision?.versionNumber;
+    const latestDraftRevision = application?.latestDraftRevision?.versionNumber;
 
     const newerSubmissionExists = latestSubmittedRevision > thisVersion;
     const latestSubmissionHref = getViewApplicationPageRoute(
@@ -146,7 +147,7 @@ class ViewApplication extends Component<Props> {
       <div>
         Application ID: {application?.rowId}
         <br />
-        {this.state.newerDraftExists && (
+        {latestDraftRevision > 1 && (
           <>
             Version: {thisVersion}
             <br />

--- a/app/pages/reporter/application/[applicationId]/version/[versionNumber]/view.tsx
+++ b/app/pages/reporter/application/[applicationId]/version/[versionNumber]/view.tsx
@@ -72,18 +72,11 @@ class ViewApplication extends Component<Props> {
     }
   `;
 
-  constructor(props) {
-    super(props);
-    const latestSubmittedRevision =
-      props.query.application?.latestSubmittedRevision?.versionNumber;
-    const latestDraftRevision =
-      props.query.application?.latestDraftRevision?.versionNumber;
-    // Disabling in order to initialize state based on props:
-    // eslint-disable-next-line react/state-in-constructor
-    this.state = {
-      newerDraftExists: latestDraftRevision > latestSubmittedRevision
-    };
-  }
+  state = {
+    newerDraftExists:
+      this.props.query.application?.latestDraftRevision?.versionNumber >
+      this.props.query.application?.latestSubmittedRevision?.versionNumber
+  };
 
   render() {
     const {session} = this.props.query;
@@ -153,15 +146,12 @@ class ViewApplication extends Component<Props> {
       <div>
         Application ID: {application?.rowId}
         <br />
-        {
-          // @ts-ignore
-          this.state.newerDraftExists && (
-            <>
-              Version: {thisVersion}
-              <br />
-            </>
-          )
-        }
+        {this.state.newerDraftExists && (
+          <>
+            Version: {thisVersion}
+            <br />
+          </>
+        )}
         BC GHG ID: {application?.facilityByFacilityId.bcghgid}
       </div>
     );
@@ -189,18 +179,14 @@ class ViewApplication extends Component<Props> {
                 >
                   {changesRequested &&
                     !newerSubmissionExists &&
-                    // @ts-ignore
                     !this.state.newerDraftExists && (
                       <ReviseApplicationButton
                         application={query.application}
                       />
                     )}
-                  {
-                    // @ts-ignore
-                    this.state.newerDraftExists &&
-                      !newerSubmissionExists &&
-                      resumeLatestDraftButton
-                  }
+                  {this.state.newerDraftExists &&
+                    !newerSubmissionExists &&
+                    resumeLatestDraftButton}
                 </ApplicationDecision>
               </>
             )}

--- a/app/tests/unit/pages/reporter/application/[applicationId]/version/[versionNumber]/__snapshots__/view.test.tsx.snap
+++ b/app/tests/unit/pages/reporter/application/[applicationId]/version/[versionNumber]/__snapshots__/view.test.tsx.snap
@@ -398,6 +398,11 @@ exports[`View submitted application page should render a "View most recent submi
       Application ID: 
       1
       <br />
+      <React.Fragment>
+        Version: 
+        1
+        <br />
+      </React.Fragment>
       BC GHG ID: 
       123456
     </div>

--- a/app/tests/unit/pages/reporter/application/[applicationId]/version/[versionNumber]/__snapshots__/view.test.tsx.snap
+++ b/app/tests/unit/pages/reporter/application/[applicationId]/version/[versionNumber]/__snapshots__/view.test.tsx.snap
@@ -16,6 +16,11 @@ exports[`View submitted application page displays a "Resume latest draft" button
       Application ID: 
       1
       <br />
+      <React.Fragment>
+        Version: 
+        1
+        <br />
+      </React.Fragment>
       BC GHG ID: 
       123456
     </div>
@@ -550,6 +555,11 @@ exports[`View submitted application page should render a "View most recent submi
       Application ID: 
       1
       <br />
+      <React.Fragment>
+        Version: 
+        1
+        <br />
+      </React.Fragment>
       BC GHG ID: 
       123456
     </div>

--- a/app/tests/unit/pages/reporter/application/[applicationId]/version/[versionNumber]/__snapshots__/view.test.tsx.snap
+++ b/app/tests/unit/pages/reporter/application/[applicationId]/version/[versionNumber]/__snapshots__/view.test.tsx.snap
@@ -70,6 +70,7 @@ exports[`View submitted application page displays a "Resume latest draft" button
             },
           }
         }
+        diffQuery={null}
         liveValidate={false}
         query={
           Object {
@@ -219,6 +220,7 @@ exports[`View submitted application page displays a "Revise" button when changes
             },
           }
         }
+        diffQuery={null}
         liveValidate={false}
         query={
           Object {
@@ -314,6 +316,7 @@ exports[`View submitted application page does not show an application decision w
             },
           }
         }
+        diffQuery={null}
         liveValidate={false}
         query={
           Object {
@@ -470,6 +473,7 @@ exports[`View submitted application page should render a "View most recent submi
             },
           }
         }
+        diffQuery={null}
         liveValidate={false}
         query={
           Object {
@@ -626,6 +630,7 @@ exports[`View submitted application page should render a "View most recent submi
             },
           }
         }
+        diffQuery={null}
         liveValidate={false}
         query={
           Object {
@@ -730,6 +735,7 @@ exports[`View submitted application page shows approval when reviewed and approv
             },
           }
         }
+        diffQuery={null}
         liveValidate={false}
         query={
           Object {
@@ -834,6 +840,7 @@ exports[`View submitted application page shows rejection when reviewed and rejec
             },
           }
         }
+        diffQuery={null}
         liveValidate={false}
         query={
           Object {
@@ -938,6 +945,7 @@ exports[`View submitted application page shows reviewer comments when reviewed a
             },
           }
         }
+        diffQuery={null}
         liveValidate={false}
         query={
           Object {

--- a/app/tests/unit/pages/reporter/application/[applicationId]/version/[versionNumber]/view.test.tsx
+++ b/app/tests/unit/pages/reporter/application/[applicationId]/version/[versionNumber]/view.test.tsx
@@ -165,6 +165,7 @@ describe('View submitted application page', () => {
     expect(
       r.find('ApplicationDecision').first().prop('reviewComments')[0]
     ).toBe(comments[0]);
+    expect(r.find('Relay(ReviseApplicationButton)').exists()).toBeTrue();
     expect(r).toMatchSnapshot();
   });
 
@@ -180,6 +181,7 @@ describe('View submitted application page', () => {
       }
     };
     const r = shallow(<ViewApplication query={query} router={router} />);
+    expect(r.find('Relay(ReviseApplicationButton)').exists()).toBeFalse();
     expect(r.exists('Button')).toBe(true);
     expect(r.find('Button').text()).toBe('Resume latest draft');
     expect(r).toMatchSnapshot();


### PR DESCRIPTION
- [GGIRCS-2325](https://youtrack.button.is/issue/GGIRCS-2325) Uses state to hold `newerDraftExists` variable when presenting the option to revise to prevent flashing "Resume latest draft" after clicking Revise
- [GGIRCS-2457](https://youtrack.button.is/issue/GGIRCS-2457)
  - Part A: Show the correct version number when viewing a submitted application
  - Part B: When viewing submitted applications that have subsequent drafts, the version number should be shown