### PR TITLE
fix: mandatory products only populate on non-deleted associations

### DIFF
--- a/app/containers/Forms/ProductField.tsx
+++ b/app/containers/Forms/ProductField.tsx
@@ -160,7 +160,12 @@ export default createFragmentContainer(ProductFieldComponent, {
   `,
   naicsCode: graphql`
     fragment ProductField_naicsCode on NaicsCode {
-      allowableProducts: productNaicsCodesByNaicsCodeId {
+      allowableProducts: productNaicsCodesByNaicsCodeId(
+        filter: {
+          deletedAt: {isNull: true}
+          productByProductId: {productState: {equalTo: PUBLISHED}}
+        }
+      ) {
         edges {
           node {
             productId

--- a/app/containers/Forms/ProductsArrayField.tsx
+++ b/app/containers/Forms/ProductsArrayField.tsx
@@ -73,7 +73,11 @@ export default createFragmentContainer(ProductsArrayFieldComponent, {
   naicsProducts: graphql`
     fragment ProductsArrayField_naicsProducts on NaicsCode {
       mandatoryProducts: productNaicsCodesByNaicsCodeId(
-        condition: {isMandatory: true}
+        filter: {
+          isMandatory: {equalTo: true}
+          deletedAt: {isNull: true}
+          productByProductId: {productState: {equalTo: PUBLISHED}}
+        }
       ) {
         edges {
           node {


### PR DESCRIPTION
Fixes an issue where deleted product-naics-code associations still showed up if the product is mandatory