### PR TITLE
fix: error message on 'Save & Continue' click

### DIFF
--- a/app/containers/Applications/ApplicationWizardStep.tsx
+++ b/app/containers/Applications/ApplicationWizardStep.tsx
@@ -54,9 +54,9 @@ const ApplicationWizardStep: React.FunctionComponent<Props> = ({
     setSaved(true);
   };
 
-  const onComplete = (result) => {
-    const formData = result.data;
-    storeResult(formData);
+  const onComplete = async (result) => {
+    const {formData} = result;
+    await storeResult(formData);
     onStepComplete();
   };
 


### PR DESCRIPTION
The latest update to Relay slightly changed how we should write the 'onComplete' form callback.
Bonus: we await on relay store update