### PR TITLE
Fix: conditional benchmark settings display

### DIFF
--- a/app/containers/Products/ProductRowItemContainer.tsx
+++ b/app/containers/Products/ProductRowItemContainer.tsx
@@ -198,9 +198,11 @@ export const ProductRowItemComponent: React.FunctionComponent<Props> = ({
               <Dropdown.Item onClick={() => setProductModalShow(true)}>
                 Product details
               </Dropdown.Item>
-              <Dropdown.Item onClick={() => setBenchmarkModalShow(true)}>
-                Benchmark
-              </Dropdown.Item>
+              {product.isCiipProduct && (
+                <Dropdown.Item onClick={() => setBenchmarkModalShow(true)}>
+                  Benchmark
+                </Dropdown.Item>
+              )}
               <Dropdown.Item onClick={() => setLinkProductModalShow(true)}>
                 Linked products
               </Dropdown.Item>

--- a/app/mutations/product/updateProductMutation.ts
+++ b/app/mutations/product/updateProductMutation.ts
@@ -10,9 +10,7 @@ const mutation = graphql`
   mutation updateProductMutation($input: UpdateProductInput!) {
     updateProduct(input: $input) {
       product {
-        id
-        productName
-        productState
+        ...ProductRowItemContainer_product
       }
     }
   }

--- a/app/tests/unit/containers/Products/productRowItemContainer.test.tsx
+++ b/app/tests/unit/containers/Products/productRowItemContainer.test.tsx
@@ -171,4 +171,22 @@ describe('ProductList', () => {
       .first();
     expect(input.prop('disabled')).toBe(true);
   });
+
+  it('should not render the benchmark setting dropdown option when the product is not a ciip-benchmarked product', async () => {
+    const testProduct = {...product, isCiipProduct: false};
+    const r = mount(
+      <table>
+        <tbody>
+          <ProductRowItemComponent product={testProduct} query={query} />
+        </tbody>
+      </table>
+    );
+    r.find('DropdownToggle').simulate('click');
+    expect(
+      r.find('DropdownMenu DropdownItem').contains('Product details')
+    ).toBe(true);
+    expect(
+      r.find('DropdownMenu DropdownItem').at(1).contains('Benchmark')
+    ).toBe(false);
+  });
 });

--- a/schema/data/fixtures/analyst-all-access-setup.sql
+++ b/schema/data/fixtures/analyst-all-access-setup.sql
@@ -16,4 +16,8 @@ insert into ggircs_portal.application_revision_status(application_id, version_nu
 -- Add a naics code
 insert into ggircs_portal.naics_code(naics_code, ciip_sector, naics_description) values ('1234', 'sector', 'code description');
 
+alter table ggircs_portal.product disable trigger _protect_read_only_products;
+update ggircs_portal.product set is_ciip_product = true;
+alter table ggircs_portal.product enable trigger _protect_read_only_products;
+
 commit;


### PR DESCRIPTION
- hides benchmark option in admin product page if the product is not a ciip benchmarked product.
- updates the updateProduct mutation to return the shape of the fragment (fixes a require-refresh bug)
![nobenchmark](https://user-images.githubusercontent.com/26367840/121071734-2d542880-c785-11eb-979a-686e2f8a3c21.png)
