### PR TITLE
fix: use `sort -u` instead of `sort | uniq`

### DIFF
--- a/.bin/sqitch-check-immutable-files.sh
+++ b/.bin/sqitch-check-immutable-files.sh
@@ -3,7 +3,7 @@
 # This script checks whether those changes were modified in the current dir since the base branch and returns an error if that is the case
 # usage: sqitch-immutable-files.sh schema_dir base_branch
 
-set -euo pipefail
+set -xeuo pipefail
 # gets the list of modified files via git diff, and removes the schema/deploy prefix, and the .sql suffix to match the sqitch plan change name
 modified_changes=$(git diff --name-only "${2}" -- "${1}"/deploy | sed -e "s/.*\/\(deploy\)\///g; s/@.*//g; s/\.sql$//g")
 

--- a/.bin/sqitch-check-immutable-files.sh
+++ b/.bin/sqitch-check-immutable-files.sh
@@ -15,7 +15,7 @@ changes_after_last_tag=$(tac "${1}"/sqitch.plan | sed "/^$last_tag_on_base_branc
 
 # comm compares two ordered files and returns three columns "-23" suppresses colums 2 and 3,
 # so it only returns the first column (the lines unique to file 1)
-immutable_modified_files=$(comm -23 <(echo "$modified_changes" | sort | uniq) <(echo "$changes_after_last_tag" | sort | uniq))
+immutable_modified_files=$(comm -23 <(echo "$modified_changes" | sort -u) <(echo "$changes_after_last_tag" | sort -u))
 if [ -n "$immutable_modified_files" ]; then
   echo "The following sqitch changes are immutable as they are part of a tagged release. Please add incremental changes instead."
   echo "$immutable_modified_files"


### PR DESCRIPTION
The latter can cause a SIGPIPE