### PR TITLE
fix: fixing double-margin around flex table cell

### DIFF
--- a/app/components/FilterableTable/FilterableTableFilterRow.tsx
+++ b/app/components/FilterableTable/FilterableTableFilterRow.tsx
@@ -46,17 +46,19 @@ const FilterableTableFilterRow: React.FunctionComponent<Props> = ({
           onChange={handleFilterChange}
         />
       ))}
-      <td className="flex">
-        <Button variant="outline-secondary" onClick={clearForm}>
-          Clear
-        </Button>
-        <Button
-          style={{marginLeft: '5px'}}
-          variant="primary"
-          onClick={() => onSubmit(searchFilters)}
-        >
-          Apply
-        </Button>
+      <td>
+        <div className="flex">
+          <Button variant="outline-secondary" onClick={clearForm}>
+            Clear
+          </Button>
+          <Button
+            style={{marginLeft: '5px'}}
+            variant="primary"
+            onClick={() => onSubmit(searchFilters)}
+          >
+            Apply
+          </Button>
+        </div>
       </td>
       <style jsx>{`
         .flex {

--- a/app/tests/unit/components/FilterableTable/__snapshots__/FilterableTable.test.tsx.snap
+++ b/app/tests/unit/components/FilterableTable/__snapshots__/FilterableTable.test.tsx.snap
@@ -30,36 +30,28 @@ Array [
           onKeyDown={[Function]}
         >
           <td
-            className="jsx-870174952 flex"
+            className="jsx-870174952"
           >
-            <Button
-              active={false}
-              disabled={false}
-              onClick={[Function]}
-              variant="outline-secondary"
+            <div
+              className="jsx-870174952 flex"
             >
-              <button
-                className="btn btn-outline-secondary"
+              <Button
+                active={false}
                 disabled={false}
                 onClick={[Function]}
-                type="button"
+                variant="outline-secondary"
               >
-                Clear
-              </button>
-            </Button>
-            <Button
-              active={false}
-              disabled={false}
-              onClick={[Function]}
-              style={
-                Object {
-                  "marginLeft": "5px",
-                }
-              }
-              variant="primary"
-            >
-              <button
-                className="btn btn-primary"
+                <button
+                  className="btn btn-outline-secondary"
+                  disabled={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  Clear
+                </button>
+              </Button>
+              <Button
+                active={false}
                 disabled={false}
                 onClick={[Function]}
                 style={
@@ -67,11 +59,23 @@ Array [
                     "marginLeft": "5px",
                   }
                 }
-                type="button"
+                variant="primary"
               >
-                Apply
-              </button>
-            </Button>
+                <button
+                  className="btn btn-primary"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "marginLeft": "5px",
+                    }
+                  }
+                  type="button"
+                >
+                  Apply
+                </button>
+              </Button>
+            </div>
           </td>
         </tr>
       </thead>

--- a/app/tests/unit/components/FilterableTable/__snapshots__/FilterableTableFilterRow.test.tsx.snap
+++ b/app/tests/unit/components/FilterableTable/__snapshots__/FilterableTableFilterRow.test.tsx.snap
@@ -28,36 +28,28 @@ exports[`The filterable table headers component only renders elements that are s
         </FormControl>
       </td>
       <td
-        className="jsx-870174952 flex"
+        className="jsx-870174952"
       >
-        <Button
-          active={false}
-          disabled={false}
-          onClick={[Function]}
-          variant="outline-secondary"
+        <div
+          className="jsx-870174952 flex"
         >
-          <button
-            className="btn btn-outline-secondary"
+          <Button
+            active={false}
             disabled={false}
             onClick={[Function]}
-            type="button"
+            variant="outline-secondary"
           >
-            Clear
-          </button>
-        </Button>
-        <Button
-          active={false}
-          disabled={false}
-          onClick={[Function]}
-          style={
-            Object {
-              "marginLeft": "5px",
-            }
-          }
-          variant="primary"
-        >
-          <button
-            className="btn btn-primary"
+            <button
+              className="btn btn-outline-secondary"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              Clear
+            </button>
+          </Button>
+          <Button
+            active={false}
             disabled={false}
             onClick={[Function]}
             style={
@@ -65,11 +57,23 @@ exports[`The filterable table headers component only renders elements that are s
                 "marginLeft": "5px",
               }
             }
-            type="button"
+            variant="primary"
           >
-            Apply
-          </button>
-        </Button>
+            <button
+              className="btn btn-primary"
+              disabled={false}
+              onClick={[Function]}
+              style={
+                Object {
+                  "marginLeft": "5px",
+                }
+              }
+              type="button"
+            >
+              Apply
+            </button>
+          </Button>
+        </div>
       </td>
     </tr>
   </thead>
@@ -120,36 +124,28 @@ exports[`The filterable table headers component renders as many td elements as s
         </FormControl>
       </td>
       <td
-        className="jsx-870174952 flex"
+        className="jsx-870174952"
       >
-        <Button
-          active={false}
-          disabled={false}
-          onClick={[Function]}
-          variant="outline-secondary"
+        <div
+          className="jsx-870174952 flex"
         >
-          <button
-            className="btn btn-outline-secondary"
+          <Button
+            active={false}
             disabled={false}
             onClick={[Function]}
-            type="button"
+            variant="outline-secondary"
           >
-            Clear
-          </button>
-        </Button>
-        <Button
-          active={false}
-          disabled={false}
-          onClick={[Function]}
-          style={
-            Object {
-              "marginLeft": "5px",
-            }
-          }
-          variant="primary"
-        >
-          <button
-            className="btn btn-primary"
+            <button
+              className="btn btn-outline-secondary"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              Clear
+            </button>
+          </Button>
+          <Button
+            active={false}
             disabled={false}
             onClick={[Function]}
             style={
@@ -157,11 +153,23 @@ exports[`The filterable table headers component renders as many td elements as s
                 "marginLeft": "5px",
               }
             }
-            type="button"
+            variant="primary"
           >
-            Apply
-          </button>
-        </Button>
+            <button
+              className="btn btn-primary"
+              disabled={false}
+              onClick={[Function]}
+              style={
+                Object {
+                  "marginLeft": "5px",
+                }
+              }
+              type="button"
+            >
+              Apply
+            </button>
+          </Button>
+        </div>
       </td>
     </tr>
   </thead>
@@ -176,36 +184,28 @@ exports[`The filterable table headers component renders search and reset buttons
       onKeyDown={[Function]}
     >
       <td
-        className="jsx-870174952 flex"
+        className="jsx-870174952"
       >
-        <Button
-          active={false}
-          disabled={false}
-          onClick={[Function]}
-          variant="outline-secondary"
+        <div
+          className="jsx-870174952 flex"
         >
-          <button
-            className="btn btn-outline-secondary"
+          <Button
+            active={false}
             disabled={false}
             onClick={[Function]}
-            type="button"
+            variant="outline-secondary"
           >
-            Clear
-          </button>
-        </Button>
-        <Button
-          active={false}
-          disabled={false}
-          onClick={[Function]}
-          style={
-            Object {
-              "marginLeft": "5px",
-            }
-          }
-          variant="primary"
-        >
-          <button
-            className="btn btn-primary"
+            <button
+              className="btn btn-outline-secondary"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              Clear
+            </button>
+          </Button>
+          <Button
+            active={false}
             disabled={false}
             onClick={[Function]}
             style={
@@ -213,11 +213,23 @@ exports[`The filterable table headers component renders search and reset buttons
                 "marginLeft": "5px",
               }
             }
-            type="button"
+            variant="primary"
           >
-            Apply
-          </button>
-        </Button>
+            <button
+              className="btn btn-primary"
+              disabled={false}
+              onClick={[Function]}
+              style={
+                Object {
+                  "marginLeft": "5px",
+                }
+              }
+              type="button"
+            >
+              Apply
+            </button>
+          </Button>
+        </div>
       </td>
     </tr>
   </thead>


### PR DESCRIPTION
Fixing an issue where setting `display: flex` on a single `<td>` element would cause small rendering issues in a bootstrap table.

![image](https://user-images.githubusercontent.com/11507754/119728948-eaab5b80-be28-11eb-939a-9c120e653cf9.png)
