### PR TITLE
Contrast and text accessibility fixes

### DIFF
--- a/app/components/FilterableTable/FilterableTablePagination.tsx
+++ b/app/components/FilterableTable/FilterableTablePagination.tsx
@@ -116,6 +116,13 @@ const FilterableTablePagination: React.FunctionComponent<Props> = ({
         .pagination {
           display: flex;
         }
+        :global(.pagination a.page-link) {
+          color: #036;
+        }
+        :global(.pagination .page-item.active .page-link) {
+          background-color: #036;
+          border-color: #036;
+        }
       `}</style>
     </>
   );

--- a/app/components/ProgressStepIndicator.tsx
+++ b/app/components/ProgressStepIndicator.tsx
@@ -46,10 +46,14 @@ const NumberedCircle: React.FunctionComponent<NumberCircleProps> = ({
         .numberedCircle {
           margin-top: -1.75rem;
           width: 2.44rem;
+          height: 2.44rem;
           line-height: 2.44rem;
           border-radius: 50%;
           text-align: center;
           font-weight: bold;
+        }
+        .numberedCircle.badge-light {
+          border: 1px solid #bfbfbf;
         }
       `}</style>
     </>

--- a/app/components/helpers/HelpButton.tsx
+++ b/app/components/helpers/HelpButton.tsx
@@ -121,7 +121,7 @@ const HelpButton: React.FunctionComponent<Props> = ({
           position: fixed;
           right: 70px;
           bottom: 94px;
-          padding: 1.6em;
+          padding: 1.4em;
           background: #fff;
           max-width: 310px;
           min-height: 80px;
@@ -152,7 +152,7 @@ const HelpButton: React.FunctionComponent<Props> = ({
           right: 0;
         }
         span[role='img'] {
-          margin-right: 0.2em;
+          margin-right: 0.5em;
         }
       `}</style>
     </>

--- a/app/containers/Applications/ApplicationDetailsCardItem.tsx
+++ b/app/containers/Applications/ApplicationDetailsCardItem.tsx
@@ -184,6 +184,10 @@ export const ApplicationDetailsCardItemComponent: React.FunctionComponent<Props>
         .diffTo {
           background-color: rgba(70, 241, 118, 0.3);
         }
+        .has-error .summary-item svg,
+        .has-error .summary-item .error-detail .text-danger {
+          color: #c70012 !important;
+        }
         .summary-form-header > .row {
           justify-content: space-between;
         }

--- a/app/tests/unit/components/FilterableTable/__snapshots__/FilterableTablePagination.test.tsx.snap
+++ b/app/tests/unit/components/FilterableTable/__snapshots__/FilterableTablePagination.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PaginationBar should not render the Pagination component if Math.ceil(totalCount / pageSize) < 2 1`] = `
 <Fragment>
   <div
-    className="jsx-285597962 pagination"
+    className="jsx-1384315916 pagination"
   >
     <Dropdown
       navbar={false}
@@ -14,7 +14,7 @@ exports[`PaginationBar should not render the Pagination component if Math.ceil(t
       >
         Items Per Page: 
         <strong
-          className="jsx-285597962"
+          className="jsx-1384315916"
         >
           20
         </strong>
@@ -70,9 +70,9 @@ exports[`PaginationBar should not render the Pagination component if Math.ceil(t
     </Dropdown>
   </div>
   <JSXStyle
-    id="285597962"
+    id="1384315916"
   >
-    .pagination.jsx-285597962{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}
+    .pagination.jsx-1384315916{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}.pagination a.page-link{color:#036;}.pagination .page-item.active .page-link{background-color:#036;border-color:#036;}
   </JSXStyle>
 </Fragment>
 `;
@@ -80,7 +80,7 @@ exports[`PaginationBar should not render the Pagination component if Math.ceil(t
 exports[`PaginationBar should render a maximum of 9 pagination pages if Math.ceil(totalCount / pageSize) > 9 1`] = `
 <Fragment>
   <div
-    className="jsx-285597962 pagination"
+    className="jsx-1384315916 pagination"
   >
     <Dropdown
       navbar={false}
@@ -91,7 +91,7 @@ exports[`PaginationBar should render a maximum of 9 pagination pages if Math.cei
       >
         Items Per Page: 
         <strong
-          className="jsx-285597962"
+          className="jsx-1384315916"
         >
           20
         </strong>
@@ -253,9 +253,9 @@ exports[`PaginationBar should render a maximum of 9 pagination pages if Math.cei
     </ForwardRef>
   </div>
   <JSXStyle
-    id="285597962"
+    id="1384315916"
   >
-    .pagination.jsx-285597962{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}
+    .pagination.jsx-1384315916{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}.pagination a.page-link{color:#036;}.pagination .page-item.active .page-link{background-color:#036;border-color:#036;}
   </JSXStyle>
 </Fragment>
 `;
@@ -263,7 +263,7 @@ exports[`PaginationBar should render a maximum of 9 pagination pages if Math.cei
 exports[`PaginationBar should render the Pagination component if Math.ceil(totalCount / pageSize) > 1 1`] = `
 <Fragment>
   <div
-    className="jsx-285597962 pagination"
+    className="jsx-1384315916 pagination"
   >
     <Dropdown
       navbar={false}
@@ -274,7 +274,7 @@ exports[`PaginationBar should render the Pagination component if Math.ceil(total
       >
         Items Per Page: 
         <strong
-          className="jsx-285597962"
+          className="jsx-1384315916"
         >
           20
         </strong>
@@ -372,9 +372,9 @@ exports[`PaginationBar should render the Pagination component if Math.ceil(total
     </ForwardRef>
   </div>
   <JSXStyle
-    id="285597962"
+    id="1384315916"
   >
-    .pagination.jsx-285597962{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}
+    .pagination.jsx-1384315916{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}.pagination a.page-link{color:#036;}.pagination .page-item.active .page-link{background-color:#036;border-color:#036;}
   </JSXStyle>
 </Fragment>
 `;

--- a/app/tests/unit/components/__snapshots__/ProgressStepIndicator.test.tsx.snap
+++ b/app/tests/unit/components/__snapshots__/ProgressStepIndicator.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`The Progress Step Indicator Matches snapshot with 2/4 steps completed a
   >
     Array [
       <div
-        className="jsx-1375059393 numberedCircle badge-success"
+        className="jsx-2841694627 numberedCircle badge-success"
       >
         <svg
           aria-hidden="true"
@@ -79,7 +79,7 @@ exports[`The Progress Step Indicator Matches snapshot with 2/4 steps completed a
     ]
     Array [
       <div
-        className="jsx-1375059393 numberedCircle badge-success"
+        className="jsx-2841694627 numberedCircle badge-success"
       >
         <svg
           aria-hidden="true"
@@ -109,7 +109,7 @@ exports[`The Progress Step Indicator Matches snapshot with 2/4 steps completed a
     ]
     Array [
       <div
-        className="jsx-1375059393 numberedCircle badge-danger"
+        className="jsx-2841694627 numberedCircle badge-danger"
       >
         110
       </div>,
@@ -117,7 +117,7 @@ exports[`The Progress Step Indicator Matches snapshot with 2/4 steps completed a
     ]
     Array [
       <div
-        className="jsx-1375059393 numberedCircle badge-danger"
+        className="jsx-2841694627 numberedCircle badge-danger"
       >
         111
       </div>,
@@ -224,7 +224,7 @@ exports[`The Progress Step Indicator Matches snapshot with 3 steps and a title 1
   >
     Array [
       <div
-        className="jsx-1375059393 numberedCircle badge-success"
+        className="jsx-2841694627 numberedCircle badge-success"
       >
         99
       </div>,
@@ -232,7 +232,7 @@ exports[`The Progress Step Indicator Matches snapshot with 3 steps and a title 1
     ]
     Array [
       <div
-        className="jsx-1375059393 numberedCircle badge-success"
+        className="jsx-2841694627 numberedCircle badge-success"
       >
         100
       </div>,
@@ -240,7 +240,7 @@ exports[`The Progress Step Indicator Matches snapshot with 3 steps and a title 1
     ]
     Array [
       <div
-        className="jsx-1375059393 numberedCircle badge-danger"
+        className="jsx-2841694627 numberedCircle badge-danger"
       >
         110
       </div>,
@@ -337,7 +337,7 @@ exports[`The Progress Step Indicator Matches snapshot with 4/4 steps completed a
   >
     Array [
       <div
-        className="jsx-1375059393 numberedCircle badge-success"
+        className="jsx-2841694627 numberedCircle badge-success"
       >
         <svg
           aria-hidden="true"
@@ -367,7 +367,7 @@ exports[`The Progress Step Indicator Matches snapshot with 4/4 steps completed a
     ]
     Array [
       <div
-        className="jsx-1375059393 numberedCircle badge-success"
+        className="jsx-2841694627 numberedCircle badge-success"
       >
         <svg
           aria-hidden="true"
@@ -397,7 +397,7 @@ exports[`The Progress Step Indicator Matches snapshot with 4/4 steps completed a
     ]
     Array [
       <div
-        className="jsx-1375059393 numberedCircle badge-danger"
+        className="jsx-2841694627 numberedCircle badge-danger"
       >
         <svg
           aria-hidden="true"
@@ -427,7 +427,7 @@ exports[`The Progress Step Indicator Matches snapshot with 4/4 steps completed a
     ]
     Array [
       <div
-        className="jsx-1375059393 numberedCircle badge-danger"
+        className="jsx-2841694627 numberedCircle badge-danger"
       >
         <svg
           aria-hidden="true"

--- a/app/tests/unit/components/helpers/__snapshots__/HelpButton.test.tsx.snap
+++ b/app/tests/unit/components/helpers/__snapshots__/HelpButton.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`HelpButton as an external user (closed) matches the last accepted snaps
 Array [
   <button
     aria-label="Click for help options"
-    className="jsx-327948841"
+    className="jsx-2871078921"
     id="help-button"
     onClick={[Function]}
     type="button"
@@ -63,18 +63,18 @@ Array [
 exports[`HelpButton as an external user (opened) matches the last accepted snapshot 1`] = `
 Array [
   <div
-    className="jsx-327948841"
+    className="jsx-2871078921"
     id="help-bubble"
   >
     <ul
-      className="jsx-327948841"
+      className="jsx-2871078921"
     >
       <li
-        className="jsx-327948841"
+        className="jsx-2871078921"
       >
         <span
           aria-hidden="true"
-          className="jsx-327948841"
+          className="jsx-2871078921"
           role="img"
         >
           📖
@@ -88,16 +88,16 @@ Array [
         </a>
       </li>
       <li
-        className="jsx-327948841"
+        className="jsx-2871078921"
       >
         OR
       </li>
       <li
-        className="jsx-327948841"
+        className="jsx-2871078921"
       >
         <span
           aria-hidden="true"
-          className="jsx-327948841"
+          className="jsx-2871078921"
           role="img"
         >
           ✉️
@@ -114,14 +114,14 @@ Array [
       </li>
     </ul>
     <span
-      className="jsx-327948841 triangle"
+      className="jsx-2871078921 triangle"
     >
       ◥
     </span>
   </div>,
   <button
     aria-label="Click for help options"
-    className="jsx-327948841"
+    className="jsx-2871078921"
     id="help-button"
     onClick={[Function]}
     type="button"
@@ -153,7 +153,7 @@ exports[`HelpButton as an internal user (closed) matches the last accepted snaps
 Array [
   <button
     aria-label="Click for help options"
-    className="jsx-327948841"
+    className="jsx-2871078921"
     id="help-button"
     onClick={[Function]}
     type="button"
@@ -212,18 +212,18 @@ Array [
 exports[`HelpButton as an internal user (opened) matches the last accepted snapshot 1`] = `
 Array [
   <div
-    className="jsx-327948841"
+    className="jsx-2871078921"
     id="help-bubble"
   >
     <ul
-      className="jsx-327948841"
+      className="jsx-2871078921"
     >
       <li
-        className="jsx-327948841"
+        className="jsx-2871078921"
       >
         <span
           aria-hidden="true"
-          className="jsx-327948841"
+          className="jsx-2871078921"
           role="img"
         >
           👋
@@ -235,16 +235,16 @@ Array [
         </a>
       </li>
       <li
-        className="jsx-327948841"
+        className="jsx-2871078921"
       >
         OR
       </li>
       <li
-        className="jsx-327948841"
+        className="jsx-2871078921"
       >
         <span
           aria-hidden="true"
-          className="jsx-327948841"
+          className="jsx-2871078921"
           role="img"
         >
           📖
@@ -259,14 +259,14 @@ Array [
       </li>
     </ul>
     <span
-      className="jsx-327948841 triangle"
+      className="jsx-2871078921 triangle"
     >
       ◥
     </span>
   </div>,
   <button
     aria-label="Click for help options"
-    className="jsx-327948841"
+    className="jsx-2871078921"
     id="help-button"
     onClick={[Function]}
     type="button"

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplicationDetailsCardItem.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplicationDetailsCardItem.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`ApplicationDetailsCardItemComponent should render the individual summar
         md={6}
       >
         <h2
-          className="jsx-2766932351"
+          className="jsx-3603849546"
         >
           Fuel Usage
         </h2>
@@ -114,9 +114,9 @@ exports[`ApplicationDetailsCardItemComponent should render the individual summar
     </CardBody>
   </ForwardRef>
   <JSXStyle
-    id="2766932351"
+    id="3603849546"
   >
-    h2{font-size:1.5rem;margin-bottom:0.5rem;font-weight:500;line-height:1.2;}.diffFrom{background-color:rgba(243,76,96,0.3);}.diffTo{background-color:rgba(70,241,118,0.3);}.summary-form-header&gt;.row{-webkit-box-pack:justify;-webkit-justify-content:space-between;-ms-flex-pack:justify;justify-content:space-between;}@media print{button,.btn{display:none !important;}}
+    h2{font-size:1.5rem;margin-bottom:0.5rem;font-weight:500;line-height:1.2;}.diffFrom{background-color:rgba(243,76,96,0.3);}.diffTo{background-color:rgba(70,241,118,0.3);}.has-error .summary-item svg,.has-error .summary-item .error-detail .text-danger{color:#c70012 !important;}.summary-form-header&gt;.row{-webkit-box-pack:justify;-webkit-justify-content:space-between;-ms-flex-pack:justify;justify-content:space-between;}@media print{button,.btn{display:none !important;}}
   </JSXStyle>
 </Card>
 `;


### PR DESCRIPTION
- Fixes text contrast for the blue pagination component and red error details on grey summary table background [GGIRCS-2453](https://youtrack.button.is/issue/GGIRCS-2453)
- Increases margin next to unicode icons in the HelpButton to counteract crowding that appears to occur specifically on MacOS Big Sur and only in Chrome (`span` does not expand to contain the full width of its content as it should)
- Adds a light grey 1px border around only `badge-light` progress step nodes to increase contrast of the ultra-light grey against a white background

### Pagination before and after:

<img width="422" alt="Screen Shot 2021-05-26 at 4 59 29 PM" src="https://user-images.githubusercontent.com/5522075/119745817-ca3cca80-be43-11eb-9245-65634e309b8a.png">
<img width="425" alt="Screen Shot 2021-05-26 at 4 59 12 PM" src="https://user-images.githubusercontent.com/5522075/119745818-cad56100-be43-11eb-8157-5cd4fbb407da.png">
<br/>

### Progress nodes before and after:
<br/>
<p>
<img width="223" alt="Screen Shot 2021-05-26 at 4 56 05 PM" src="https://user-images.githubusercontent.com/5522075/119745659-6d411480-be43-11eb-8d16-352a4741aa0a.png">
<img width="223" alt="Screen Shot 2021-05-26 at 4 56 57 PM" src="https://user-images.githubusercontent.com/5522075/119745657-6ca87e00-be43-11eb-932c-b5764e98afc1.png">
</p>