### PR TITLE
chore: updating mailhog chart

### DIFF
--- a/helm/cas-ciip-portal/Chart.yaml
+++ b/helm/cas-ciip-portal/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: "0.8.4"
     repository: https://bcgov.github.io/cas-postgres/
   - name: mailhog
-    version: "3.3.0"
+    version: "5.2.3"
     repository: "https://codecentric.github.io/helm-charts/"
     condition: mailhog.enable
   - name: cas-airflow-dag-trigger


### PR DESCRIPTION
An update to the mailhog chart - this will also reset the yearly counter on -test to avoid our deployment to be scaled down automatically