### PR TITLE
Chore: refactor network triggers admin

### DIFF
--- a/app/components/AddOrganisationModal.tsx
+++ b/app/components/AddOrganisationModal.tsx
@@ -1,9 +1,10 @@
 import React, {useState} from 'react';
 import {Button, Modal} from 'react-bootstrap';
-import JsonSchemaForm, {IChangeEvent} from '@rjsf/core';
+import {IChangeEvent} from '@rjsf/core';
 import FormFieldTemplate from 'containers/Forms/FormFieldTemplate';
 import FormObjectFieldTemplate from 'containers/Forms/FormObjectFieldTemplate';
 import addOperatorSchema from 'components/organisation/addOrganisationSchema';
+import JsonSchemaForm from './helpers/LoadingOnSubmitForm';
 
 interface Props {
   onAddOrganisation?: (...args: any[]) => void;

--- a/app/components/AddOrganisationModal.tsx
+++ b/app/components/AddOrganisationModal.tsx
@@ -28,8 +28,8 @@ const AddOrganisationModal: React.FunctionComponent<Props> = (props) => {
         }
       }
     };
+    await onAddOrganisation(variables);
     setModalVisible(!isModalVisible);
-    onAddOrganisation(variables);
   };
 
   return (

--- a/app/components/Admin/CreateNaicsCodeModal.tsx
+++ b/app/components/Admin/CreateNaicsCodeModal.tsx
@@ -19,7 +19,6 @@ export const CreateNaicsCodeModal: React.FunctionComponent<Props> = ({
   disabled
 }) => {
   const submitForm: (e: React.SyntheticEvent<any>) => void = async (e) => {
-    console.log(e);
     e.stopPropagation();
     e.preventDefault();
     e.persist();

--- a/app/components/Admin/CreateNaicsCodeModal.tsx
+++ b/app/components/Admin/CreateNaicsCodeModal.tsx
@@ -3,10 +3,11 @@ import {Button, Form, Modal, Container, Col, Row, Alert} from 'react-bootstrap';
 
 interface Props {
   validated: boolean;
-  onSubmit: (e: React.SyntheticEvent<any>) => Promise<void>;
+  onSubmit: (form: any) => Promise<void>;
   show: boolean;
   onClose: () => void;
   showActiveCodeError: boolean;
+  disabled?: boolean;
 }
 
 export const CreateNaicsCodeModal: React.FunctionComponent<Props> = ({
@@ -14,8 +15,19 @@ export const CreateNaicsCodeModal: React.FunctionComponent<Props> = ({
   onSubmit,
   show,
   onClose,
-  showActiveCodeError
+  showActiveCodeError,
+  disabled
 }) => {
+  const submitForm: (e: React.SyntheticEvent<any>) => void = async (e) => {
+    console.log(e);
+    e.stopPropagation();
+    e.preventDefault();
+    e.persist();
+
+    await onSubmit(e.target);
+    onClose();
+  };
+
   return (
     <>
       <Modal
@@ -30,40 +42,42 @@ export const CreateNaicsCodeModal: React.FunctionComponent<Props> = ({
         </Modal.Header>
         <Modal.Body>
           <Container>
-            <Form noValidate validated={validated} onSubmit={onSubmit}>
-              <Row>
-                <Col md={4}>
-                  <Form.Group controlId="naicsCode">
-                    <Form.Label>NAICS Code</Form.Label>
-                    <Form.Control required type="text" />
-                    <Form.Control.Feedback type="invalid">
-                      NAICS Code is required
-                    </Form.Control.Feedback>
-                  </Form.Group>
-                </Col>
-                <Col md={8}>
-                  <Form.Group controlId="ciipSector">
-                    <Form.Label>CIIP Sector</Form.Label>
-                    <Form.Control type="text" />
-                  </Form.Group>
-                </Col>
-              </Row>
-              <Form.Group controlId="naicsDescription">
-                <Form.Label>NAICS Description</Form.Label>
-                <Form.Control required type="text" />
-                <Form.Control.Feedback type="invalid">
-                  NAICS Description is required
-                </Form.Control.Feedback>
-              </Form.Group>
-              {showActiveCodeError && (
-                <Alert variant="danger">
-                  This NAICS code already exists. Please delete the currently
-                  active code before entering new information
-                </Alert>
-              )}
-              <Button variant="primary" type="submit">
-                Submit
-              </Button>
+            <Form noValidate validated={validated} onSubmit={submitForm}>
+              <fieldset disabled={disabled}>
+                <Row>
+                  <Col md={4}>
+                    <Form.Group controlId="naicsCode">
+                      <Form.Label>NAICS Code</Form.Label>
+                      <Form.Control required type="text" />
+                      <Form.Control.Feedback type="invalid">
+                        NAICS Code is required
+                      </Form.Control.Feedback>
+                    </Form.Group>
+                  </Col>
+                  <Col md={8}>
+                    <Form.Group controlId="ciipSector">
+                      <Form.Label>CIIP Sector</Form.Label>
+                      <Form.Control type="text" />
+                    </Form.Group>
+                  </Col>
+                </Row>
+                <Form.Group controlId="naicsDescription">
+                  <Form.Label>NAICS Description</Form.Label>
+                  <Form.Control required type="text" />
+                  <Form.Control.Feedback type="invalid">
+                    NAICS Description is required
+                  </Form.Control.Feedback>
+                </Form.Group>
+                {showActiveCodeError && (
+                  <Alert variant="danger">
+                    This NAICS code already exists. Please delete the currently
+                    active code before entering new information
+                  </Alert>
+                )}
+                <Button variant="primary" type="submit">
+                  Submit
+                </Button>
+              </fieldset>
             </Form>
           </Container>
         </Modal.Body>

--- a/app/components/Admin/DeleteConfirmationModal.tsx
+++ b/app/components/Admin/DeleteConfirmationModal.tsx
@@ -1,3 +1,4 @@
+import LoadingOnClickButton from 'components/helpers/LoadingOnClickButton';
 import React from 'react';
 import {Button, Modal, Alert, Col, Row} from 'react-bootstrap';
 
@@ -38,9 +39,13 @@ export const DeleteConfirmationModal: React.FunctionComponent<Props> = ({
         <p>{deleteObject.deleteItemDescription}</p>
         <Row>
           <Col md={{span: 4, offset: 4}}>
-            <Button onClick={handleDelete} variant="danger">
+            <LoadingOnClickButton
+              onClick={handleDelete}
+              variant="danger"
+              loadingText="Deleting..."
+            >
               Confirm Delete
-            </Button>
+            </LoadingOnClickButton>
           </Col>
           <Col md={{span: 3, offset: 1}}>
             <Button onClick={onClose} variant="secondary">

--- a/app/components/helpers/LoadingOnClickButton.tsx
+++ b/app/components/helpers/LoadingOnClickButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import withPromiseLoading from 'lib/withPromiseLoading';
-import {Button, ButtonProps} from 'react-bootstrap';
+import {Button as BootstrapButton, ButtonProps} from 'react-bootstrap';
 
 const IN_FLIGHT_PROPERTY = 'disabled';
 const ASYNC_HANDLER = 'onClick';
@@ -12,21 +12,17 @@ interface Props extends ButtonProps {
 // Wraps a bootstrap Button with the `withPromiseLoading` higher order component.
 // This will make the button enter a disabled state until the
 // onClick handler completes.
-const LoadingOnClickButton: React.FunctionComponent<Props> = ({
+const Button: React.FunctionComponent<Props> = ({
   loadingText,
   ...buttonProps
 }) => {
   return (
-    <Button {...buttonProps}>
+    <BootstrapButton {...buttonProps}>
       {loadingText !== undefined && buttonProps[IN_FLIGHT_PROPERTY]
         ? loadingText
         : buttonProps.children}
-    </Button>
+    </BootstrapButton>
   );
 };
 
-export default withPromiseLoading(
-  LoadingOnClickButton,
-  ASYNC_HANDLER,
-  IN_FLIGHT_PROPERTY
-);
+export default withPromiseLoading(Button, ASYNC_HANDLER, IN_FLIGHT_PROPERTY);

--- a/app/components/helpers/LoadingOnSubmitForm.tsx
+++ b/app/components/helpers/LoadingOnSubmitForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import JsonSchemaForm, {FormProps} from '@rjsf/core';
+import RJSF, {FormProps} from '@rjsf/core';
 import withPromiseLoading from 'lib/withPromiseLoading';
 
 const IN_FLIGHT_PROPERTY = 'disabled';
@@ -7,11 +7,11 @@ const ASYNC_HANDLER = 'onSubmit';
 
 interface Props<T> extends FormProps<T> {}
 
-function FormWithFieldset<T>(props: Props<T>) {
+function JsonSchemaForm<T>(props: Props<T>) {
   return (
-    <JsonSchemaForm {...props}>
+    <RJSF {...props}>
       <fieldset disabled={props.disabled}>{props.children}</fieldset>
-    </JsonSchemaForm>
+    </RJSF>
   );
 }
 
@@ -19,7 +19,7 @@ function FormWithFieldset<T>(props: Props<T>) {
 const LoadingOnSubmitForm: <T>(
   props: Props<T>
 ) => JSX.Element = withPromiseLoading(
-  FormWithFieldset,
+  JsonSchemaForm,
   ASYNC_HANDLER,
   IN_FLIGHT_PROPERTY
 );

--- a/app/components/helpers/LoadingOnSubmitForm.tsx
+++ b/app/components/helpers/LoadingOnSubmitForm.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import JsonSchemaForm, {FormProps} from '@rjsf/core';
+import withPromiseLoading from 'lib/withPromiseLoading';
+
+const IN_FLIGHT_PROPERTY = 'disabled';
+const ASYNC_HANDLER = 'onSubmit';
+
+interface Props<T> extends FormProps<T> {}
+
+function FormWithFieldset<T>(props: Props<T>) {
+  return (
+    <JsonSchemaForm {...props}>
+      <fieldset disabled={props.disabled}>{props.children}</fieldset>
+    </JsonSchemaForm>
+  );
+}
+
+// Typescript needs a little help to link the exposed props with the wrapped props
+const LoadingOnSubmitForm: <T>(
+  props: Props<T>
+) => JSX.Element = withPromiseLoading(
+  FormWithFieldset,
+  ASYNC_HANDLER,
+  IN_FLIGHT_PROPERTY
+);
+
+export default LoadingOnSubmitForm;

--- a/app/containers/Admin/NaicsCode/NaicsCodeTable.tsx
+++ b/app/containers/Admin/NaicsCode/NaicsCodeTable.tsx
@@ -5,7 +5,13 @@ import {NaicsCodeTable_query} from '__generated__/NaicsCodeTable_query.graphql';
 import NaicsCodeTableRow from './NaicsCodeTableRow';
 import CreateNaicsCodeModal from 'components/Admin/CreateNaicsCodeModal';
 import createNaicsCodeMutation from 'mutations/naics_code/createNaicsCodeMutation';
+import withPromiseLoading from 'lib/withPromiseLoading';
 
+const LoadingCreateNaicsCodeModal = withPromiseLoading(
+  CreateNaicsCodeModal,
+  'onSubmit',
+  'disabled'
+);
 interface Props {
   relay: RelayProp;
   query: NaicsCodeTable_query;
@@ -31,29 +37,21 @@ export const NaicsCodeTableContainer: React.FunctionComponent<Props> = (
     );
   };
 
-  const handleCreateNaicsCode = async (e: React.SyntheticEvent<any>) => {
-    const form = e.currentTarget;
-    e.stopPropagation();
-    e.preventDefault();
-    e.persist();
+  const handleCreateNaicsCode = async (form: any) => {
     setValidated(true);
 
-    if (naicsCodeIsActive(e.target[0].value)) setShowActiveCodeError(true);
+    if (naicsCodeIsActive(form[1].value)) setShowActiveCodeError(true);
     else if (form.checkValidity() === true) {
       const {environment} = props.relay;
       const variables = {
         input: {
-          naicsCodeInput: e.target[0].value,
-          ciipSectorInput: e.target[1].value ? e.target[1].value : null,
-          naicsDescriptionInput: e.target[2].value
+          naicsCodeInput: form[1].value,
+          ciipSectorInput: form[2].value ? form[2].value : null,
+          naicsDescriptionInput: form[3].value
         }
       };
-      try {
-        await createNaicsCodeMutation(environment, variables);
-      } catch (e) {
-        console.error(e);
-      }
-      handleClose();
+
+      await createNaicsCodeMutation(environment, variables);
     }
   };
 
@@ -67,7 +65,7 @@ export const NaicsCodeTableContainer: React.FunctionComponent<Props> = (
           New NAICS Code
         </Button>
       </div>
-      <CreateNaicsCodeModal
+      <LoadingCreateNaicsCodeModal
         validated={validated}
         onSubmit={handleCreateNaicsCode}
         show={showCreateModal}

--- a/app/containers/Admin/OrganisationRequestsTableRow.tsx
+++ b/app/containers/Admin/OrganisationRequestsTableRow.tsx
@@ -36,11 +36,7 @@ export const OrganisationRequestsTableRowComponent: React.FunctionComponent<Prop
       }
     };
 
-    const response = await updateUserOrganisationMutation(
-      props.relay.environment,
-      variables
-    );
-    console.log(response);
+    await updateUserOrganisationMutation(props.relay.environment, variables);
   };
 
   return (

--- a/app/containers/Admin/ReportingYear/NewReportingYearFormDialog.tsx
+++ b/app/containers/Admin/ReportingYear/NewReportingYearFormDialog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Modal, Container, Button} from 'react-bootstrap';
 import globalFormStyles from '../../Forms/FormSharedStyles';
-import JsonSchemaForm, {FormValidation} from '@rjsf/core';
+import {FormValidation} from '@rjsf/core';
 import {JSONSchema7} from 'json-schema';
 import FormObjectFieldTemplate from 'containers/Forms/FormObjectFieldTemplate';
 import FormFieldTemplate from 'containers/Forms/FormFieldTemplate';
@@ -9,6 +9,7 @@ import newReportingYearSchema from './create_reporting_year.json';
 import DatePickerWidget from 'components/Forms/DatePickerWidget';
 import {validateAllDates, validateUniqueKey} from './reportingYearValidation';
 import {ensureFullTimestamp} from 'functions/formatDates';
+import LoadingOnSubmitForm from 'components/helpers/LoadingOnSubmitForm';
 
 interface Props {
   show: boolean;
@@ -72,7 +73,7 @@ const NewReportingYearFormDialog: React.FunctionComponent<Props> = ({
         </Modal.Header>
         <Modal.Body>
           <Container>
-            <JsonSchemaForm
+            <LoadingOnSubmitForm
               omitExtraData
               liveOmit
               noHtml5Validate
@@ -99,7 +100,7 @@ const NewReportingYearFormDialog: React.FunctionComponent<Props> = ({
               <Button type="submit" variant="primary">
                 Save Reporting Year
               </Button>
-            </JsonSchemaForm>
+            </LoadingOnSubmitForm>
           </Container>
         </Modal.Body>
       </Modal>

--- a/app/containers/Admin/ReportingYear/ReportingYearFormDialog.tsx
+++ b/app/containers/Admin/ReportingYear/ReportingYearFormDialog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Modal, Container, Button} from 'react-bootstrap';
 import globalFormStyles from '../../Forms/FormSharedStyles';
-import JsonSchemaForm, {FormValidation} from '@rjsf/core';
+import {FormValidation} from '@rjsf/core';
 import {JSONSchema7} from 'json-schema';
 import FormObjectFieldTemplate from 'containers/Forms/FormObjectFieldTemplate';
 import FormFieldTemplate from 'containers/Forms/FormFieldTemplate';
@@ -13,6 +13,7 @@ import {
   nowMoment,
   ensureFullTimestamp
 } from 'functions/formatDates';
+import LoadingOnSubmitForm from 'components/helpers/LoadingOnSubmitForm';
 
 function transformUiSchema(json, formFields) {
   if (!formFields) return;
@@ -87,7 +88,7 @@ const ReportingYearFormDialog: React.FunctionComponent<Props> = ({
         </Modal.Header>
         <Modal.Body>
           <Container>
-            <JsonSchemaForm
+            <LoadingOnSubmitForm
               omitExtraData
               liveOmit
               noHtml5Validate
@@ -113,7 +114,7 @@ const ReportingYearFormDialog: React.FunctionComponent<Props> = ({
               <Button type="submit" variant="primary">
                 Save Reporting Year
               </Button>
-            </JsonSchemaForm>
+            </LoadingOnSubmitForm>
           </Container>
         </Modal.Body>
       </Modal>

--- a/app/containers/Applications/ReviseApplicationButtonContainer.tsx
+++ b/app/containers/Applications/ReviseApplicationButtonContainer.tsx
@@ -1,10 +1,10 @@
 import React, {useState} from 'react';
 import {useRouter} from 'next/router';
-import {Button} from 'react-bootstrap';
 import createApplicationRevisionMutation from 'mutations/application/createApplicationRevisionMutation';
 import {createFragmentContainer, graphql, RelayProp} from 'react-relay';
 import {ReviseApplicationButtonContainer_application} from 'ReviseApplicationButtonContainer_application.graphql';
 import {getApplicationPageRoute} from 'routes';
+import LoadingOnClickButton from 'components/helpers/LoadingOnClickButton';
 
 interface Props {
   application: ReviseApplicationButtonContainer_application;
@@ -31,13 +31,17 @@ export const ReviseApplicationButton: React.FunctionComponent<Props> = ({
 
     await createApplicationRevisionMutation(relay.environment, variables);
 
-    router.push(getApplicationPageRoute(application.id));
+    await router.push(getApplicationPageRoute(application.id));
   };
 
   return (
-    <Button variant="primary" onClick={handleClick}>
+    <LoadingOnClickButton
+      variant="primary"
+      onClick={handleClick}
+      loadingText="Starting revision..."
+    >
       Revise Application
-    </Button>
+    </LoadingOnClickButton>
   );
 };
 

--- a/app/containers/Facilities/AddFacilityModal.tsx
+++ b/app/containers/Facilities/AddFacilityModal.tsx
@@ -2,13 +2,14 @@ import React, {useState} from 'react';
 import {graphql, createFragmentContainer} from 'react-relay';
 import {AddFacilityModal_query} from 'AddFacilityModal_query.graphql';
 import {Button, Modal, Card} from 'react-bootstrap';
-import JsonSchemaForm, {IChangeEvent} from '@rjsf/core';
+import {IChangeEvent} from '@rjsf/core';
 import FormFieldTemplate from 'containers/Forms/FormFieldTemplate';
 import FormObjectFieldTemplate from 'containers/Forms/FormObjectFieldTemplate';
 import addFacilitySchema from 'components/facility/addFacilitySchema';
 import OrganisationRowIdField from './OrganisationRowIdField';
 import SearchDropdownWidget from 'components/Forms/SearchDropdownWidget';
 import NumberField from 'containers/Forms/NumberField';
+import JsonSchemaForm from 'components/helpers/LoadingOnSubmitForm';
 
 interface Props {
   query: AddFacilityModal_query;
@@ -50,9 +51,8 @@ const AddFacilityModal: React.FunctionComponent<Props> = (props) => {
         }
       }
     };
+    await onAddFacility(variables);
     setModalVisible(!isModalVisible);
-    console.log(variables);
-    onAddFacility(variables);
   };
 
   return (

--- a/app/containers/Products/ProductCreatorContainer.tsx
+++ b/app/containers/Products/ProductCreatorContainer.tsx
@@ -4,14 +4,8 @@ import {IChangeEvent} from '@rjsf/core';
 import {Card} from 'react-bootstrap';
 import createProductMutation from 'mutations/product/createProductMutation';
 import {CiipProductState} from 'createProductMutation.graphql';
-import withPromiseLoading from 'lib/withPromiseLoading';
 import ProductCreatorForm from './ProductCreatorForm';
 
-const LoadingProductCreatorForm = withPromiseLoading(
-  ProductCreatorForm,
-  'saveProduct',
-  'disabled'
-);
 interface Props {
   relay: RelayProp;
   toggleShowCreateForm: (...args: any[]) => void;
@@ -75,7 +69,7 @@ export const ProductCreator: React.FunctionComponent<Props> = ({
             Create a Product
           </Card.Header>
           <Card.Body style={{padding: '2em'}}>
-            <LoadingProductCreatorForm
+            <ProductCreatorForm
               saveProduct={saveProduct}
               disabled={false}
               toggleShowCreateForm={toggleShowCreateForm}

--- a/app/containers/Products/ProductCreatorForm.tsx
+++ b/app/containers/Products/ProductCreatorForm.tsx
@@ -4,9 +4,10 @@ import FormArrayFieldTemplate from 'containers/Forms/FormArrayFieldTemplate';
 import FormFieldTemplate from 'containers/Forms/FormFieldTemplate';
 import {JSONSchema7} from 'json-schema';
 import productSchema from './product-schema.json';
-import JsonSchemaForm, {IChangeEvent} from '@rjsf/core';
+import {IChangeEvent} from '@rjsf/core';
 import {Button} from 'react-bootstrap';
 import HeaderWidget from 'components/HeaderWidget';
+import LoadingOnSubmitForm from 'components/helpers/LoadingOnSubmitForm';
 
 interface Props {
   saveProduct: (e: IChangeEvent) => Promise<void>;
@@ -20,7 +21,7 @@ const ProductCreatorForm: React.FunctionComponent<Props> = ({
   toggleShowCreateForm
 }) => {
   return (
-    <JsonSchemaForm
+    <LoadingOnSubmitForm
       omitExtraData
       liveOmit
       widgets={{header: HeaderWidget}}
@@ -43,7 +44,7 @@ const ProductCreatorForm: React.FunctionComponent<Props> = ({
       >
         Close
       </Button>
-    </JsonSchemaForm>
+    </LoadingOnSubmitForm>
   );
 };
 

--- a/app/lib/withPromiseLoading.tsx
+++ b/app/lib/withPromiseLoading.tsx
@@ -10,7 +10,7 @@ const withPromiseLoading = function higherOrderComponent<
   asyncEventHandler: HandlerKey,
   isInFlightProp: InFlightKey
 ): (props: TProps) => JSX.Element {
-  return (props: TProps) => {
+  return function WithPromiseLoadingWrapper(props: TProps) {
     const [isLoading, setIsLoading] = useState(false);
 
     let isSubscribed = true;

--- a/app/lib/withPromiseLoading.tsx
+++ b/app/lib/withPromiseLoading.tsx
@@ -10,43 +10,45 @@ const withPromiseLoading = function higherOrderComponent<
   asyncEventHandler: HandlerKey,
   isInFlightProp: InFlightKey
 ): (props: TProps) => JSX.Element {
-  return function WithPromiseLoadingWrapper(props: TProps) {
-    const [isLoading, setIsLoading] = useState(false);
+  return {
+    [`WithPromiseLoading(${Wrapped.name})`](props: TProps) {
+      const [isLoading, setIsLoading] = useState(false);
 
-    let isSubscribed = true;
+      let isSubscribed = true;
 
-    // This is to avoid making changes to the state after the component has been unmounted
-    // In case the asyncEventHandler has side-effects on the DOM
-    useEffect(() => {
-      return function cleanUp() {
-        isSubscribed = false;
+      // This is to avoid making changes to the state after the component has been unmounted
+      // In case the asyncEventHandler has side-effects on the DOM
+      useEffect(() => {
+        return function cleanUp() {
+          isSubscribed = false;
+        };
+      }, []);
+
+      const handleAsyncEvent = async (...args) => {
+        if (!isSubscribed) return;
+        setIsLoading(true);
+
+        try {
+          // We can only verify that the key exists on TProps,
+          // not the type of the property for that key
+          await (props[asyncEventHandler] as any)(...args);
+        } catch (err) {
+          Sentry.captureException(err);
+        }
+
+        if (!isSubscribed) return;
+        setIsLoading(false);
       };
-    }, []);
 
-    const handleAsyncEvent = async (...args) => {
-      if (!isSubscribed) return;
-      setIsLoading(true);
+      const childProps = {
+        ...props,
+        [isInFlightProp]: isLoading,
+        [asyncEventHandler]: handleAsyncEvent
+      };
 
-      try {
-        // We can only verify that the key exists on TProps,
-        // not the type of the property for that key
-        await (props[asyncEventHandler] as any)(...args);
-      } catch (err) {
-        Sentry.captureException(err);
-      }
-
-      if (!isSubscribed) return;
-      setIsLoading(false);
-    };
-
-    const childProps = {
-      ...props,
-      [isInFlightProp]: isLoading,
-      [asyncEventHandler]: handleAsyncEvent
-    };
-
-    return <Wrapped {...childProps} />;
-  };
+      return <Wrapped {...childProps} />;
+    }
+  }[`WithPromiseLoading(${Wrapped.name})`];
 };
 
 export default withPromiseLoading;

--- a/app/tests/unit/components/Admin/DeleteConfirmationModal.test.tsx
+++ b/app/tests/unit/components/Admin/DeleteConfirmationModal.test.tsx
@@ -32,7 +32,9 @@ describe('CreateNaicsCodeModal', () => {
         onClose={jest.fn()}
       />
     );
-    renderer.find('Button').at(0).prop('onClick')({} as any);
+    renderer.find('WithPromiseLoading(Button)').at(0).prop('onClick')(
+      {} as any
+    );
     expect(handleDelete).toBeCalledTimes(1);
   });
 });

--- a/app/tests/unit/components/Admin/NaicsCodeModal.test.tsx
+++ b/app/tests/unit/components/Admin/NaicsCodeModal.test.tsx
@@ -24,7 +24,11 @@ describe('CreateNaicsCodeModal', () => {
         onClose={jest.fn()}
       />
     );
-    renderer.find('Form').prop('onSubmit')({});
+    await renderer.find('Form').prop('onSubmit')({
+      stopPropagation: () => {},
+      preventDefault: () => {},
+      persist: () => {}
+    } as any);
     expect(handleSubmit).toBeCalledTimes(1);
   });
 });

--- a/app/tests/unit/components/Admin/__snapshots__/DeleteConfirmationModal.test.tsx.snap
+++ b/app/tests/unit/components/Admin/__snapshots__/DeleteConfirmationModal.test.tsx.snap
@@ -87,14 +87,13 @@ exports[`CreateNaicsCodeModal should match the snapshot with the DeleteConfirmat
           }
         }
       >
-        <Button
-          active={false}
-          disabled={false}
+        <WithPromiseLoading(Button)
+          loadingText="Deleting..."
           onClick={[MockFunction]}
           variant="danger"
         >
           Confirm Delete
-        </Button>
+        </WithPromiseLoading(Button)>
       </Col>
       <Col
         md={

--- a/app/tests/unit/components/Admin/__snapshots__/NaicsCodeModal.test.tsx.snap
+++ b/app/tests/unit/components/Admin/__snapshots__/NaicsCodeModal.test.tsx.snap
@@ -37,80 +37,84 @@ exports[`CreateNaicsCodeModal should match the snapshot with the NaicsCodeTable 
         <Form
           inline={false}
           noValidate={true}
-          onSubmit={[MockFunction]}
+          onSubmit={[Function]}
           validated={true}
         >
-          <Row
-            noGutters={false}
+          <fieldset
+            className="jsx-2506197536"
           >
-            <Col
-              md={4}
+            <Row
+              noGutters={false}
             >
-              <FormGroup
-                controlId="naicsCode"
+              <Col
+                md={4}
               >
-                <FormLabel
-                  column={false}
-                  srOnly={false}
+                <FormGroup
+                  controlId="naicsCode"
                 >
-                  NAICS Code
-                </FormLabel>
-                <FormControl
-                  required={true}
-                  type="text"
-                />
-                <Feedback
-                  type="invalid"
-                >
-                  NAICS Code is required
-                </Feedback>
-              </FormGroup>
-            </Col>
-            <Col
-              md={8}
-            >
-              <FormGroup
-                controlId="ciipSector"
+                  <FormLabel
+                    column={false}
+                    srOnly={false}
+                  >
+                    NAICS Code
+                  </FormLabel>
+                  <FormControl
+                    required={true}
+                    type="text"
+                  />
+                  <Feedback
+                    type="invalid"
+                  >
+                    NAICS Code is required
+                  </Feedback>
+                </FormGroup>
+              </Col>
+              <Col
+                md={8}
               >
-                <FormLabel
-                  column={false}
-                  srOnly={false}
+                <FormGroup
+                  controlId="ciipSector"
                 >
-                  CIIP Sector
-                </FormLabel>
-                <FormControl
-                  type="text"
-                />
-              </FormGroup>
-            </Col>
-          </Row>
-          <FormGroup
-            controlId="naicsDescription"
-          >
-            <FormLabel
-              column={false}
-              srOnly={false}
+                  <FormLabel
+                    column={false}
+                    srOnly={false}
+                  >
+                    CIIP Sector
+                  </FormLabel>
+                  <FormControl
+                    type="text"
+                  />
+                </FormGroup>
+              </Col>
+            </Row>
+            <FormGroup
+              controlId="naicsDescription"
             >
-              NAICS Description
-            </FormLabel>
-            <FormControl
-              required={true}
-              type="text"
-            />
-            <Feedback
-              type="invalid"
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                NAICS Description
+              </FormLabel>
+              <FormControl
+                required={true}
+                type="text"
+              />
+              <Feedback
+                type="invalid"
+              >
+                NAICS Description is required
+              </Feedback>
+            </FormGroup>
+            <Button
+              active={false}
+              disabled={false}
+              type="submit"
+              variant="primary"
             >
-              NAICS Description is required
-            </Feedback>
-          </FormGroup>
-          <Button
-            active={false}
-            disabled={false}
-            type="submit"
-            variant="primary"
-          >
-            Submit
-          </Button>
+              Submit
+            </Button>
+          </fieldset>
         </Form>
       </Container>
     </ModalBody>

--- a/app/tests/unit/containers/Admin/NaicsCodes/NaicsCodeTable.test.tsx
+++ b/app/tests/unit/containers/Admin/NaicsCodes/NaicsCodeTable.test.tsx
@@ -74,7 +74,9 @@ describe('NaicsCodeTable', () => {
         }}
       />
     );
-    expect(renderer.exists('WithPromiseLoadingWrapper')).toBe(true);
+    expect(renderer.exists('WithPromiseLoading(CreateNaicsCodeModal)')).toBe(
+      true
+    );
   });
 
   it('should open CreateNaicsCode modal component on New NAICS Code Button click', async () => {
@@ -102,7 +104,9 @@ describe('NaicsCodeTable', () => {
 
     renderer.find('Button').first().simulate('click');
 
-    expect(renderer.find('WithPromiseLoadingWrapper').prop('show')).toBe(true);
+    expect(
+      renderer.find('WithPromiseLoading(CreateNaicsCodeModal)').prop('show')
+    ).toBe(true);
   });
 
   it('should call the create mutation on Form submit', async () => {
@@ -140,9 +144,9 @@ describe('NaicsCodeTable', () => {
       3: {value: 'c'},
       checkValidity: jest.fn(() => true)
     } as any;
-    await renderer.find('WithPromiseLoadingWrapper').prop('onSubmit')(
-      callParams
-    );
+    await renderer
+      .find('WithPromiseLoading(CreateNaicsCodeModal)')
+      .prop('onSubmit')(callParams);
 
     expect(spy).toBeCalledTimes(1);
     expect(spy).toBeCalledWith(null, {

--- a/app/tests/unit/containers/Admin/NaicsCodes/NaicsCodeTable.test.tsx
+++ b/app/tests/unit/containers/Admin/NaicsCodes/NaicsCodeTable.test.tsx
@@ -74,7 +74,7 @@ describe('NaicsCodeTable', () => {
         }}
       />
     );
-    expect(renderer.exists('CreateNaicsCodeModal')).toBe(true);
+    expect(renderer.exists('WithPromiseLoadingWrapper')).toBe(true);
   });
 
   it('should open CreateNaicsCode modal component on New NAICS Code Button click', async () => {
@@ -102,7 +102,7 @@ describe('NaicsCodeTable', () => {
 
     renderer.find('Button').first().simulate('click');
 
-    expect(renderer.find('CreateNaicsCodeModal').prop('show')).toBe(true);
+    expect(renderer.find('WithPromiseLoadingWrapper').prop('show')).toBe(true);
   });
 
   it('should call the create mutation on Form submit', async () => {
@@ -134,13 +134,15 @@ describe('NaicsCodeTable', () => {
       />
     );
 
-    renderer.find('CreateNaicsCodeModal').prop('onSubmit')({
-      stopPropagation: jest.fn(),
-      preventDefault: jest.fn(),
-      persist: jest.fn(),
-      currentTarget: {checkValidity: jest.fn(() => true)},
-      target: [{value: 'a'}, {value: 'b'}, {value: 'c'}]
-    } as any);
+    const callParams = {
+      1: {value: 'a'},
+      2: {value: 'b'},
+      3: {value: 'c'},
+      checkValidity: jest.fn(() => true)
+    } as any;
+    await renderer.find('WithPromiseLoadingWrapper').prop('onSubmit')(
+      callParams
+    );
 
     expect(spy).toBeCalledTimes(1);
     expect(spy).toBeCalledWith(null, {

--- a/app/tests/unit/containers/Admin/NaicsCodes/__snapshots__/NaicsCodeTable.test.tsx.snap
+++ b/app/tests/unit/containers/Admin/NaicsCodes/__snapshots__/NaicsCodeTable.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`NaicsCodeTable should match the snapshot with the NaicsCodeTable contai
       New NAICS Code
     </Button>
   </div>
-  <WithPromiseLoadingWrapper
+  <WithPromiseLoading(CreateNaicsCodeModal)
     onClose={[Function]}
     onSubmit={[Function]}
     show={false}

--- a/app/tests/unit/containers/Admin/NaicsCodes/__snapshots__/NaicsCodeTable.test.tsx.snap
+++ b/app/tests/unit/containers/Admin/NaicsCodes/__snapshots__/NaicsCodeTable.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`NaicsCodeTable should match the snapshot with the NaicsCodeTable contai
       New NAICS Code
     </Button>
   </div>
-  <CreateNaicsCodeModal
+  <WithPromiseLoadingWrapper
     onClose={[Function]}
     onSubmit={[Function]}
     show={false}

--- a/app/tests/unit/containers/Applications/ReviseApplicationButtonContainer.test.tsx
+++ b/app/tests/unit/containers/Applications/ReviseApplicationButtonContainer.test.tsx
@@ -24,7 +24,12 @@ describe('The ReviseApplicationButton', () => {
     );
 
     expect(r).toMatchSnapshot();
-    expect(r.exists('Button')).toBe(true);
-    expect(r.find('Button').text()).toBe('Revise Application');
+    expect(r.exists('WithPromiseLoading(Button)')).toBe(true);
+    expect(r.find('WithPromiseLoading(Button)').prop('loadingText')).toBe(
+      'Starting revision...'
+    );
+    expect(r.find('WithPromiseLoading(Button)').prop('children')).toBe(
+      'Revise Application'
+    );
   });
 });

--- a/app/tests/unit/containers/Applications/__snapshots__/ReviseApplicationButtonContainer.test.tsx.snap
+++ b/app/tests/unit/containers/Applications/__snapshots__/ReviseApplicationButtonContainer.test.tsx.snap
@@ -1,12 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`The ReviseApplicationButton should render a "Revise" button when the version being viewed === the latest draft version (there is not yet a newer draft) 1`] = `
-<Button
-  active={false}
-  disabled={false}
+<WithPromiseLoading(Button)
+  loadingText="Starting revision..."
   onClick={[Function]}
   variant="primary"
 >
   Revise Application
-</Button>
+</WithPromiseLoading(Button)>
 `;

--- a/app/tests/unit/containers/ReportingYear/__snapshots__/NewReportingYearFormDialog.test.tsx.snap
+++ b/app/tests/unit/containers/ReportingYear/__snapshots__/NewReportingYearFormDialog.test.tsx.snap
@@ -36,16 +36,12 @@ exports[`NewReportingYearFormDialog Should match last accepted snapshot 1`] = `
       <Container
         fluid={false}
       >
-        <Form
-          ErrorList={[Function]}
+        <WithPromiseLoading(JsonSchemaForm)
           FieldTemplate={[Function]}
           ObjectFieldTemplate={[Function]}
-          disabled={false}
           formData={Object {}}
           liveOmit={true}
-          liveValidate={false}
           noHtml5Validate={true}
-          noValidate={false}
           omitExtraData={true}
           onSubmit={[Function]}
           schema={
@@ -122,7 +118,7 @@ exports[`NewReportingYearFormDialog Should match last accepted snapshot 1`] = `
           >
             Save Reporting Year
           </Button>
-        </Form>
+        </WithPromiseLoading(JsonSchemaForm)>
       </Container>
     </ModalBody>
   </Modal>

--- a/app/tests/unit/containers/ReportingYear/__snapshots__/ReportingYearFormDialog.test.tsx.snap
+++ b/app/tests/unit/containers/ReportingYear/__snapshots__/ReportingYearFormDialog.test.tsx.snap
@@ -37,11 +37,9 @@ exports[`ReportingYearFormDialog Should match last accepted snapshot: no inputs 
       <Container
         fluid={false}
       >
-        <Form
-          ErrorList={[Function]}
+        <WithPromiseLoading(JsonSchemaForm)
           FieldTemplate={[Function]}
           ObjectFieldTemplate={[Function]}
-          disabled={false}
           formData={
             Object {
               "applicationCloseTime": "2026-03-01T00:00:00-08:00",
@@ -53,9 +51,7 @@ exports[`ReportingYearFormDialog Should match last accepted snapshot: no inputs 
             }
           }
           liveOmit={true}
-          liveValidate={false}
           noHtml5Validate={true}
-          noValidate={false}
           omitExtraData={true}
           onSubmit={[Function]}
           schema={
@@ -113,7 +109,7 @@ exports[`ReportingYearFormDialog Should match last accepted snapshot: no inputs 
           >
             Save Reporting Year
           </Button>
-        </Form>
+        </WithPromiseLoading(JsonSchemaForm)>
       </Container>
     </ModalBody>
   </Modal>
@@ -674,11 +670,9 @@ exports[`ReportingYearFormDialog Should match last accepted snapshot: some past 
       <Container
         fluid={false}
       >
-        <Form
-          ErrorList={[Function]}
+        <WithPromiseLoading(JsonSchemaForm)
           FieldTemplate={[Function]}
           ObjectFieldTemplate={[Function]}
-          disabled={false}
           formData={
             Object {
               "applicationCloseTime": "2030-12-30T13:49:54.191757-08:00",
@@ -690,9 +684,7 @@ exports[`ReportingYearFormDialog Should match last accepted snapshot: some past 
             }
           }
           liveOmit={true}
-          liveValidate={false}
           noHtml5Validate={true}
-          noValidate={false}
           omitExtraData={true}
           onSubmit={[Function]}
           schema={
@@ -750,7 +742,7 @@ exports[`ReportingYearFormDialog Should match last accepted snapshot: some past 
           >
             Save Reporting Year
           </Button>
-        </Form>
+        </WithPromiseLoading(JsonSchemaForm)>
       </Container>
     </ModalBody>
   </Modal>


### PR DESCRIPTION
Refactoring of mutation buttons / forms to show a disabled state until the mutation is completed:
- Most Admin/analyst buttons
- 'Revise Application' button on the reporter side