### PR TITLE
Fix broken links on footer copyright page

### DIFF
--- a/app/containers/Applications/ApplyButtonContainer.tsx
+++ b/app/containers/Applications/ApplyButtonContainer.tsx
@@ -116,7 +116,11 @@ export const ApplyButton: React.FunctionComponent<Props> = ({
           <p>
             Note, submission of a CIIP application does not constitute meeting
             reporting obligations as required under the{' '}
-            <a href="https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/14029_01">
+            <a
+              href="https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/14029_01"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
               <em>Greenhouse Gas Industrial Reporting and Control Act</em>
             </a>{' '}
             or its regulations.

--- a/app/pages/resources/copyright.tsx
+++ b/app/pages/resources/copyright.tsx
@@ -136,7 +136,7 @@ class Copyright extends Component<Props> {
           <p>
             For more information, please read the{' '}
             <a
-              href="/gov/content/governments/services-for-government/policies-procedures/intellectual-property/frequently-asked-questions"
+              href="https://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/intellectual-property/frequently-asked-questions"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -144,7 +144,7 @@ class Copyright extends Component<Props> {
             </a>{' '}
             or contact the{' '}
             <a
-              href="/gov/content/governments/services-for-government/policies-procedures/intellectual-property/intellectual-property-program/intellectual-property-disposals"
+              href="https://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/intellectual-property/intellectual-property-program/intellectual-property-disposals"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/app/tests/unit/containers/Applications/__snapshots__/ApplyButtonContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ApplyButtonContainer.test.tsx.snap
@@ -165,6 +165,8 @@ exports[`The apply button should render a warning modal if no swrs report exists
          
         <a
           href="https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/14029_01"
+          rel="noreferrer noopener"
+          target="_blank"
         >
           <em>
             Greenhouse Gas Industrial Reporting and Control Act
@@ -262,6 +264,8 @@ exports[`The apply button should render an Apply For CIIP button if no applicati
          
         <a
           href="https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/14029_01"
+          rel="noreferrer noopener"
+          target="_blank"
         >
           <em>
             Greenhouse Gas Industrial Reporting and Control Act

--- a/app/tests/unit/pages/resources/__snapshots__/copyright.test.tsx.snap
+++ b/app/tests/unit/pages/resources/__snapshots__/copyright.test.tsx.snap
@@ -120,7 +120,7 @@ exports[`BCGov core copyright page matches the last accepted Snapshot 1`] = `
       For more information, please read the
        
       <a
-        href="/gov/content/governments/services-for-government/policies-procedures/intellectual-property/frequently-asked-questions"
+        href="https://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/intellectual-property/frequently-asked-questions"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -130,7 +130,7 @@ exports[`BCGov core copyright page matches the last accepted Snapshot 1`] = `
       or contact the
        
       <a
-        href="/gov/content/governments/services-for-government/policies-procedures/intellectual-property/intellectual-property-program/intellectual-property-disposals"
+        href="https://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/intellectual-property/intellectual-property-program/intellectual-property-disposals"
         rel="noopener noreferrer"
         target="_blank"
       >


### PR DESCRIPTION
- Fixes two broken links in footer copyright page due to use of relative URLs in the boilerplate we used:  [GGIRCS-2458](https://youtrack.button.is/issue/GGIRCS-2458)
- Similar: external link to regulation from "missing SWRS report" warning opens in a new tab