### PR TITLE
"Organisation" --> "Operation" in admin-facing UI

### DIFF
--- a/app/components/AddOrganisationModal.tsx
+++ b/app/components/AddOrganisationModal.tsx
@@ -33,12 +33,12 @@ const AddOrganisationModal: React.FunctionComponent<Props> = (props) => {
 
   return (
     <>
-      <p style={{marginTop: '20px'}}>Operator not in the list?</p>
+      <p style={{marginTop: '20px'}}>Operation not in the list?</p>
       <Button
         variant="outline-primary"
         onClick={() => setModalVisible(!isModalVisible)}
       >
-        Add Operator +
+        Add Operation +
       </Button>
       <Modal
         centered
@@ -48,7 +48,7 @@ const AddOrganisationModal: React.FunctionComponent<Props> = (props) => {
         aria-labelledby="add-new-operator"
       >
         <Modal.Header id="add-new-operator">
-          <h2 className="h5">Add a new Operator</h2>
+          <h2 className="h5">Add a new Operation</h2>
         </Modal.Header>
         <Modal.Body>
           <JsonSchemaForm

--- a/app/components/Dashboard/formConfiguration.tsx
+++ b/app/components/Dashboard/formConfiguration.tsx
@@ -17,7 +17,7 @@ const FormConfiguration: React.FunctionComponent = () => {
         </ListGroup.Item>
         <ListGroup.Item>
           <Link href="/admin/naics-products" passHref>
-            <Card.Link href="#">Allowed Products</Card.Link>
+            <Card.Link href="#">Allowed &amp; Mandatory Products</Card.Link>
           </Link>
         </ListGroup.Item>
       </ListGroup>

--- a/app/components/Dashboard/reportingOperations.tsx
+++ b/app/components/Dashboard/reportingOperations.tsx
@@ -17,7 +17,7 @@ const ApplicationManagement: React.FunctionComponent = () => {
         </ListGroup.Item>
         <ListGroup.Item>
           <Link href="/analyst/add-organisation" passHref>
-            <Card.Link href="#">Operators</Card.Link>
+            <Card.Link href="#">Operations</Card.Link>
           </Link>
         </ListGroup.Item>
         <ListGroup.Item>

--- a/app/containers/Organisations/AddOrganisation.tsx
+++ b/app/containers/Organisations/AddOrganisation.tsx
@@ -42,10 +42,10 @@ export const AddOrganisationComponent: React.FunctionComponent<Props> = (
     <div>
       <Card style={{marginTop: '50px'}}>
         <Card.Body>
-          <Card.Title>Search for an operator: </Card.Title>
+          <Card.Title>Search for an operation: </Card.Title>
           <Dropdown className="search-dropdown">
             <Dropdown.Toggle id="org-dropdown" className="search-toggle">
-              Find Operator
+              Find Operation
             </Dropdown.Toggle>
             <Dropdown.Menu>
               <FormControl

--- a/app/cypress/integration/analyst-access-all-pages.spec.js
+++ b/app/cypress/integration/analyst-access-all-pages.spec.js
@@ -20,8 +20,7 @@ describe('When logged in as an analyst', () => {
     cy.url().should('include', '/analyst/application/');
     cy.visit('/analyst');
     cy.url().should('include', '/analyst');
-    cy.get('.card-body');
-    cy.contains('Operations').click();
+    cy.get('.card-link').contains('Operations').click();
     cy.url().should('include', '/analyst/add-organisation');
     cy.visit('/analyst');
     cy.url().should('include', '/analyst');

--- a/app/cypress/integration/analyst-access-all-pages.spec.js
+++ b/app/cypress/integration/analyst-access-all-pages.spec.js
@@ -21,7 +21,7 @@ describe('When logged in as an analyst', () => {
     cy.visit('/analyst');
     cy.url().should('include', '/analyst');
     cy.get('.card-body');
-    cy.contains('Operators').click();
+    cy.contains('Operations').click();
     cy.url().should('include', '/analyst/add-organisation');
     cy.visit('/analyst');
     cy.url().should('include', '/analyst');

--- a/app/pages/analyst/add-organisation.tsx
+++ b/app/pages/analyst/add-organisation.tsx
@@ -41,14 +41,14 @@ class AddOrganisationPage extends Component<Props> {
   render() {
     const {query} = this.props;
     return (
-      <DefaultLayout session={query.session} title="Add Organisation">
+      <DefaultLayout session={query.session} title="Add Reporting Operation">
         <Card>
           <Card.Header className="h5">Attention</Card.Header>
           <Card.Body>
             <Card.Text>
               <p>
-                Manually adding an organisation via this UI has the potential to
-                create duplicate and SWRS-orphaned organisations in the data.
+                Manually adding an operation via this UI has the potential to
+                create duplicate and SWRS-orphaned operations in the data.
               </p>
               <p>
                 This is an escape hatch and should be used as a last resort in
@@ -56,27 +56,26 @@ class AddOrganisationPage extends Component<Props> {
                 application deadline without it.
               </p>
               <p>
-                Adding an organisation in this way will allow the reporter to
-                apply for CIIP, but will also create an organisation that has no
-                relation to SWRS data.
+                Adding an operation in this way will allow the reporter to apply
+                for CIIP, but will also create an operation that has no relation
+                to SWRS data.
               </p>
               <br />
-              <p>Some steps to take before adding an organisation manually:</p>
+              <p>Some steps to take before adding an operation manually:</p>
               <ol>
                 <li>
-                  Search below for the organisation, in case the reporter was
-                  simply making typos when searching for an existing
-                  organisation.
+                  Search below for the operation, in case the reporter was
+                  simply making typos when searching for an existing operation.
                 </li>
                 <li>
                   If you have reason to believe that a SWRS report containing
-                  information for this organisation is going to be received in
-                  the near future, instruct the reporter to try applying again
-                  in a few days when their SWRS report has been received.
+                  information for this operation is going to be received in the
+                  near future, instruct the reporter to try applying again in a
+                  few days when their SWRS report has been received.
                 </li>
                 <li>
                   Attempt some external investigation to find out why this
-                  organisation is missing.
+                  operation is missing.
                 </li>
               </ol>
             </Card.Text>

--- a/app/pages/analyst/organisation-requests.tsx
+++ b/app/pages/analyst/organisation-requests.tsx
@@ -59,7 +59,7 @@ class OrganisationRequests extends Component<Props> {
   render() {
     const {query} = this.props;
     return (
-      <DefaultLayout session={query.session} title="Organisation Requests">
+      <DefaultLayout session={query.session} title="Operation Access Requests">
         <OrganisationRequestsTable query={query} />
       </DefaultLayout>
     );

--- a/app/tests/unit/components/AddOrganisationModal.test.tsx
+++ b/app/tests/unit/components/AddOrganisationModal.test.tsx
@@ -14,6 +14,6 @@ describe('AddOrganisationFacility Component', () => {
     const render = mount(
       <AddOrganisationFacility onAddOrganisation={jest.fn()} />
     );
-    expect(render.find('Button').text()).toBe('Add Operator +');
+    expect(render.find('Button').text()).toBe('Add Operation +');
   });
 });

--- a/app/tests/unit/components/__snapshots__/AddOrganisationModal.test.tsx.snap
+++ b/app/tests/unit/components/__snapshots__/AddOrganisationModal.test.tsx.snap
@@ -9,7 +9,7 @@ Array [
       }
     }
   >
-    Operator not in the list?
+    Operation not in the list?
   </p>,
   <Button
     active={false}
@@ -23,7 +23,7 @@ Array [
       onClick={[Function]}
       type="button"
     >
-      Add Operator +
+      Add Operation +
     </button>
   </Button>,
   <Modal


### PR DESCRIPTION
"Organisation" --> "Operation"
- on access requests page
- on search/add organisations page
- also updates the link wording in the admin dash from "Allowed Products" --> "Allowed & Mandatory Products"

\*Note: This does not update the word "organisation" where it occurs in URLs, eg: `/analyst/add-organisation` or `/analyst/organisation-requests`.

[GGIRCS-2367](https://youtrack.button.is/issue/GGIRCS-2367)

<img width="547" alt="Screen Shot 2021-05-27 at 5 31 42 PM" src="https://user-images.githubusercontent.com/5522075/119912965-6a145a00-bf11-11eb-9cf2-6dff9386e9f8.png">

<img width="1231" alt="Screen Shot 2021-05-27 at 5 31 27 PM" src="https://user-images.githubusercontent.com/5522075/119912981-76001c00-bf11-11eb-8935-ee47a439b3ae.png">
