### PR TITLE
fix: acme issue dag is only triggered once

### DIFF
--- a/helm/cas-ciip-portal/Chart.yaml
+++ b/helm/cas-ciip-portal/Chart.yaml
@@ -20,6 +20,7 @@ dependencies:
     version: 1.0.6
     repository: https://bcgov.github.io/cas-airflow
     alias: airflow-ciip-cert-issue
+    condition: route.insecure
   - name: cas-airflow-dag-trigger
     version: 1.0.6
     repository: https://bcgov.github.io/cas-airflow


### PR DESCRIPTION
The dag-trigger chart for the acme issue job is only pulled in when `route.insecure` is set