### PR TITLE
One more place to Bootstrapify a dynamic toast

### DIFF
--- a/app/components/Forms/AddCommentField.tsx
+++ b/app/components/Forms/AddCommentField.tsx
@@ -25,6 +25,7 @@ const AddCommentField: React.FunctionComponent<FieldProps<string>> = (
     props.onChange(value);
     setExpanded(false);
     toast.success('Your comment was saved.', {
+      className: 'toastalert-success',
       autoClose: 5000,
       position: 'top-center'
     });

--- a/app/components/helpers/Toaster.tsx
+++ b/app/components/helpers/Toaster.tsx
@@ -28,11 +28,11 @@ export const Toaster: React.FunctionComponent = () => {
           top: 0.5rem;
           right: 0.7rem;
         }
-        :global(.Toastify__close-button--default) {
+        :global(.Toastify__close-button, .Toastify__close-button--default) {
           opacity: 1;
           color: currentColor;
         }
-        :global(.Toastify__progress-bar--default) {
+        :global(.Toastify__progress-bar, .Toastify__progress-bar--default) {
           background: transparent;
         }
       `}</style>


### PR DESCRIPTION
One last toast that managed to escape restyling in #1697 as part of [GGIRCS-1639](https://youtrack.button.is/issue/GGIRCS-1639) - when saving a comment related to one of the application form fields.