### PR TITLE
fix: display 2019 NAICS codes

### DIFF
--- a/schema/data/prod/form_json/administration.json
+++ b/schema/data/prod/form_json/administration.json
@@ -143,9 +143,7 @@
     "operator": {
       "naics": {
         "ui:col-md": 8,
-        "ui:field": "naics",
-        "ui:widget": "SearchWidget",
-        "ui:placeholder": "Search NAICS..."
+        "ui:field": "naics_2019"
       },
       "ui:order": [
         "name",


### PR DESCRIPTION
Makes it so the 2019 admin form does not use the custom NAICS field. This allows invalid NAICS codes that were entered for 2019 applications before we restricted and validated the input to render