### PR TITLE
chore: remove broken action install perl with apt

### DIFF
--- a/.github/actions/dev-env-setup/action.yml
+++ b/.github/actions/dev-env-setup/action.yml
@@ -5,9 +5,8 @@ runs:
   steps:
     - name: asdf setup
       uses: asdf-vm/actions/setup@v1
-    - uses: shogo82148/actions-setup-perl@v1
     - name: install pg perl library
-      run: sudo apt-get install -y libpq-dev libdbd-pg-perl
+      run: sudo apt-get install -y perl libpq-dev libdbd-pg-perl
       shell: bash
     - name: set perl env variables
       shell: bash
@@ -18,19 +17,19 @@ runs:
         echo "PERL_MM_OPT=INSTALL_BASE=/home/runner/perl5" >> $GITHUB_ENV
         echo "/home/runner/perl5/bin" >> $GITHUB_PATH
         echo "CURRENT_PERL_VERSION=$(perl -e 'print "$^V\n"')" >> $GITHUB_ENV
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       id: asdf-cache
       with:
         path: |
           ~/.asdf
         key: ${{ runner.os }}-asdf-cache-${{ hashFiles('.tool-versions') }}
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       id: perl-cache
       with:
         path: |
           ~/perl5
         key: ${{ runner.os }}-perl-cache-${{ env.CURRENT_PERL_VERSION }}-${{ hashFiles('cpanfile') }}
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       id: yarn-cache
       with:
         path: |

--- a/cpanfile
+++ b/cpanfile
@@ -1,3 +1,3 @@
-requires 'DBD::Pg', '== 3.15.1';
+requires 'DBD::Pg', '== 3.16.0';
 requires 'App::Sqitch', '== 1.3.1';
 requires 'TAP::Parser::SourceHandler::pgTAP', '== 3.36';


### PR DESCRIPTION
No card. 

Removing [setup perl action](https://github.com/shogo82148/actions-setup-perl/releases) as the most recent release has been causing tests to fail. Using apt instead