### PR TITLE
chore: nodejs version update

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-nodejs 12.20.1
+nodejs 12.22.2
 yarn 1.22.0
 postgres 12.6
 python 3.9.2

--- a/app/package.json
+++ b/app/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint --ext .js,.jsx,.ts,.tsx ."
   },
   "engines": {
-    "node": "12.20.1",
+    "node": "12.22.2",
     "yarn": "1.22.0"
   },
   "author": "",


### PR DESCRIPTION
this updates nodejs to address
- CVE-2021-22883 
- CVE-2021-22884