### PR TITLE
fix: new products can be edited

### DIFF
--- a/app/mutations/product/createProductMutation.ts
+++ b/app/mutations/product/createProductMutation.ts
@@ -11,20 +11,7 @@ const mutation = graphql`
     createProduct(input: $input) {
       productEdge {
         node {
-          id
-          productName
-          units
-          requiresEmissionAllocation
-          productState
-          isCiipProduct
-          isEnergyProduct
-          addPurchasedElectricityEmissions
-          subtractExportedElectricityEmissions
-          addPurchasedHeatEmissions
-          subtractExportedHeatEmissions
-          subtractGeneratedElectricityEmissions
-          subtractGeneratedHeatEmissions
-          requiresProductAmount
+          ...ProductRowItemContainer_product
         }
       }
     }


### PR DESCRIPTION
updating the create product mutation so that the relay store receives empty lists for benchmarks and linked products