### PR TITLE
Fix 2276 deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ app/tests/perf/**/*.json
 k6files/
 
 .terraform
+.terraform/
+*.tfstate
+*.tfvars
+.terraform.lock.hcl
+credentials.json
+terraform/*.sh

--- a/helm/cas-ciip-portal/templates/jobs/terraform-apply.yaml
+++ b/helm/cas-ciip-portal/templates/jobs/terraform-apply.yaml
@@ -38,14 +38,13 @@ spec:
                   name: gcp-credentials-secret
                   key: gcp_project_id
             - name: TF_VAR_openshift_namespace
-              value: "{{ .Release.Namespace | quote }}"
+              value: {{ .Release.Namespace | quote }}
             - name: TF_VAR_apps
               value: '["ciip-backups", "ciip-documents", "ciip-2018"]'
             - name: kubernetes_host
               value: "https://api.silver.devops.gov.bc.ca:6443"
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/etc/gcp/credentials.json"
-          # Terraform was having an issue pulling kubernetes_host in as a TF_VAR, so we add it as a attribute to the command
           command:
             - /bin/sh
             - -c
@@ -55,7 +54,7 @@ spec:
               cd working;
               export TF_VAR_kubernetes_token=$( cat /var/run/secrets/kubernetes.io/serviceaccount/token );
               terraform init -backend-config=/etc/tf/gcs.tfbackend;
-              terraform apply -var=\"kubernetes_host=$kubernetes_host\" -auto-approve";
+              terraform apply -var="kubernetes_host=$kubernetes_host" -auto-approve;
       restartPolicy: Never
       volumes:
         - name: service-account-credentials-volume


### PR DESCRIPTION
When deploying via ShipIt, https://github.com/bcgov/cas-ciip-portal/pull/2277 failed with the following error. 

```bash
I0214 21:13:56.470711 3629 request.go:668] Waited for 1.10366045s due to client-side throttling, not priority and fairness, request: GET:https://10.98.0.1:443/apis/infrastructure.cluster.x-k8s.io/v1alpha5?timeout=32s
Error: UPGRADE FAILED: YAML parse error on cas-ciip-portal/templates/jobs/terraform-apply.yaml: error converting YAML to JSON: yaml: line 48: did not find expected key
```

Due to similar errors exposed in the past, attempting to resolve the error by removing comments and double quote.