### PR TITLE
fix: add missing product fields to mandatory update mutation

### DIFF
--- a/app/containers/Forms/ProductsArrayField.tsx
+++ b/app/containers/Forms/ProductsArrayField.tsx
@@ -42,7 +42,18 @@ export const ProductsArrayFieldComponent: React.FunctionComponent<Props> = (
           units: productUnits,
           requiresEmissionAllocation,
           requiresProductAmount,
-          isEnergyProduct
+          isEnergyProduct,
+          productName,
+          productState,
+          isCiipProduct,
+          isReadOnly,
+          addPurchasedElectricityEmissions,
+          subtractExportedElectricityEmissions,
+          addPurchasedHeatEmissions,
+          subtractExportedHeatEmissions,
+          subtractGeneratedElectricityEmissions,
+          subtractGeneratedHeatEmissions,
+          addEmissionsFromEios
         } = edge.node.productByProductId;
         return {
           requiresEmissionAllocation,
@@ -50,7 +61,18 @@ export const ProductsArrayFieldComponent: React.FunctionComponent<Props> = (
           isEnergyProduct,
           productUnits,
           productRowId,
-          isMandatory: true
+          isMandatory: true,
+          productName,
+          productState,
+          isCiipProduct,
+          isReadOnly,
+          addPurchasedElectricityEmissions,
+          subtractExportedElectricityEmissions,
+          addPurchasedHeatEmissions,
+          subtractExportedHeatEmissions,
+          subtractGeneratedElectricityEmissions,
+          subtractGeneratedHeatEmissions,
+          addEmissionsFromEios
         };
       })
     );
@@ -83,11 +105,23 @@ export default createFragmentContainer(ProductsArrayFieldComponent, {
           node {
             id
             productByProductId {
+              id
               rowId
+              productName
+              productState
               units
               requiresEmissionAllocation
-              requiresProductAmount
               isEnergyProduct
+              isCiipProduct
+              isReadOnly
+              addPurchasedElectricityEmissions
+              subtractExportedElectricityEmissions
+              addPurchasedHeatEmissions
+              subtractExportedHeatEmissions
+              subtractGeneratedElectricityEmissions
+              subtractGeneratedHeatEmissions
+              addEmissionsFromEios
+              requiresProductAmount
             }
           }
         }


### PR DESCRIPTION
The updateProduct mutation in the mandatory products component (ProductsArrayField) was missing the energy product boolean fields, which caused the validation to skip the energy product validations since they were always being evaluated as false.